### PR TITLE
Store coordinate system in COORDSYS rather than COORD for compatibility with Fortran, IDL, C

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -146,7 +146,7 @@ def write_map(filename,m,nest=False,dtype=np.float32,fits_IDL=True,coord=None):
     tbhdu.header.update('ORDERING',ordering,
                         'Pixel ordering scheme, either RING or NESTED')
     if coord:
-        tbhdu.header.update('COORD',coord,
+        tbhdu.header.update('COORDSYS',coord,
                             'Ecliptic, Galactic or eQuatorial')
     tbhdu.header.update('EXTNAME','xtension',
                         'name of this binary table extension')


### PR DESCRIPTION
healpy.write_map the  stores the coordinate system in the header under COORD, but it appears that all of the implementations in HEALPix itself (at least in Fortran, IDL, and C) use COORDSYS. This patch has healpy.write_map use COORDSYS for compatibility.
