### PR TITLE
Replace xrange with six.moves.xrange to support Python 3

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -24,6 +24,7 @@ try:
 except ImportError:
     import pyfits as pf
 import numpy as np
+import six
 from . import pixelfunc
 from .sphtfunc import Alm
 import warnings
@@ -422,7 +423,7 @@ def mwrfits(filename,data,hdu=1,colnames=None,keys=None):
     else:
         colnames = ['']*len(data)
     cols=[]
-    for line in xrange(len(data)):
+    for line in six.moves.xrange(len(data)):
         cols.append(pf.Column(name=colnames[line],
                                format=getformat(data[line]),
                                array=data[line]))

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -23,6 +23,7 @@ from . import pixelfunc
 import matplotlib
 from matplotlib import axes,ticker,colors,cm,lines,cbook,figure
 import numpy as np
+import six
 from ._healpy_pixel_lib import UNSEEN
 
 pi = np.pi
@@ -394,7 +395,7 @@ class SphericalProjAxes(axes.Axes):
         elif len(w) >= 2:
             xx.append(x[0:w[0]])
             yy.append(y[0:w[0]])
-            for i in xrange(len(w)-1):
+            for i in six.moves.xrange(len(w)-1):
                 xx.append(x[w[i]:w[i+1]])
                 yy.append(y[w[i]:w[i+1]])
             xx.append(x[w[-1]:])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 cython>=0.16
 matplotlib
 astropy
+six


### PR DESCRIPTION
As we have already done in a few other places. Also add missing dependency on six. Fixes #226.