### PR TITLE
Fix typo and missing keywords in the handling of a set of spin-0 maps.

### DIFF
--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -742,10 +742,9 @@ def smoothing(map_in, fwhm = 0.0, sigma = None,  pol = True,
     else:
         # Treat each map independently (any number)
         output_map = []
-        for m, mask in zip(map_in, masks):
-            alm = map2alm(map_in, iter = iter, pol = pol,
-                          use_weights = use_weights,
-                       datapath = datapath)
+        for m in map_in:
+            alm = map2alm(m, lmax = lmax, mmax = mmax, iter = iter, pol = pol,
+                          use_weights = use_weights, datapath = datapath)
             smoothalm(alm, fwhm = fwhm, sigma = sigma, 
                       inplace = True, verbose = verbose)
             output_map.append(alm2map(alm, nside, pixwin = False, verbose=verbose))


### PR DESCRIPTION
In the spin-0 case, the sequence of maps is iterated but the element is not used. In addition, the lmax and mmax keywords are not propagated (and the mask stuff doesn't need to be iterated).