### PR TITLE
Use pkg_resources to load pykg-config

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ recursive-include healpy/data *.fits
 recursive-include healpy/test/data *
 exclude healpy/test/data/wmap*v4.fits
 exclude healpy/test/data/ipython*
-include COPYING INSTALL.rst README.rst MANIFEST.in CHANGELOG.rst ez_setup.py
+include COPYING INSTALL.rst README.rst MANIFEST.in CHANGELOG.rst ez_setup.py pykg_config.py
 include healpy/src/_healpy_utils.h
 include healpy/src/_query_disc.cpp
 include healpy/src/_sphtools.cpp

--- a/pykg_config.py
+++ b/pykg_config.py
@@ -1,0 +1,3 @@
+# Helper to run pykg-config, whether it is installed or lives in a zipped egg.
+from pkg_resources import run_script
+run_script('pykg-config >= 1.2.0', 'pykg-config.py')


### PR DESCRIPTION
This makes it possible to run the pykg-config script even if it resides
inside a zipped egg. This allows us to use pykg-config master.
