### PR TITLE
Simplify Alm and Healpix_Map C++ interface.

### DIFF
--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -10,24 +10,10 @@ from healpy.pixelfunc import maptype
 import os
 import cython
 
-from _common cimport tsize, arr, xcomplex, Healpix_Ordering_Scheme, RING, NEST
+from _common cimport tsize, arr, xcomplex, Healpix_Ordering_Scheme, RING, NEST, Healpix_Map, Alm, ndarray2map, ndarray2alm
 
 cdef double UNSEEN = -1.6375e30
 cdef double rtol_UNSEEN = 1.e-7 * 1.6375e30
-
-cdef extern from "alm.h":
-    cdef cppclass Alm[T]:
-        Alm(int lmax_=0, int mmax_=0)
-        void Set (int lmax_, int mmax_)
-        void Set (arr[T] &data, int lmax_, int mmax_)
-        tsize Num_Alms (int l, int m)
-
-cdef extern from "healpix_map.h":
-    cdef cppclass Healpix_Map[T]:
-        Healpix_Map()
-        void Set(arr[T] &data, Healpix_Ordering_Scheme scheme)
-        T average()
-        void Add(T x)
 
 cdef extern from "alm_healpix_tools.h":
     cdef void map2alm_iter(Healpix_Map[double] &m,
@@ -45,58 +31,10 @@ cdef extern from "alm_healpix_tools.h":
 cdef extern from "healpix_data_io.h":
     cdef void read_weight_ring (string &dir, int nside, arr[double] &weight)
 
-cdef extern from "hack.h":
-    cdef xcomplex[double]* cast_to_ptr_xcomplex_d(char *)
-
 cdef Num_Alms(int l, int m):
     if not m <= l:
         raise ValueError("mmax must be <= lmax")
     return ((m+1)*(m+2))/2 + (m+1)*(l-m)
-
-cdef class WrapMap(object):
-    """This class provides a wrapper to a ndarray so it can be sent as Map to healpix_cxx functions.
-    """
-    cdef Healpix_Map[double] * h
-    cdef arr[double] * a
-    cdef object m
-    cdef int is_init
-
-    def __init__(self, np.ndarray[double] m):
-        if self.is_init == 1:
-            raise Exception('Already init...')
-        self.is_init = 1
-        self.m = np.ascontiguousarray(m)
-        self.a = new arr[double](<double*>(<np.ndarray>self.m).data, (<np.ndarray>self.m).size)
-        self.h = new Healpix_Map[double]()
-        self.h.Set(self.a[0], RING)
-
-    def __dealloc__(self):
-        if self.is_init == 1:
-            #print "deallocating map wrapper..."
-            del self.a, self.h
-
-cdef class WrapAlm(object):
-    """This class provides a wrapper to a ndarray so it can be sent as Alm to healpix_cxx functions.
-    """
-    cdef Alm[xcomplex[double]] * h
-    cdef arr[xcomplex[double]] * a
-    cdef object m
-    cdef int is_init
-
-    def __init__(self, np.ndarray[np.complex128_t] m, int lmax, int mmax):
-        if self.is_init == 1:
-            raise Exception('Already init...')
-        self.is_init = 1
-        self.m = np.ascontiguousarray(m)
-        self.h = new Alm[xcomplex[double]]()
-        self.a = new arr[xcomplex[double]](cast_to_ptr_xcomplex_d((<np.ndarray>self.m).data),
-                                           (<np.ndarray>self.m).size)
-        self.h.Set(self.a[0], lmax, mmax)
-
-    def __dealloc__(self):
-        if self.is_init == 1:
-            #print "deallocating alm wrapper..."
-            del self.a, self.h
 
 DATAPATH = None
 
@@ -106,9 +44,10 @@ def get_datapath():
         DATAPATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
     return DATAPATH
 
+
 def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False, 
             regression = True, datapath = None):
-    """Computes the alm of an Healpix map.
+    """Computes the alm of a Healpix map.
 
     Parameters
     ----------
@@ -134,29 +73,24 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
     info = maptype(m)
     if info == 0:
         polarization = False
-        mmi = m
+        mi = np.ascontiguousarray(m, dtype=np.float64)
     elif info == 1:
         polarization = False
-        mmi = m[0]
+        mi = np.ascontiguousarray(m[0], dtype=np.float64)
     elif info == 3:
         polarization = True
-        mmi = m[0]
-        mmq = m[1]
-        mmu = m[2]
+        mi = np.ascontiguousarray(m[0], dtype=np.float64)
+        mq = np.ascontiguousarray(m[1], dtype=np.float64)
+        mu = np.ascontiguousarray(m[2], dtype=np.float64)
     else:
         raise ValueError("Wrong input map (must be a valid healpix map "
                          "or a sequence of 1 or 3 maps)")
-    
-    # Get the map as a contiguous ndarray object if it isn't
-    cdef np.ndarray[np.float64_t, ndim=1] mi, mq, mu
-    mi = np.ascontiguousarray(mmi, dtype = np.float64)
+
     # create UNSEEN mask for I map
     mask_mi = False if count_bad(mi) == 0 else mkmask(mi)
     # same for polarization maps if needed
     if polarization:
