### PR TITLE
Remove CPU overheads in _query_disc.pyx.

### DIFF
--- a/healpy/src/_query_disc.pyx
+++ b/healpy/src/_query_disc.pyx
@@ -70,7 +70,7 @@ def query_disc(nside, vec, radius, inclusive = False, fact = 4, nest = False, np
     else:
         hb.query_disc(pointing(v), radius, pixset)
 
-    return pixset_to_array(pixset,buff)
+    return pixset_to_array(pixset, buff)
 
 
 def query_polygon(nside, vertices, inclusive = False, fact = 4, nest = False, np.ndarray[np.int64_t, ndim=1] buff=None):
@@ -136,7 +136,7 @@ def query_polygon(nside, vertices, inclusive = False, fact = 4, nest = False, np
     else:
         hb.query_polygon(vert, pixset)
 
-    return pixset_to_array(pixset,buff)
+    return pixset_to_array(pixset, buff)
 
 def query_strip(nside, theta1, theta2, inclusive = False, nest = False, np.ndarray[np.int64_t, ndim=1] buff=None):
     """Returns pixels whose centers lie within the colatitude range
@@ -182,7 +182,7 @@ def query_strip(nside, theta1, theta2, inclusive = False, nest = False, np.ndarr
     cdef rangeset[int64] pixset
     hb.query_strip(theta1, theta2, inclusive, pixset)
 
-    return pixset_to_array(pixset,buff)
+    return pixset_to_array(pixset, buff)
 
 
 def _boundaries_single(nside, pix, step=1, nest=False):

--- a/healpy/test/test_query_disc.py
+++ b/healpy/test/test_query_disc.py
@@ -54,19 +54,21 @@ class TestQueryDisc(unittest.TestCase):
     
         
         # allocate something manifestly too short, should raise a value error
-        buff = np.empty(0,dtype=np.int64)
+        buff = np.empty(0, dtype=np.int64)
         self.assertRaises(ValueError,
-                          lambda : query_disc(self.NSIDE,self.vec,self.radius,inclusive=True,buff=buff))
+                          query_disc,
+                          self.NSIDE, self.vec, self.radius, inclusive=True, buff=buff)
         
 
         # allocate something of wrong type, should raise a value error
-        buff = np.empty(nside2npix(self.NSIDE),dtype=np.float64)
+        buff = np.empty(nside2npix(self.NSIDE), dtype=np.float64)
         self.assertRaises(ValueError,
-                lambda : query_disc(self.NSIDE,self.vec,self.radius,inclusive=True,buff=buff))
+                          query_disc,
+                          self.NSIDE, self.vec, self.radius, inclusive=True, buff=buff)
        
         # allocate something acceptable, should succeed and return a subview
-        buff = np.empty(nside2npix(self.NSIDE),dtype=np.int64)
-        result = query_disc(self.NSIDE,self.vec,self.radius,inclusive=True,buff=buff)
+        buff = np.empty(nside2npix(self.NSIDE), dtype=np.int64)
+        result = query_disc(self.NSIDE, self.vec, self.radius, inclusive=True, buff=buff)
         
         assert result.base is buff
         


### PR DESCRIPTION
This pull request comprises a number of optimizations to _query_disc, especially for use cases where a query_X function is called multiple times. Using these I have seen reductions in typical CPU usage of about 95%, i.e. calls to query_X functions now run 20 times faster on my OS X 10.9.2 system with anaconda python.
1. The isnsideok call could take up to 50% of the CPU time for a typical query_\* call. Resolved.
2. Allow passing in of a buffer to remove overhead of reallocating memory when repeated query_\* calls are made.
3. Switch off bounds checking in pixset_to_array
