### PR TITLE
Move unit tests into custom test command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,4 +93,4 @@ install:
       python setup.py install
     fi
 
-script: ./testbuild.sh
+script: python setup.py test

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -61,7 +61,7 @@ If everything goes fine, you can test it::
 
 or run the test suite with nose::
 
-    cd healpy-1.7.4 && nosetests -v
+    cd healpy-1.7.4 && python setup.py test
 
 Building against external Healpix and cfitsio
 ---------------------------------------------

--- a/testbuild.sh
+++ b/testbuild.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-cd build/lib*/healpy && py.test -v --doctest-modules


### PR DESCRIPTION
Now you can run the unit tests with `python setup.py test`. Setuptools automatically takes care of temporarily modifying the `PYTHONPATH`. This will make it easier to run the unit tests in the Debian packaging.
