### PR TITLE
Look for pkgconfig files in either lib64 or lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,9 @@ class build_external_clib(build_clib):
     def _environ(self):
         """Construct an environment dictionary suitable for having pkg-config
         pick up .pc files in the build_clib directory."""
-        pkg_config_path = os.path.join(os.path.realpath(self.build_clib), 'lib', 'pkgconfig')
+        pkg_config_path = (
+            os.path.join(os.path.realpath(self.build_clib), 'lib64', 'pkgconfig') +
+            ':' + os.path.join(os.path.realpath(self.build_clib), 'lib', 'pkgconfig'))
         try:
             pkg_config_path += ':' + os.environ['PKG_CONFIG_PATH']
         except KeyError:


### PR DESCRIPTION
On OpenSUSE, libraries are installed into `lib64` instead of `lib`. If
we build our own healpix_cxx library, then we need to remember to add
both `lib64` and `lib` to the `PKG_CONFIG_PATH`.

Reported by @bsesar.