### PR TITLE
Pass through all arguments to CC and CXX to configure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -282,8 +282,8 @@ class build_external_clib(build_clib):
             log.info("building library '%s' from source", library)
 
             # Determine which compilers we are to use.
-            cc = self.compiler.compiler[0]
-            cxx = self.compiler.compiler_cxx[0]
+            cc = ' '.join(self.compiler.compiler)
+            cxx = ' '.join(self.compiler.compiler_cxx)
 
             # Use a subdirectory of build_temp as the build directory.
             build_temp = os.path.realpath(os.path.join(self.build_temp, library))


### PR DESCRIPTION
Previously, if one attempted to pass arguments to the compiler by
setting the `CC` or `CXX` environment variables, the additional arguments
would be ignored and not passed on to the configure scripts for cfitsio
and healpix_cxx. For instance, if one ran setup.py as follows:

```
$ env CC="gcc -foo -bar" CXX="g++ -foo -bar" python setup.py build...
```

then the `-foo` and `-bar` arguments would not be passed on when
building cfitsio or healpix_cxx.

With this patch, the `CC` and `CXX` environment variables are propagated to
the cfitsio and healpix_cxx builds including any additional command line
arguments.

This partially addresses #136 and #151, in which it is necessary to pass
some additional arguments to the C++ compiler to build on Anaconda for
Mac OS.
