### PR TITLE
Make write_alm compatible with older versions of pyfits

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -382,7 +382,7 @@ def write_alm(filename,alms,out_dtype=None,lmax=-1,mmax=-1,mmax_in=-1):
         creal = pf.Column(name="real", format=getformat(out_dtype), unit="unknown", array=out_data['real'])
         cimag = pf.Column(name="imag", format=getformat(out_dtype), unit="unknown", array=out_data['imag'])
 
-        tbhdu = pf.BinTableHDU.from_columns([cindex,creal,cimag])
+        tbhdu = pf.new_table([cindex,creal,cimag])
         hdulist.append(tbhdu)
     writeto(tbhdu, filename)
     


### PR DESCRIPTION
Use `pyfits.new_table()` instead of `pyfits.BinTableHDU.from_columns()`
because the former is present in the older versions of pyfits that are
available in SL6 and Debian Wheezy.

Note that `pyfits.new_table()` has been deprecated, but we are using it
in all of the other FITS-writing functions.