### PR TITLE
RWO: Typo fix to fix hemisphere in orthview projplot

### DIFF
--- a/healpy/projector.py
+++ b/healpy/projector.py
@@ -741,7 +741,7 @@ class OrthographicProj(SphericalProj):
                 if half_sky:
                     x = np.nan
                 else:
-                    x *= 1
+                    x *= -1
         if half_sky:
             mask = (np.asarray(x)**2+np.asarray(y)**2>1.0)
         else:


### PR DESCRIPTION
Fixes issue #286 where points plotted with projplot on orthview appear in the wrong hemisphere.