### PR TITLE
Require Python distribute >= 0.6.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 # Bootstrap distribute installation
 from distribute_setup import use_setuptools
-use_setuptools()
+use_setuptools('0.6.10')
 
 import os
 from os.path import join


### PR DESCRIPTION
This is the version that is present on SL6. If the distribute < 0.6.10
is installed, or if distribute is completely absent, then distribute
0.6.10 will be downloaded when setup.py is run. If distribute >= 0.6.10
is present, then nothing is downloaded. This is important because when
building RPMs we don't want to require a network connection.
