### PR TITLE
Removing hardcoded limit of 2000 pixels for projections.

### DIFF
--- a/healpy/projector.py
+++ b/healpy/projector.py
@@ -565,13 +565,6 @@ class CartesianProj(SphericalProj):
         else:
             ysize = np.long(ysize)
             ratio = float(ysize)/float(xsize)
-        if max(xsize,ysize) > 2000:
-            if max(xsize,ysize) == xsize:
-                xsize = 2000
-                ysize = np.long(round(ratio*xsize))
-            else:
-                ysize = 2000
-                xsize = np.long(round(ysize/ratio))
         super(CartesianProj,self).set_proj_plane_info(xsize=xsize, lonra=lonra, latra=latra, 
                                                         ysize=ysize, ratio=ratio)
 


### PR DESCRIPTION
I was attempting to create some high-resolution images and ran into this hardcoded limit. I'm not sure if there was an alternate reason to the limit.  (Also first time PR'ing in github, i'm used to bitbucket/hg, so let me know if I should have done something differently).
