### PR TITLE
Smoothing should completely honour verbose setting

### DIFF
--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -734,7 +734,7 @@ def smoothing(maps, fwhm = 0.0, sigma = None, invert = False, pol = True,
                        datapath = datapath)
         smoothalm(alms, fwhm = fwhm, sigma = sigma, invert = invert,
                   inplace = True, verbose = verbose)
-        output_map = alm2map(alms, nside, pixwin = False)
+        output_map = alm2map(alms, nside, pixwin = False, verbose=verbose)
     else:
         # Treat each map independently (any number)
         output_map = []
@@ -744,7 +744,7 @@ def smoothing(maps, fwhm = 0.0, sigma = None, invert = False, pol = True,
                        datapath = datapath)
             smoothalm(alm, fwhm = fwhm, sigma = sigma, invert = invert,
                       inplace = True, verbose = verbose)
-            output_map.append(alm2map(alm, nside, pixwin = False))
+            output_map.append(alm2map(alm, nside, pixwin = False, verbose=verbose))
     if pixelfunc.maptype(output_map) == 0:
         output_map[masks.flatten()] = UNSEEN
     else:


### PR DESCRIPTION
In an effort to suppress some of the automatic output, I discovered `smoothing` was not passing on the `verbose` option to internal calls to `alm2map`. This mean that you keep getting

```
Sigma is 0.000000 arcmin (0.000000 rad) 
-> fwhm is 0.000000 arcmin
```

messages even when you've explicitly set `verbose=False`. This patch just ensures the verbose flags gets passed on.

The only other option I could see as being desirable would be explicitly passing `verbose=False` onto `alm2map` to silence the messages.
