### PR TITLE
Removed 'distclean' command; it provides the same functionality as 'clean -all'

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -67,3 +67,12 @@ the best way to install healpy if you plan to develop is to build the C++ extens
 python setup.py build_ext --inplace
 
 the add the healpy/healpy folder to your PYTHONPATH
+
+Clean
+-----
+
+When you run "python setup.py", temporary build products are placed in the
+"build" directory. If you want to clean out and remove the "build" directory,
+then run:
+
+python setup.py clean --all

--- a/setup.py
+++ b/setup.py
@@ -59,15 +59,6 @@ if is_clang_or_llvm_the_default_cc():
     print ("Detected clang/llvm compiler, disabling openMP, as it is currently unsupported")
     default_options['openmp'] = False
 
-# Command distclean to remove the build directory (both healpy and in hpbeta)
-# 
-if 'distclean' in sys.argv:
-    # Remove build directory of healpy and hpbeta
-    hpy = 'build'
-    print 'Removing ', hpy, ' directory...'
-    shutil.rmtree(hpy, True)
-    sys.exit(0)
-
 
 options = []
 for option in FLAGS_DICT:


### PR DESCRIPTION
Apparently, the following setup.py command wipes the `build` directory completely:

```
python setup.py clean --all
```

See http://stackoverflow.com/questions/1594827/cleaning-build-directory-in-setup-py.

This patch removes the 'distclean' command and adds instructions for running `clean -all` to the installation instructions.
