### PR TITLE
using py.test

### DIFF
--- a/travistest.sh
+++ b/travistest.sh
@@ -2,7 +2,7 @@
 cd build/lib*/healpy/test/data
 . get_wmap_maps.sh
 cd ../..
-nosetests -v --with-doctest
+py.test -v --doctest-modules
 nosetests_returnvalue=$?
 echo Run Cython extensions doctests
 python run_doctest_cython.py


### PR DESCRIPTION
nosetests was NOT actually running the unit tests...
now noticed anafast tests are not passing, probably due to the fix we did on the masking.
