### PR TITLE
FIX: Switch submodule protocols from git to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "healpixsubmodule"]
 	path = healpixsubmodule
-	url = git://github.com/healpy/healpixmirror.git
+	url = https://github.com/healpy/healpixmirror.git
 [submodule "cfitsio"]
 	path = cfitsio
-	url = git://github.com/healpy/cfitsio.git
+	url = https://github.com/healpy/cfitsio.git


### PR DESCRIPTION
Some of us are working behind company firewalls that
do not allow access to git:// protocols, thus making
it impossible to use these projects as is.

This commit changes to protocols from git:// to
https://.  New repository clones should work with the
new protocols just fine.

Existing repository clones will have to run:

    git submodule sync

in order to copy the protocol changes from
.gitmodules to .git/config