### PR TITLE
Check that nside <= 2**29

### DIFF
--- a/healpy/src/_healpy_fitsio_lib.cc
+++ b/healpy/src/_healpy_fitsio_lib.cc
@@ -56,7 +56,7 @@ static PyObject *healpy_pixwin(PyObject *self, PyObject *args, PyObject *kwds)
     return NULL;
 
   healpyAssertValue((nside&(nside-1))==0,
-    "Wrong nside value (must be a power of 2)");
+    "Wrong nside value (must be a power of 2, less than 2**30)");
 
   arr<double> pw_temp, pw_pol;
   read_pixwin(datapath, nside, pw_temp, pw_pol);

--- a/healpy/src/_pixelfunc.pyx
+++ b/healpy/src/_pixelfunc.pyx
@@ -14,7 +14,7 @@ def ringinfo(nside, np.ndarray[int64, ndim=1] ring not None):
     Parameters
     ----------
     nside : int
-      The healpix nside parameter, must be a power of 2
+      The healpix nside parameter, must be a power of 2, less than 2**30
     ring : int, scalar or array-like
       The ring number
 
@@ -42,7 +42,7 @@ def ringinfo(nside, np.ndarray[int64, ndim=1] ring not None):
             0.94280904,  0.74535599]), array([ True,  True,  True, False,  True, False,  True], dtype=bool))
     """
     if not isnsideok(nside):
-        raise ValueError('Wrong nside value, must be a power of 2')
+        raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     cdef Healpix_Ordering_Scheme scheme = NEST
     cdef T_Healpix_Base[int64] hb = T_Healpix_Base[int64](nside, scheme, SET_NSIDE)
     num = ring.shape[0]
@@ -63,7 +63,7 @@ def pix2ring(nside, np.ndarray[int64, ndim=1] pix not None, nest=False):
     Parameters
     ----------
     nside : int
-      The healpix nside parameter, must be a power of 2
+      The healpix nside parameter, must be a power of 2, less than 2**30
     pix : int64, scalar or array-like
       The pixel identifier(s)
     nest : bool
@@ -86,7 +86,7 @@ def pix2ring(nside, np.ndarray[int64, ndim=1] pix not None, nest=False):
     """
 
     if not isnsideok(nside):
-        raise ValueError('Wrong nside value, must be a power of 2')
+        raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     cdef Healpix_Ordering_Scheme scheme
     if nest:
         scheme = NEST

