### PR TITLE
pip installation doesn't work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -243,11 +243,11 @@ if on_rtd:
     cmdclass = {}
     extension_list = []
 else:
-    libraries = [('healpix_cxx', {}),
-                 ('cxxsupport', {}),
-                 ('psht', {}),
-                 ('fftpack', {}),
-                 ('c_utils', {})]
+    libraries = [('healpix_cxx', {'sources':[]}),
+                 ('cxxsupport', {'sources':[]}),
+                 ('psht', {'sources':[]}),
+                 ('fftpack', {'sources':[]}),
+                 ('c_utils', {'sources':[]})]
     cmdclass = {'build_ext': custom_build_ext, 'build_clib': build_healpix}
     extension_list = [pixel_lib, spht_lib, hfits_lib,
                       Extension("healpy.pshyt", ["pshyt/pshyt."+ext],


### PR DESCRIPTION
Hi,

The current version of healpy fails to be installed via "pip install" with the following error message:
"error: in 'libraries' option (library 'healpix_cxx'), 'sources' must be
present and must be a list of source filenames"

The suggested fix is in my pull request.

Cheers,
        Sergey
