### PR TITLE
Adding text to instruct the user to use IPython in tutorial.

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -17,7 +17,7 @@ Note: Running the code below in a regular Python session will not display the ma
 >>> matplotlib inline # for IPython notebook
 >>> matplotlib qt     # using Qt (e.g. Windows)
 >>> matplotlib osx    # on Macs
->>> matplotlib gtx    # GTK
+>>> matplotlib gtk    # GTK
 
 The resolution of the map is defined by the *NSIDE* parameter. The :py:func:`~healpy.pixelfunc.nside2npix` function gives the number of pixel *NPIX* of the map:
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -6,6 +6,19 @@ Creating and manipulating maps
 
 Maps are simply numpy arrays, where each array element refers to a location in the sky as defined by the Healpix pixelization schemes (see the `healpix website`_).
 
+Note: Running the code below in a regular Python session will not display the maps; it’s recommended that iPython be used:
+
+.. code-block:: bash
+
+    % ipython
+
+...then select the appropriate backend display:
+
+>>> matplotlib inline # for IPython notebook
+>>> matplotlib qt     # using Qt (e.g. Windows)
+>>> matplotlib osx    # on Macs
+>>> matplotlib gtx    # GTK
+
 The resolution of the map is defined by the *NSIDE* parameter. The :py:func:`~healpy.pixelfunc.nside2npix` function gives the number of pixel *NPIX* of the map:
 
 >>> import numpy as np

--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -720,7 +720,7 @@ def reorder(map_in, inp=None, out=None, r2n=None, n2r=None):
         return mapout
 
 def nside2npix(nside):
-    """Give the number of pixel for the given nside.
+    """Give the number of pixels for the given nside.
 
     Parameters
     ----------
@@ -756,7 +756,7 @@ def nside2npix(nside):
     return 12*nside**2
 
 def nside2resol(nside, arcmin=False):
-    """Give approximate resolution for nside.
+    """Give approximate resolution (pixel size in radian or arcmin) for nside.
 
     Resolution is just the square root of the pixel area, which is a gross
     approximation given the different pixel shapes
@@ -802,7 +802,7 @@ def nside2resol(nside, arcmin=False):
 
 
 def nside2pixarea(nside, degrees=False):
-    """Give pixel area given nside.
+    """Give pixel area given nside in square radians or square degrees.
 
     Parameters
     ----------


### PR DESCRIPTION
If a user launches a regular Python session and tries to follow the tutorial, maps will not be displayed. No error or instruction on how to set things up to view the plots is returned. It would be preferable to display a warning message with direction, but adding this to the docs would be a huge help.