### PR TITLE
Add _common.pxd to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include healpy/src/_healpy_utils.h
 include healpy/src/_query_disc.cpp
 include healpy/src/_sphtools.cpp
 include healpy/src/_pixelfunc.cpp
+include healpy/src/_common.pxd
 include healpy/src/_query_disc.pyx
 include healpy/src/_sphtools.pyx
 include healpy/src/_pixelfunc.pyx


### PR DESCRIPTION
Building from the latest release tarball, `healpy-1.8.0.tar.gz`, fails if Cython is installed because the Cython source `_common.pxd` is not in the distribution. We never noticed this before because in previous releases Healpy would only try to generate the Cython sources when building from git.

This patch addresses the issue by adding `_common.pxd` to `MANIFEST.in` so that the file gets shipped in the tarball created by `python setup.py sdist`.

After merging this, could we do a 1.8.1 release to get the patch onto PyPI?
