### PR TITLE
return a result when boundaries() is called with the healpixels given as python list

### DIFF
--- a/healpy/src/_query_disc.pyx
+++ b/healpy/src/_query_disc.pyx
@@ -279,12 +279,13 @@ def boundaries(nside, pix, step=1, nest=False):
         raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     if isinstance(pix, (int, long)):
         return _boundaries_single(nside, pix, step=step, nest=nest)
-    if type(pix) is np.ndarray:
-        if not issubclass(pix.dtype.type, np.integer):
-            raise ValueError('Array of pixels has to be integers')
-        if pix.ndim!=1:
-            raise ValueError('Array has to one dimensional')
-        return _boundaries_multiple(nside, pix, step=step, nest=nest)
+    if not (type(pix) is np.ndarray):
+       pix = np.asarray(pix)
+    if not issubclass(pix.dtype.type, np.integer):
+        raise ValueError('Array of pixels has to be integers')
+    if pix.ndim!=1:
+        raise ValueError('Array has to one dimensional')
+    return _boundaries_multiple(nside, pix, step=step, nest=nest)
 
 # Try to implement pix2ang
 ### @cython.boundscheck(False)


### PR DESCRIPTION
Hi, 
currently when boundaries() method is called like this 

healpy.boundaries(2,[2,3]) 
it returns None 

This pull requests fixes this by trying to cast the input to a numpy array.

Cheers,
        Sergey