### PR TITLE
Disable maintainer mode when compiling healpix_cxx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -323,7 +323,8 @@ class build_external_clib(build_clib):
                 'CFLAGS=' + cflags,
                 'CXXFLAGS=' + cflags,
                 '--disable-shared',
-                '--with-pic']
+                '--with-pic',
+                '--disable-maintainer-mode']
 
             log.info('%s', ' '.join(cmd))
             check_call(cmd, cwd=build_temp, env=self._environ)


### PR DESCRIPTION
`pip` does not preserve file modification times when unpacking tarballs.
This causes `make` to think that it needs to rerun `automake` when
building `healpix_cxx`. Since only developers generally have `automake`,
this causes the installation to fail.

This patch works around the deficiency in `pip` by adding
`--disable-maintainer-mode` to the flags passed to `configure`. As a
result, `make` will not attempt to re-run `automake`.

Note that we need to add

```
AM_MAINTAINER_MODE([enable])
```

to `healpix_cxx`'s `configure.ac` file in order to make `configure`
recognize this option.

Fixes #155.
