### PR TITLE
Bootstrap installation with a modern version of setuptools

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     USER_SITE = None
 
-DEFAULT_VERSION = "0.7.2"
+DEFAULT_VERSION = "0.9.6"
 DEFAULT_URL = "https://pypi.python.org/packages/source/s/setuptools/"
 
 def _python_cmd(*args):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python
 
-# Bootstrap distribute installation
-from ez_setup import use_setuptools
-use_setuptools('0.6.10')
+# Bootstrap setuptools installation.
+# Setuptools 0.6.10 is the oldest version with which we have tested Healpy,
+# and is also the least common denominator present on Scientific Linux 6.
+# If the user has setuptools >= 0.6.10, just take it.
+# Otherwise, let use_setuptools() download its default, more recent version. 
+try:
+    import pkg_resources
+    pkg_resources.require("setuptools >= 0.6.10")
+except:
+    from ez_setup import use_setuptools
+    use_setuptools()
 
 import os
 from os.path import join


### PR DESCRIPTION
Addresses #143.

Setuptools 0.6.10 is the oldest version with which we have tested Healpy, and is also the least common denominator present on Scientific Linux 6. If the user has setuptools >= 0.6.10, just take it. Otherwise, let `use_setuptools()` download its default, more recent version.

While we are at it, update to the latest copy of `ez_setup.py` from the Setuptools project.
