### PR TITLE
Upgrading to Miniconda 3.4.2 to fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   # Install python and dependencies via system or anaconda
   - |
     if $USE_ANACONDA; then
-      wget http://repo.continuum.io/miniconda/Miniconda-3.0.0-Linux-x86_64.sh \
+      wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh \
         -O miniconda.sh && \
       bash miniconda.sh -b && \
       ~/miniconda/bin/conda create --yes -n anaconda_env \


### PR DESCRIPTION
We were a few versions behind the latest Miniconda release. This patch fixes all of the Miniconda builds in the Travis matrix.