-        mq = np.ascontiguousarray(mmq, dtype = np.float64)
         mask_mq = False if count_bad(mq) == 0 else mkmask(mq)
-        mu = np.ascontiguousarray(mmu, dtype = np.float64)
         mask_mu = False if count_bad(mu) == 0 else mkmask(mu)
 
     # replace UNSEEN pixels with zeros
@@ -186,32 +120,31 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
         if mq.size != npix or mu.size != npix:
             raise ValueError("Input maps must have same size")
     
-    # Wrap the map into an Healpix_Map
-    MI = WrapMap(mi)
+    # View the ndarray as a Healpix_Map
+    MI = ndarray2map(mi, RING)
     if polarization:
-        MQ = WrapMap(mq)
-        MU = WrapMap(mu)
+        MQ = ndarray2map(mq, RING)
+        MU = ndarray2map(mu, RING)
 
     # if regression is True, remove average of the intensity map before computing alm
     cdef double avg = 0.0
     if regression:
-        avg = MI.h.average()
-        MI.h.Add(-avg)
+        avg = MI.average()
+        MI.Add(-avg)
 
     # Create an ndarray object that will contain the alm for output (to be returned)
-    cdef np.ndarray almI, almG, almC
     n_alm = Num_Alms(lmax_, mmax_)
-    almI = np.empty(n_alm, dtype = np.complex128)
+    almI = np.empty(n_alm, dtype=np.complex128)
     if polarization:
-        almG = np.empty(n_alm, dtype = np.complex128)
-        almC = np.empty(n_alm, dtype = np.complex128)
-    
-    # Wrap it into an healpix Alm object
-    AI = WrapAlm(almI, lmax_, mmax_)
-    if polarization:
-        AG = WrapAlm(almG, lmax_, mmax_)
-        AC = WrapAlm(almC, lmax_, mmax_)
+        almG = np.empty(n_alm, dtype=np.complex128)
+        almC = np.empty(n_alm, dtype=np.complex128)
 
+    # View the ndarray as an Alm
+    AI = ndarray2alm(almI, lmax_, mmax_)
+    if polarization:
+        AG = ndarray2alm(almG, lmax_, mmax_)
+        AC = ndarray2alm(almC, lmax_, mmax_)
+    
     # ring weights
     cdef arr[double] * w_arr = new arr[double]()
     cdef int i
@@ -230,10 +163,9 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
         w_arr.allocAndFill(2 * nside, 1.)
     
     if polarization:
-        map2alm_pol_iter(MI.h[0], MQ.h[0], MU.h[0], AI.h[0], AG.h[0], AC.h[0],
-                         niter, w_arr[0])
+        map2alm_pol_iter(MI[0], MQ[0], MU[0], AI[0], AG[0], AC[0], niter, w_arr[0])
     else:
-        map2alm_iter(MI.h[0], AI.h[0], niter, w_arr[0])
+        map2alm_iter(MI[0], AI[0], niter, w_arr[0])
     
     # restore input map with UNSEEN pixels
     if mask_mi is not False:
@@ -245,13 +177,15 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
             mu[mask_mu] = UNSEEN
     
     if regression:
-        MI.h.Add(avg)
+        MI.Add(avg)
         almI[0] += avg * sqrt(4 * np.pi)
 
     del w_arr
     if polarization:
+        del MI, MQ, MU, AI, AG, AC
         return almI, almG, almC
     else:
+        del MI, AI
         return almI
 
 

--- a/healpy/src/hack.h
+++ b/healpy/src/hack.h
@@ -1,3 +1,0 @@
-#include "xcomplex.h"
-
-inline xcomplex<double>* cast_to_ptr_xcomplex_d(char *a) {return (xcomplex<double>*)a;};


### PR DESCRIPTION
Before this patch, viewing an ndarray as an Alm or Healpix_Map C++ instance is done via a wrapper object that contains:
1) the Alm or Healpix_Map instance
2) the intermediate arr
3) a reference to the ndarray
This patch provides the functions ndarray2alm and ndarray2map to view an ndarray as Alm or Healpix_Map.
-  It is neither necessary to keep the intermediate arr since it doesn't own its buffer, nor it is  necessary to keep an intermediate ndarray, as long as the ndarray, which owns the buffer during the Healpix_Map or Alm lifetime is contiguous and of correct type (i.e.: no temporary buffer is created in the helper functions, whose lifetime would be shorter than that of the Alm or Healpix_Map instance).
- Remove hack.h, not required.
- Move Alm and Healpix_Map declaration in _common.pxd.
- new test cases test_map2alm and test_map2alm_pol
- This patch adds 4 warnings: 
  warning: healpy/src/_common.pxd:123:45: Buffer unpacking not optimized away.
  This are innocuous (I asked to the cython-user mailing list: https://groups.google.com/forum/#!topic/cython-users/L07S7zVj1wk ). They come from the inline qualifier in ndarray2map and ndarray2alm, and this qualifier is required because non-extern function in pxd file must be inline.
  We could easily get rid of these warnings by putting these functions in a _common.pyx module.
