### PR TITLE
LIGO enhancements to write_map

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -82,7 +82,7 @@ def read_cl(filename, dtype=np.float64, h=False):
       the cl array
     """
     hdulist=pf.open(filename)
-    cl = [hdulist[1].data.field(n) for n in range(len(hdulist[1].data.columns))]
+    cl = [hdulist[1].data.field(n) for n in range(len(hdulist[1].columns))]
     hdulist.close()
     if len(cl) == 1:
         return cl[0]

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -5,6 +5,7 @@ except:
     import pyfits as pf
 import unittest
 import numpy as np
+import gzip
 
 import healpy
 from ..fitsfunc import *
@@ -43,6 +44,24 @@ class TestFitsFunc(unittest.TestCase):
         read_m = pf.open(self.filename)[1].data
         for comp in range(3):
             self.assertTrue(np.all(self.m == read_m.field(comp)))
+
+    def tearDown(self):
+        os.remove(self.filename)
+
+class TestFitsFuncGzip(unittest.TestCase):
+
+    def setUp(self):
+        self.nside = 4
+        self.m = np.arange(healpy.nside2npix(self.nside))
+        self.filename = 'testmap.fits.gz'
+
+    def test_write_map(self):
+        write_map(self.filename, self.m)
+        # Make sure file is gzip-compressed
+        gzfile = gzip.open(self.filename, 'rb')
+        gzfile.read()
+        gzfile.close()
+        read_m = pf.open(self.filename)[1].data.field(0)
 
     def tearDown(self):
         os.remove(self.filename)

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -24,6 +24,14 @@ class TestFitsFunc(unittest.TestCase):
         self.assertEqual(read_m.shape[1], 1024)
         self.assertTrue(np.all(self.m == read_m.flatten()))
 
+    def test_write_map_units_string(self):
+        write_map(self.filename, self.m, column_units='K')
+        read_m = pf.open(self.filename)[1].data.field(0)
+
+    def test_write_map_units_list(self):
+        write_map(self.filename, [self.m, self.m], column_units=['K', 'K'])
+        read_m = pf.open(self.filename)[1].data.field(0)
+
     def test_write_map_C(self):
         write_map(self.filename, self.m, fits_IDL=False)
         read_m = pf.open(self.filename)[1].data.field(0)

--- a/healpy/test/test_pixelfunc.py
+++ b/healpy/test/test_pixelfunc.py
@@ -65,7 +65,7 @@ class TestPixelFunc(unittest.TestCase):
         npix = nside2npix(nside)
         d = [0.3, 0.5, 0.2]
         vec = np.transpose(pix2vec(nside, np.arange(npix)))
-        signal = vec.dot(d)
+        signal = np.dot(vec, d)
         mono, dipole = fit_dipole(signal)
         self.assertAlmostEqual(mono, 0.)
         self.assertAlmostEqual(d[0], dipole[0])

--- a/setup.py
+++ b/setup.py
@@ -374,6 +374,13 @@ hfits_lib = Extension('healpy._healpy_fitsio_lib',
                       language='c++'
                       )
 
+install_requires = ['matplotlib', 'numpy', 'six']
+# Add install dependency on astropy, unless pyfits is already installed.
+try:
+    import pyfits
+except ImportError:
+    install_requires.append('astropy')
+
 if on_rtd:
     libraries = []
     cmdclass = {}
@@ -439,6 +446,7 @@ setup(name='healpy',
       ext_modules = extension_list,
       package_data = {'healpy': ['data/*.fits', 'data/totcls.dat', 'test/data/*.fits', 'test/data/*.sh']},
       setup_requires=setup_requires,
+      install_requires=install_requires,
       tests_require=['pytest'],
       test_suite='healpy',
       license='GPLv2'


### PR DESCRIPTION
This is a batch of enhancements for `write_map` and some backward compatibility patches, all related to writing LIGO probability sky maps:

* support adding units to the FITS header for each column in the HEALPix map
* support writing gzip-compressed FITS files, even with old versions of pyfits
* some minor changes in numpy and pyfits usage to support older versions of these packages that come with Scientific Linux 6, the OS of several of the LIGO computing clusters