### PR TITLE
Fix deprecation warning in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def check_output(*popenargs, **kwargs):
 try:
     os.walk(followlinks=True)
 except TypeError, e:
-    if "got an unexpected keyword argument" in e.message:
+    if "got an unexpected keyword argument" in str(e):
         from os import path, listdir
         # Copied from Python 2.7's os.py
         def walk(top, topdown=True, onerror=None, followlinks=False):


### PR DESCRIPTION
In Python 2.6, `setup.py` produced the following deprecation warning:

```
setup.py:75: DeprecationWarning: BaseException.message has been
deprecated as of Python 2.6
```

Changing `e.message` to `str(e)` fixes this.
