### PR TITLE
Restrict external HEALPix installations to >= 3.30.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -409,7 +409,7 @@ else:
         'local_source': 'cfitsio',
         'supports_non_srcdir_builds': False}),
         ('healpix_cxx', {
-        'pkg_config_name': 'healpix_cxx',
+        'pkg_config_name': 'healpix_cxx >= 3.30.0',
         'local_source': 'healpixsubmodule/src/cxx/autotools'})
     ]
     extension_list = [pixel_lib, spht_lib, hfits_lib,


### PR DESCRIPTION
The healpix_cxx API has changed, and Healpy now requires healpix_cxx >= 3.30.0. When we attempt to locate preexisting builds of healpix_cxx using pkg-config, restrict to healpix_cxx >= 3.30.0. If this requirement is not satisfied, we fall back to build healpix_cxx ourselves.

Fixes #292.