### PR TITLE
Remove special cases for imports and setup.py build phases

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,48 +12,6 @@
 # serve to show the default value.
 
 import sys, os
-try:
-    from exceptions import ImportError
-except:
-    pass
-
-# To avoid problem with ReadTheDocs and compiled extensions.
-class Mock(object):
-    """Special Healpix values for masked pixels.
-    """
-    pi = 3.141516
-    class Axes(object):
-        pass
-    class Locator(object):
-        pass
-    class Normalize(object):
-        pass
-    def __init__(self, *args):
-        """Mock init
-        """
-        pass
-
-    def __getattr__(self, name):
-        return Mock
-
-    def __div__(self, x):
-        return Mock()
-
-    def __getitem__(self, idx):
-        return str(Mock())
-
-try:
-    import healpy
-except ImportError:
-    MOCK_MODULES = ['matplotlib', 'pylab', 'matplotlib.colors', 'matplotlib.axes',
-                    'matplotlib.cbook', 'pyfits',
-                    'numpy', '_healpy_pixel_lib',
-                    '_healpy_sph_transform_lib', '_healpy_fitsio_lib', '_sphtools',
-                    'healpy._sphtools']
-
-    for mod_name in MOCK_MODULES:
-        sys.modules[mod_name] = Mock()
-    
 
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -21,14 +21,6 @@
 compute spherical harmonics tranforms on them.
 """
 
-import warnings
-
-try:
-    ImportWarning
-except NameError:
-    class ImportWarning(Warning):
-        pass
-
 from .version import __version__
 
 from .pixelfunc import (ma, mask_good, mask_bad,
@@ -52,52 +44,16 @@ from .sphtfunc import (anafast, map2alm,
                       smoothing, smoothalm, almxfl, alm2cl,
                       pixwin, alm2map_der1, gauss_beam)
 
-try:
-    from ._query_disc import query_disc, query_strip, query_polygon, boundaries
-except ImportError:
-    warnings.warn('Warning: cannot import query disc module')
-try:
-    from ._pixelfunc import ringinfo, pix2ring
-except ImportError:
-    warnings.warn('Warning: cannot import pixelfunc module')
+from ._query_disc import query_disc, query_strip, query_polygon, boundaries
+from ._pixelfunc import ringinfo, pix2ring
 
-try:
-    from ._sphtools import rotate_alm
-    from ._sphtools import alm2map_spin_healpy as alm2map_spin
-    from ._sphtools import map2alm_spin_healpy as map2alm_spin
-except ImportError:
-    warnings.warn('Warning: cannot import _sphtools module')
-
-
+from ._sphtools import rotate_alm
+from ._sphtools import alm2map_spin_healpy as alm2map_spin
+from ._sphtools import map2alm_spin_healpy as map2alm_spin
 from .rotator import Rotator, vec2dir, dir2vec
-
-try:
-    from ._healpy_pixel_lib import UNSEEN
-except ImportError:
-    warnings.warn('Warning: cannot import pixel lib module')
-
-try:
-    from pshyt import job
-    from pshyt import *
-except ImportError:
-    warnings.warn("Warning: Cannot import pshyt module)",
-                  category=ImportWarning)
-
-try:
-    from .visufunc import (mollview,graticule,delgraticules,gnomview,
-                          projplot,projscatter, projtext, cartview, orthview)
-    from .zoomtool import mollzoom,set_g_clim
-    if visufunc.matplotlib.__version__ == '0.98,3':
-        warnings.warn("Bug in matplotlib 0.98.3 prevents mollview from working\n"+
-                      "You should upgrade to matplotlib 0.98.4 or above",
-                      category=ImportWarning)
-except ImportError:
-    warnings.warn("Warning: Cannot import visualisation tools (needs matplotlib)",
-                  category=ImportWarning)
-
-try:
-    from .fitsfunc import write_map,read_map,mrdfits,mwrfits,read_alm,write_alm,write_cl,read_cl
-except:
-    warnings.warn("Warning: Cannot import fits i/o tools (needs astropy)",
-                  category=ImportWarning)
+from ._healpy_pixel_lib import UNSEEN
+from .visufunc import (mollview,graticule,delgraticules,gnomview,
+                      projplot,projscatter, projtext, cartview, orthview)
+from .zoomtool import mollzoom,set_g_clim
+from .fitsfunc import write_map,read_map,mrdfits,mwrfits,read_alm,write_alm,write_cl,read_cl
 

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -25,15 +25,7 @@ import matplotlib.axes
 import numpy as np
 import six
 
-UNSEEN=None
-
-try:
-    from . import _healpy_pixel_lib as pixlib
-    #: Special value used for masked pixels
-    UNSEEN = pixlib.UNSEEN
-except:
-    import warnings
-    warnings.warn('Warning: cannot import _healpy_pixel_lib module')
+from ._healpy_pixel_lib import UNSEEN
 
 pi = np.pi
 dtor = pi/180.

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -24,22 +24,13 @@ pi = np.pi
 import warnings
 
 try:
-    from exceptions import ImportError
-except:
-    pass
+    import astropy.io.fits as pf
+except ImportError:
+    import pyfits as pf
 
-try:
-    from . import _healpy_sph_transform_lib as sphtlib
-except ImportError:
-    warnings.warn('Warning: cannot import _healpy_pixel_lib module')
-try:
-    from . import _healpy_fitsio_lib as hfitslib
-except ImportError:
-    warnings.warn('Warning: cannot import _healpy_fitsio_lib module')
-try:
-    from . import _sphtools as _sphtools
-except ImportError:
-    warnings.warn('Warning: cannot import _sphtools module')
+from . import _healpy_sph_transform_lib as sphtlib
+from . import _healpy_fitsio_lib as hfitslib
+from . import _sphtools as _sphtools
 from . import cookbook as cb
 
 import os.path
@@ -780,13 +771,6 @@ def pixwin(nside, pol = False):
         raise ValueError("No pixel window for this nside "
                          "or data files missing")
     # return hfitslib._pixwin(nside,datapath,pol)  ## BROKEN -> seg fault...
-    try:
-        try:
-            import astropy.io.fits as pf
-        except ImportError:
-            import pyfits as pf
-    except ImportError:
-        raise ImportError("You need to install astropy.io.fits or pyfits to use this function.")
     pw = pf.getdata(fname)
     pw_temp, pw_pol = pw.field(0), pw.field(1)
     if pol:

--- a/setup.py
+++ b/setup.py
@@ -6,18 +6,18 @@
 try:
     import pkg_resources
     pkg_resources.require("setuptools >= 3.2")
-except:
+except pkg_resources.ResolutionError:
     from ez_setup import use_setuptools
     use_setuptools()
 
 import os
-from os.path import join
 import errno
 import fnmatch
 import sys
 import shlex
 from distutils.sysconfig import get_config_var, get_config_vars
-from setuptools import setup, Extension
+from setuptools import setup
+from setuptools.dist import Distribution
 from setuptools.command.test import test as TestCommand
 from distutils.command.build_clib import build_clib
 from distutils.errors import DistutilsExecError
@@ -35,6 +35,7 @@ from distutils import log
 # This workaround fixes <https://github.com/healpy/healpy/issues/151>.
 if get_config_var('MACOSX_DEPLOYMENT_TARGET') and not 'MACOSX_DEPLOYMENT_TARGET' in os.environ:
     os.environ['MACOSX_DEPLOYMENT_TARGET'] = get_config_var('MACOSX_DEPLOYMENT_TARGET')
+
 
 #
 # FIXME: Copied from Python 2.7's subprocess.check_output,
@@ -81,63 +82,28 @@ def check_output(*popenargs, **kwargs):
 #
 
 
-# For ReadTheDocs, do not build the extensions, only install .py files
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
+# If the Cython-generated C++ files are absent, then fetch and install Cython
+# as an egg. If the Cython-generated files are present, then only use Cython if
+# a sufficiently new version of Cython is already present on the system.
 cython_require = 'Cython >= 0.16'
+log.info('checking if Cython-generated files have been built')
 try:
-    if ('--help' in sys.argv[1:] or
-        sys.argv[1] in ('--help-commands', 'egg_info', 'clean', '--version')):
-        from distutils.command.build_ext import build_ext        
-        ext = "c"
-        extcpp = "cpp"
-    else:
-        pkg_resources.require(cython_require)
-        from Cython.Distutils import build_ext
-        ext = "pyx"
-        extcpp = "pyx"
-except:
-    # User does not have a sufficiently new version of Cython.
-    if os.path.exists('healpy/src/_query_disc.cpp'):
-        # This source package already contains the Cython-generated sources,
-        # so we can just use them.
-        from distutils.command.build_ext import build_ext
-        ext = "c"
-        extcpp = "cpp"
-    else:
-        # This source does not contain the Cython-generated sources, so fail.
-        raise DistutilsExecError('''
-
-It looks like you are attempting to build from the Healpy development
-sources, i.e., from GitHub. You need {0} to build Healpy from
-development sources.
-
-Either install Healpy from an official stable release from:
-    https://pypi.python.org/pypi/healpy
-
-OR, to build from development sources, first get {0} from:
-    https://pypi.python.org/pypi/Cython'''.format(cython_require))
-  
-if on_rtd:
-    numpy_inc = ''
+    open('healpy/src/_query_disc.cpp')
+except IOError:
+    log.info('Cython-generated files are absent; installing Cython locally')
+    Distribution().fetch_build_eggs(cython_require)
 else:
-    if ('--help' in sys.argv[1:] or
-        sys.argv[1] in ('--help-commands', 'egg_info', 'clean', '--version')):
-        numpy_inc = ''
-    else:
-        from numpy import get_include
-        numpy_inc = get_include()
-
-# Test if pkg-config is present. If not, fall back to pykg-config.
+    log.info('Cython-generated files are present')
 try:
-    check_output(['pkg-config', '--version'])
-    setup_requires = []
-except OSError as e:
-    if e.errno != errno.ENOENT:
-        raise ValueError
-    log.warn('pkg-config is not installed, falling back to pykg-config')
-    setup_requires = ['pykg-config >= 1.2.0']
-    os.environ['PKG_CONFIG'] = sys.executable + ' ' + os.path.abspath('run_pykg_config.py')
+    log.info('Checking for %s', cython_require)
+    pkg_resources.require(cython_require)
+except pkg_resources.ResolutionError:
+    log.info('%s is not installed; not using Cython')
+    from setuptools.command.build_ext import build_ext
+    from setuptools import Extension
+else:
+    log.info('%s is installed; using Cython')
+    from Cython.Distutils import build_ext, Extension
 
 
 class build_external_clib(build_clib):
@@ -150,23 +116,115 @@ class build_external_clib(build_clib):
         build_clib.__init__(self, dist)
         self.build_args = {}
 
-    @property
-    def _environ(self):
-        """Construct an environment dictionary suitable for having pkg-config
-        pick up .pc files in the build_clib directory."""
-        pkg_config_path = (
-            os.path.join(os.path.realpath(self.build_clib), 'lib64', 'pkgconfig') +
-            ':' + os.path.join(os.path.realpath(self.build_clib), 'lib', 'pkgconfig'))
+    def autotools_path(self):
+        """
+        Install Autotools locally if we are building on Read The Docs, because
+        we will be building from git and need to generate the healpix_cxx build
+        system.
+        """
+        on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+        if not on_rtd:
+            return None
+
+        log.info("checking if autotools is installed")
         try:
-            pkg_config_path += ':' + os.environ['PKG_CONFIG_PATH']
+            check_output(['autoreconf', '--version'])
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
+            log.info("autotools is not installed")
+        else:
+            log.info("autotools is already installed")
+            return None
+
+        urls = [
+            'http://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz',
+            'http://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz',
+            'http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz',
+            'http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz',
+            'http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz'
+        ]
+
+        # Use a subdirectory of build_temp as the build directory.
+        build_temp = os.path.realpath(self.build_temp)
+        prefix = os.path.join(build_temp, 'autotools')
+        mkpath(prefix)
+
+        env = dict(os.environ)
+        path = os.path.join(prefix, 'bin')
+        try:
+            path += ':' + env['PATH']
         except KeyError:
             pass
-        return dict(os.environ, PKG_CONFIG_PATH=pkg_config_path)
+        env['PATH'] = path
+
+        # Check again if autotools is available, now that we have added the
+        # temporary path.
+        try:
+            check_output(['autoreconf', '--version'], env=env)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
+            log.info("building autotools from source")
+        else:
+            log.info("using autotools built from source")
+            return path
+
+        # Otherwise, build from source.
+        for url in urls:
+            _, _, tarball = url.rpartition('/')
+            pkg_version = tarball.replace('.tar.gz', '')
+            log.info('downloading %s', url)
+            check_call(['curl', '-O', url], cwd=build_temp)
+            log.info('extracting %s', tarball)
+            check_call(['tar', '-xzf', tarball], cwd=build_temp)
+            cwd = os.path.join(build_temp, pkg_version)
+            log.info('configuring %s', pkg_version)
+            check_call(['./configure', '--prefix', prefix, '--with-internal-glib'], env=env, cwd=cwd)
+            log.info('making %s', pkg_version)
+            check_call(['make', 'install'], env=env, cwd=cwd)
+        return path
+
+    def env(self):
+        """Construct an environment dictionary suitable for having pkg-config
+        pick up .pc files in the build_clib directory."""
+        # Test if pkg-config is present. If not, fall back to pykg-config.
+        try:
+            env = self._env
+        except AttributeError:
+            env = dict(os.environ)
+
+            path = self.autotools_path()
+            if path is not None:
+                env['PATH'] = path
+
+            try:
+                check_output(['pkg-config', '--version'])
+            except OSError as e:
+                if e.errno != errno.ENOENT:
+                    raise
+                log.warn('pkg-config is not installed, falling back to pykg-config')
+                env['PKG_CONFIG'] = sys.executable + ' ' + os.path.abspath('run_pykg_config.py')
+            else:
+                env['PKG_CONFIG'] = 'pkg-config'
+
+            build_clib = os.path.realpath(self.build_clib)
+            pkg_config_path = (
+                os.path.join(build_clib, 'lib64', 'pkgconfig') +
+                ':' + os.path.join(build_clib, 'lib', 'pkgconfig'))
+            try:
+                pkg_config_path += ':' + env['PKG_CONFIG_PATH']
+            except KeyError:
+                pass
+            env['PKG_CONFIG_PATH'] = pkg_config_path
+
+            self._env = env
+        return env
 
     def pkgconfig(self, *packages):
+        env = self.env()
         PKG_CONFIG = tuple(shlex.split(
-            os.environ.get('PKG_CONFIG', 'pkg-config'),
-            posix=(os.sep == '/')))
+            env['PKG_CONFIG'], posix=(os.sep == '/')))
         kw = {}
         index_key_flag = (
             (2, '--cflags-only-I', ('include_dirs',)),
@@ -177,7 +235,7 @@ class build_external_clib(build_clib):
         for index, flag, keys in index_key_flag:
             cmd = PKG_CONFIG + (flag,) + tuple(packages)
             log.debug('%s', ' '.join(cmd))
-            args = [token[index:].decode() for token in check_output(cmd, env=self._environ).split()]
+            args = [token[index:].decode() for token in check_output(cmd, env=env).split()]
             if args:
                 for key in keys:
                     kw.setdefault(key, []).extend(args)
@@ -187,13 +245,14 @@ class build_external_clib(build_clib):
         """Run 'autoreconf -i' for any bundled libraries to generate the
         configure script."""
         build_clib.finalize_options(self)
+        env = self.env()
 
         for lib_name, build_info in self.libraries:
             if 'sources' not in build_info:
                 log.info("checking if configure script for library '%s' exists", lib_name)
                 if not os.path.exists(os.path.join(build_info['local_source'], 'configure')):
                     log.info("running 'autoreconf -i' for library '%s'", lib_name)
-                    check_call(['autoreconf', '-i'], cwd=build_info['local_source'])
+                    check_call(['autoreconf', '-i'], cwd=build_info['local_source'], env=env)
 
     def build_library(self, library, pkg_config_name, local_source=None, supports_non_srcdir_builds=True):
         log.info("checking if library '%s' is installed", library)
@@ -208,6 +267,8 @@ class build_external_clib(build_clib):
 
             log.info("building library '%s' from source", library)
 
+            env = self.env()
+
             # Determine which compilers we are to use, and what flags.
             # This is based on what distutils.sysconfig.customize_compiler()
             # does, but that function has a problem that it doesn't produce
@@ -215,14 +276,14 @@ class build_external_clib(build_clib):
             cc, cxx, opt, cflags = get_config_vars('CC', 'CXX', 'OPT', 'CFLAGS')
             cxxflags = cflags
 
-            if 'CC' in os.environ:
-                cc = os.environ['CC']
-            if 'CXX' in os.environ:
-                cxx = os.environ['CXX']
-            if 'CFLAGS' in os.environ:
-                cflags = opt + ' ' + os.environ['CFLAGS']
-            if 'CXXFLAGS' in os.environ:
-                cxxflags = opt + ' ' + os.environ['CXXFLAGS']
+            if 'CC' in env:
+                cc = env['CC']
+            if 'CXX' in env:
+                cxx = env['CXX']
+            if 'CFLAGS' in env:
+                cflags = opt + ' ' + env['CFLAGS']
+            if 'CXXFLAGS' in env:
+                cxxflags = opt + ' ' + env['CXXFLAGS']
 
             # Use a subdirectory of build_temp as the build directory.
             build_temp = os.path.realpath(os.path.join(self.build_temp, library))
@@ -245,13 +306,13 @@ class build_external_clib(build_clib):
                 '--disable-maintainer-mode']
 
             log.info('%s', ' '.join(cmd))
-            check_call(cmd, cwd=build_temp, env=dict(self._environ,
+            check_call(cmd, cwd=build_temp, env=dict(env,
                 CC=cc, CXX=cxx, CFLAGS=cflags, CXXFLAGS=cxxflags))
 
             # Run make install.
             cmd = ['make', 'install']
             log.info('%s', ' '.join(cmd))
-            check_call(cmd, cwd=build_temp, env=self._environ)
+            check_call(cmd, cwd=build_temp, env=env)
 
             build_args = self.pkgconfig(pkg_config_name)
 
@@ -325,6 +386,20 @@ class build_external_clib(build_clib):
 
 
 class custom_build_ext(build_ext):
+    def finalize_options(self):
+        build_ext.finalize_options(self)
+
+        # Make sure that Numpy is importable
+        # (does the same thing as setup_requires=['numpy'])
+        self.distribution.fetch_build_eggs('numpy')
+        # Prevent numpy from thinking it is still in its setup process:
+        # See http://stackoverflow.com/questions/19919905
+        __builtins__.__NUMPY_SETUP__ = False
+
+        # Add Numpy header search path path
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+
     def run(self):
         # If we were asked to build any C/C++ libraries, add the directory
         # where we built them to the include path. (It's already on the library
@@ -354,39 +429,10 @@ class PyTest(TestCommand):
         sys.exit(pytest.main(self.test_args))
 
 
-def get_version():
-    context = {}
-    try:
-        execfile
-    except NameError:
-        exec(open('healpy/version.py').read(), context)
-    else:
-        execfile('healpy/version.py', context)
-    return context['__version__']
+exec(open('healpy/version.py').read())
 
-healpy_pixel_lib_src = '_healpy_pixel_lib.cc'
-healpy_spht_src = '_healpy_sph_transform_lib.cc'
-healpy_fitsio_src = '_healpy_fitsio_lib.cc'
 
-#start with base extension
-pixel_lib = Extension('healpy._healpy_pixel_lib',
-                      sources=[join('healpy','src', healpy_pixel_lib_src)],
-                      include_dirs=[numpy_inc],
-                      language='c++'
-                      )
-
-spht_lib = Extension('healpy._healpy_sph_transform_lib',
-                     sources=[join('healpy','src', healpy_spht_src)],
-                     include_dirs=[numpy_inc],
-                     language='c++'
-                     )
-
-hfits_lib = Extension('healpy._healpy_fitsio_lib',
-                      sources=[join('healpy','src', healpy_fitsio_src)],
-                      include_dirs=[numpy_inc],
-                      language='c++'
-                      )
-
+# Determine dependencies.
 install_requires = ['matplotlib', 'numpy', 'six']
 # Add install dependency on astropy, unless pyfits is already installed.
 try:
@@ -394,42 +440,9 @@ try:
 except ImportError:
     install_requires.append('astropy')
 
-if on_rtd:
-    libraries = []
-    cmdclass = {}
-    extension_list = []
-else:
-    cmdclass = {
-        'build_ext': custom_build_ext,
-        'build_clib': build_external_clib,
-        'test': PyTest}
-    libraries = [
-        ('cfitsio', {
-        'pkg_config_name': 'cfitsio',
-        'local_source': 'cfitsio',
-        'supports_non_srcdir_builds': False}),
-        ('healpix_cxx', {
-        'pkg_config_name': 'healpix_cxx >= 3.30.0',
-        'local_source': 'healpixsubmodule/src/cxx/autotools'})
-    ]
-    extension_list = [pixel_lib, spht_lib, hfits_lib,
-                      Extension("healpy._query_disc",
-                                ['healpy/src/_query_disc.'+extcpp],
-                                include_dirs=[numpy_inc],
-                                language='c++'),
-                      Extension("healpy._sphtools", 
-                                ['healpy/src/_sphtools.'+extcpp],
-                                include_dirs=[numpy_inc],
-                                language='c++'),
-                      Extension("healpy._pixelfunc", 
-                                ['healpy/src/_pixelfunc.'+extcpp],
-                                include_dirs=[numpy_inc],
-                                language='c++'),
-                      ]
-    for e in extension_list[-3:]: #extra setup for Cython extensions
-        e.pyrex_directives = {"embedsignature": True}
+
 setup(name='healpy',
-      version=get_version(),
+      version=__version__,
       description='Healpix tools package for Python',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
@@ -450,15 +463,48 @@ setup(name='healpy',
       author_email='cyrille.rosset@apc.univ-paris-diderot.fr',
       url='http://github.com/healpy',
       packages=['healpy','healpy.test'],
-      libraries=libraries,
+      libraries=[
+          ('cfitsio', {
+           'pkg_config_name': 'cfitsio',
+           'local_source': 'cfitsio',
+           'supports_non_srcdir_builds': False}),
+          ('healpix_cxx', {
+           'pkg_config_name': 'healpix_cxx >= 3.30.0',
+           'local_source': 'healpixsubmodule/src/cxx/autotools'})
+      ],
       py_modules=['healpy.pixelfunc','healpy.sphtfunc',
                   'healpy.visufunc','healpy.fitsfunc',
                   'healpy.projector','healpy.rotator',
                   'healpy.projaxes','healpy.version'],
-      cmdclass = cmdclass,
-      ext_modules = extension_list,
+      cmdclass={
+          'build_ext': custom_build_ext,
+          'build_clib': build_external_clib,
+          'test': PyTest
+      },
+      ext_modules=[
+          Extension('healpy._healpy_pixel_lib',
+                    sources=['healpy/src/_healpy_pixel_lib.cc'],
+                    language='c++'),
+          Extension('healpy._healpy_sph_transform_lib',
+                    sources=['healpy/src/_healpy_sph_transform_lib.cc'],
+                    language='c++'),
+          Extension('healpy._healpy_fitsio_lib',
+                    sources=['healpy/src/_healpy_fitsio_lib.cc'],
+                    language='c++'),
+          Extension("healpy._query_disc",
+                    ['healpy/src/_query_disc.pyx'],
+                    language='c++',
+                    cython_directives=dict(embedsignature=True)),
+          Extension("healpy._sphtools",
+                    ['healpy/src/_sphtools.pyx'],
+                    language='c++',
+                    cython_directives=dict(embedsignature=True)),
+          Extension("healpy._pixelfunc",
+                    ['healpy/src/_pixelfunc.pyx'],
+                    language='c++',
+                    cython_directives=dict(embedsignature=True))
+      ],
       package_data = {'healpy': ['data/*.fits', 'data/totcls.dat', 'test/data/*.fits', 'test/data/*.sh']},
-      setup_requires=setup_requires,
       install_requires=install_requires,
       tests_require=['pytest'],
       test_suite='healpy',


### PR DESCRIPTION
There are numerous conditional imports and setup.py special cases to support building on Read The Docs. These tend to mask the causes of user installation errors (see #295).

The RTD build environment does support installing C extensions, so these patches cause RTD to do a full build of Healpy. RTD does lack autotools, which still must be downloaded as a special case.

The method `Distribution.fetch_build_eggs()` does the same thing as setting `setup_requires`, but at a controllable point in the script. The following changes are made to handling build dependencies:

* If the Cython-generated source files are absent, then Cython is required at all phases, including if the user is just asking for `--help`, because Cython adds command line options to `setup.py`. Because we are now using  `setuptools` to enforce this dependency, Cython will be downloaded as an egg if it is needed.
* Numpy is deferred to `build_ext`.
* `pkg-config` (or the fallback, `pykg-config`) is deferred to `build_clib`.
* As indicated above, we add a special case for Read The Docs, whose build environment lacks Autotools.

The Read The Docs output for this branch is here:
http://lpsingerhealpy.readthedocs.org/en/setup_cleanup/