### PR TITLE
Optionally build against external HEALPix library (addresses issue #43)

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -6,6 +6,16 @@ Installation procedure for Healpy
 Requirements
 ------------
 
+* Healpy needs HEALPix. You can either:
+ - let Healpy build its own HEALPix library from the source code included in
+   this package (the default behavior) or
+ - use an existing installation :
+   Either define the environment variable HEALPIX_EXT_PREFIX where to find the
+   healpix libraries and include files (eg /usr/local, so that
+   /usr/local/include/healpix_base.h and /usr/local/lib/libhealpix_cxx.a
+   exist), or define HEALPIX_EXT_INC (with the healpix include
+   directory) and HEALPIX_EXT_LIB (with the healpix library directory)
+
 * Healpix needs cfitsio. You can either:
  - use an existing installation :
    Either define the environment variable CFITSIO_EXT_PREFIX where to find the

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,8 @@ Requirements
 
 The Healpix C++ library (from HEALPix 2.11 or HEALPix 2.20 for healpy >=
 0.10) is included in the healpy package, so you don't need to get it
-separately.
+separately. If you do want to use your own build of HEALPix instead of
+having Healpy build its bundled source, see INSTALL for further instructions.
 
 Download
 --------


### PR DESCRIPTION
This rebased patch, which addresses issue #43, applies cleanly to healpy master.

I removed the line to link against libsharp and rebased my patch against the latest upstream Healpy sources. I tested it on Mac OS X (Mountain Lion) and Debian Wheezy, both with the embedded HEALPix sources and with an external HEALPix library. I tested "import healpy" as well as some unit tests for a package of my own that uses Healpy.

Everything worked with the caveat that when I built HEALPix from Subversion I had to disable libhealpix_cxx's dependency on libsharp (see the attached patch for HEALPix to see what I did).
