### PR TITLE
Convert /= operations to comply with Numpy 1.10.0 casting rules

### DIFF
--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -1727,8 +1727,8 @@ def _ud_grade_core(m,nside_out,pess=False,power=None, dtype=None):
         else:
             badout = np.where(nhit == 0)
         if power:
-            nhit /= ratio
-        map_out[nhit!=0] /= nhit[nhit!=0] 
+            nhit = nhit / ratio
+        map_out[nhit!=0] = map_out[nhit!=0] / nhit[nhit!=0]
         try:
             map_out[badout] = UNSEEN
         except OverflowError:


### PR DESCRIPTION
According to the Numpy changelog(http://docs.scipy.org/doc/numpy-dev/release.html):

> Default casting for inplace operations will change to ‘same_kind’ in Numpy 1.10.0.

This is indeed the case, and Numpy inplace operations such as `/=` now must have results that can be cast to the same size and type as the left-hand side.

This patch is a straightforward transformation of the inplace operations in `healpy.ud_grade`.