--- a/healpy/src/_query_disc.pyx
+++ b/healpy/src/_query_disc.pyx
@@ -29,7 +29,7 @@ def query_disc(nside, vec, radius, inclusive = False, fact = 4, nest = False, np
       and maybe a few more. Default: False
     fact : int, optional
       Only used when inclusive=True. The overlapping test will be done at
-      the resolution fact*nside. For NESTED ordering, fact must be a power of 2,
+      the resolution fact*nside. For NESTED ordering, fact must be a power of 2, less than 2**30,
       else it can be any positive integer. Default: 4.
     nest: bool, optional
       if True, assume NESTED pixel ordering, otherwise, RING pixel ordering
@@ -51,7 +51,7 @@ def query_disc(nside, vec, radius, inclusive = False, fact = 4, nest = False, np
     """
     # Check Nside value
     if not isnsideok(nside):
-        raise ValueError('Wrong nside value, must be a power of 2')
+        raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     cdef vec3 v = vec3(vec[0], vec[1], vec[2])
     cdef Healpix_Ordering_Scheme scheme
     if nest:
@@ -66,7 +66,7 @@ def query_disc(nside, vec, radius, inclusive = False, fact = 4, nest = False, np
     if inclusive:
         factor = abs(fact)
         if nest and (factor == 0 or (factor & (factor - 1) != 0)):
-            raise ValueError('fact must be a power of 2 when '
+            raise ValueError('fact must be a power of 2, less than 2**30 when '
                              'nest is True (fact=%d)' % (fact))
         hb.query_disc_inclusive(ptg, radius, pixset, factor)
     else:
@@ -92,7 +92,7 @@ def query_polygon(nside, vertices, inclusive = False, fact = 4, nest = False, np
       polygon, and maybe a few more. Default: False.
     fact : int, optional
       Only used when inclusive=True. The overlapping test will be done at
-      the resolution fact*nside. For NESTED ordering, fact must be a power of 2,
+      the resolution fact*nside. For NESTED ordering, fact must be a power of 2, less than 2**30,
       else it can be any positive integer. Default: 4.
     nest: bool, optional
       if True, assume NESTED pixel ordering, otherwise, RING pixel ordering
@@ -114,7 +114,7 @@ def query_polygon(nside, vertices, inclusive = False, fact = 4, nest = False, np
     """
     # Check Nside value
     if not isnsideok(nside):
-        raise ValueError('Wrong nside value, must be a power of 2')
+        raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     # Create vector of vertices
     cdef vector[pointing] vert
     cdef pointing ptg
@@ -135,7 +135,7 @@ def query_polygon(nside, vertices, inclusive = False, fact = 4, nest = False, np
     if inclusive:
         factor = abs(fact)
         if nest and (factor == 0 or (factor & (factor - 1) != 0)):
-            raise ValueError('fact must be a power of 2 when '
+            raise ValueError('fact must be a power of 2, less than 2**30 when '
                              'nest is True (fact=%d)' % (fact))
         hb.query_polygon_inclusive(vert, pixset, factor)
     else:
@@ -175,7 +175,7 @@ def query_strip(nside, theta1, theta2, inclusive = False, nest = False, np.ndarr
     """
     # Check Nside value
     if not isnsideok(nside):
-        raise ValueError('Wrong nside value, must be a power of 2')
+        raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     # Create the Healpix_Base2 structure
     cdef Healpix_Ordering_Scheme scheme
     if nest:
@@ -276,7 +276,7 @@ def boundaries(nside, pix, step=1, nest=False):
     """
 
     if not isnsideok(nside):
-        raise ValueError('Wrong nside value, must be a power of 2')
+        raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     if isinstance(pix, (int, long)):
         return _boundaries_single(nside, pix, step=step, nest=nest)
     if type(pix) is np.ndarray:
@@ -292,7 +292,7 @@ def boundaries(nside, pix, step=1, nest=False):
 ### def pix2ang(nside, ipix, nest = False):
 ###     # Check Nside value
 ###     if not isnsideok(nside):
-###         raise ValueError('Wrong nside value, must be a power of 2')
+###         raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
 ###     # Create the Healpix_Base2 structure
 ###     cdef Healpix_Ordering_Scheme scheme
 ###     if nest:

--- a/healpy/test/test_pixelfunc.py
+++ b/healpy/test/test_pixelfunc.py
@@ -31,14 +31,11 @@ class TestPixelFunc(unittest.TestCase):
         np.testing.assert_array_almost_equal(theta1, self.theta0)
         np.testing.assert_array_almost_equal(phi1, self.phi0)
 
-    def test_ang2pix_ring_outofrange_doesntcrash(self):
-        # ensure nside = 1 << 30 is incorrectly calcualted,
-        # because Healpy_Base2 works upto 1<<29.
-        # Healpy_Base2 shall not crash the test suite
-        id = ang2pix(1<<30, self.theta0, self.phi0, nest=False)
-        theta1, phi1 = pix2ang(1<<30, id, nest=False)
-        self.assertFalse(np.all(np.isfinite(theta1)))
-        self.assertFalse(np.all(np.isfinite(phi1)))
+    def test_ang2pix_ring_outofrange(self):
+        # Healpy_Base2 works up to nside = 2**29.
+        # Check that a ValueError is raised for nside = 2**30.
+        self.assertRaises(
+            ValueError, ang2pix, 1<<30, self.theta0, self.phi0, nest=False)
 
     def test_ang2pix_nest(self):
         # ensure nside = 1 << 23 is correctly calculated
@@ -55,13 +52,10 @@ class TestPixelFunc(unittest.TestCase):
         self.assertTrue(np.allclose(phi1, self.phi0))
 
     def test_ang2pix_nest_outofrange_doesntcrash(self):
-        # ensure nside = 1 << 30 is incorrectly calcualted,
-        # because Healpy_Base2 works upto 1<<29.
-        # Healpy_Base2 shall not crash the test suite
-        id = ang2pix(1<<30, self.theta0, self.phi0, nest=True)
-        theta1, phi1 = pix2ang(1<<30, id, nest=True)
-        self.assertFalse(np.all(np.isfinite(theta1)))
-        self.assertFalse(np.all(np.isfinite(phi1)))
+        # Healpy_Base2 works up to nside = 2**29.
+        # Check that a ValueError is raised for nside = 2**30.
+        self.assertRaises(
+            ValueError, ang2pix, 1<<30, self.theta0, self.phi0, nest=False)
 
     def test_ang2pix_negative_theta(self):
         self.assertRaises(AssertionError, ang2pix, 32, -1, 0)


### PR DESCRIPTION
`Healpy_Base2` works up to `nside = 2**29`. Raise a `ValueError` if `nside` is out of bounds, instead of silently producing incorrect output.

The `TestPixelFunc.test_ang2pix_nest_outofrange_doesntcrash` unit test was failing on Mac OS X 10.9 anyway: the returned `theta` contained non-finite values, but `phi` did not.
