### PR TITLE
Adapt to some changes in behavior of pkg_resources.run_script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ healpy/src/_pixelfunc.cpp
 healpy/src/_sphtools.cpp
 healpy.egg-info
 dist
+.eggs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ exclude cfitsio/*pdf cfitsio/*ps cfitsio/*doc cfitsio/*tex
 prune cfitsio/docs
 exclude *.so
 exclude *.a
-include COPYING CITATION INSTALL.rst README.rst MANIFEST.in CHANGELOG.rst ez_setup.py pykg_config.py
+include COPYING CITATION INSTALL.rst README.rst MANIFEST.in CHANGELOG.rst ez_setup.py run_pykg_config.py
 include healpy/src/_healpy_utils.h
 include healpy/src/_query_disc.cpp
 include healpy/src/_sphtools.cpp

--- a/pykg_config.py
+++ b/pykg_config.py
@@ -1,3 +1,0 @@
-# Helper to run pykg-config, whether it is installed or lives in a zipped egg.
-from pkg_resources import run_script
-run_script('pykg-config >= 1.2.0', 'pykg-config.py')

--- a/run_pykg_config.py
+++ b/run_pykg_config.py
@@ -1,0 +1,6 @@
+# Helper to run pykg-config, whether it is installed or lives in a zipped egg.
+from setuptools import Distribution
+from pkg_resources import run_script
+requirement = 'pykg-config >= 1.2.0'
+Distribution().fetch_build_eggs(requirement)
+run_script(requirement, 'pykg-config.py')

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ except OSError as e:
         raise ValueError
     log.warn('pkg-config is not installed, falling back to pykg-config')
     setup_requires = ['pykg-config >= 1.2.0']
-    os.environ['PKG_CONFIG'] = sys.executable + ' ' + os.path.abspath('pykg_config.py')
+    os.environ['PKG_CONFIG'] = sys.executable + ' ' + os.path.abspath('run_pykg_config.py')
 
 
 class build_external_clib(build_clib):


### PR DESCRIPTION
Previously, dependencies listed in `setup_requires` were available within other scripts running inside the setup directory. Now that setup eggs are downloaded to the `.egg` directory, it seems that we have to create a dummy `Distribution` object to get to scripts.

Also, the `pykg_config.py` script had to be renamed to avoid a name collision with the `pykg_config` package.

Fixes #216.