### PR TITLE
Don't disable OpenMP under llvm; Apple's llvm-g++-4.2 supports OpenMP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import sys
 import subprocess
 
-def is_clang_or_llvm_the_default_cc():
+def is_clang_the_default_cc():
     """Check if the cc command runs clang or not. Return true if it does.
     """
     from distutils import sysconfig
@@ -24,7 +24,7 @@ def is_clang_or_llvm_the_default_cc():
     if p.returncode:
         return False
 
-    return ('clang' in cc_output or 'llvm' in cc_output)
+    return ('clang' in cc_output)
 
 TARGET_DICT = {
     'linux': 'healpy',
@@ -54,8 +54,8 @@ try:
 except KeyError:
     raise AssertionError ('Unsupported platform: %s' % SYSTEM_STRING)
 
-if is_clang_or_llvm_the_default_cc():
-    print ("Detected clang/llvm compiler, disabling openMP, as it is currently unsupported")
+if is_clang_the_default_cc():
+    print ("Detected clang compiler, disabling openMP, as it is currently unsupported")
     default_options['openmp'] = False
 
 


### PR DESCRIPTION
Am I crazy? Apple's llvm compiler supports OpenMP, at least on my system with Mountain Lion and Xcode 4.5.2. The following test program proves it:

``` C
/* compile with:
 *
 *   $ llvm-gcc-4.2 -fopenmp omptest.c -o omptest
 *
 * prints out:
 * Thread 0 says: 0
 * Thread 1 says: 50
 * Thread 0 says: 1
 * Thread 1 says: 51
 * ...
 */

#include <stdio.h>
#include <omp.h>

int main(int argc, char **argv)
{
    int i;
    omp_set_num_threads(2);

    #pragma omp parallel for
    for (i = 0; i < 100; i ++)
        printf("Thread %d says: %d\n", omp_get_thread_num(), i);

    return 0;
}
```

Moreover, I must have known this at some level when I made the MacPorts port for HEALPix, because on line 32 of the Portfile at https://trac.macports.org/browser/trunk/dports/science/healpix/Portfile?rev=91373#L32, I change the compiler from `clang` to `llvm-gcc-4.2`.

The pull request modifies `setup.py` so that OpenMP is turned off my default only under `clang`, not under `llvm`.
