### PR TITLE
Remove Cython & numpy dependencies when querying setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,10 +86,16 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 cython_require = 'Cython >= 0.16'
 try:
-    pkg_resources.require(cython_require)
-    from Cython.Distutils import build_ext
-    ext = "pyx"
-    extcpp = "pyx"
+    if ('--help' in sys.argv[1:] or
+        sys.argv[1] in ('--help-commands', 'egg_info', 'clean', '--version')):
+        from distutils.command.build_ext import build_ext        
+        ext = "c"
+        extcpp = "cpp"
+    else:
+        pkg_resources.require(cython_require)
+        from Cython.Distutils import build_ext
+        ext = "pyx"
+        extcpp = "pyx"
 except:
     # User does not have a sufficiently new version of Cython.
     if os.path.exists('healpy/src/_query_disc.cpp'):
@@ -115,9 +121,12 @@ OR, to build from development sources, first get {0} from:
 if on_rtd:
     numpy_inc = ''
 else:
-    from numpy import get_include
-    numpy_inc = get_include()
-
+    if ('--help' in sys.argv[1:] or
+        sys.argv[1] in ('--help-commands', 'egg_info', 'clean', '--version')):
+        numpy_inc = ''
+    else:
+        from numpy import get_include
+        numpy_inc = get_include()
 
 # Test if pkg-config is present. If not, fall back to pykg-config.
 try:


### PR DESCRIPTION
When installing through pip and using the requirements file, pip makes two passes through the `setup.py` files of the packages (including healpy): the first pass is to obtain some info, through the `setup.py egg_info` command. 
In a clean environment, where numpy and Cython are not yet installed (e.g., a virtualenv), this result in an error, since `setup.py` unconditionally imports numpy and Cython. Using a conditional import, by testing the argument given to `setup.py`, allows one to install healpy in one go (`pip install healpy`) without first needing to install numpy and Cython separately. This also prevents problems when one runs e.g. `setup.py --help` in a clean environment.
More information can be found at the [pip issue tracker](https://github.com/pypa/pip/issues/25); the solution given there at the bottom, is the one implemented here.
