### PR TITLE
Depend on Astropy instead of PyFITS for FITS support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Requirements
 * Python development package is required for some distribution (e.g.,
   python-dev package for Ubuntu)
 
-* `PyFITS <http://www.stsci.edu/resources/software_hardware/pyfits>`_
+* `Astropy <http://www.astropy.org>`_
 
 Quick installation with Pip
 ---------------------------

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -27,12 +27,7 @@ import tempfile
 import shutil
 import os
 import warnings
-
-try:
-    import astropy.io.fits as pf
-except ImportError:
-    import pyfits as pf
-
+import astropy.io.fits as pf
 import numpy as np
 
 from . import pixelfunc

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -22,11 +22,7 @@ import numpy as np
 import six
 pi = np.pi
 import warnings
-
-try:
-    import astropy.io.fits as pf
-except ImportError:
-    import pyfits as pf
+import astropy.io.fits as pf
 
 from . import _healpy_sph_transform_lib as sphtlib
 from . import _healpy_fitsio_lib as hfitslib

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -1,8 +1,5 @@
 import os
-try:
-    import astropy.io.fits as pf
-except:
-    import pyfits as pf
+import astropy.io.fits as pf
 import unittest
 import numpy as np
 import gzip

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -1,7 +1,4 @@
-try:
-    import astropy.io.fits as pf
-except:
-    import pyfits as pf
+import astropy.io.fits as pf
 import os
 import numpy as np
 from copy import deepcopy

--- a/setup.py
+++ b/setup.py
@@ -432,15 +432,6 @@ class PyTest(TestCommand):
 exec(open('healpy/version.py').read())
 
 
-# Determine dependencies.
-install_requires = ['matplotlib', 'numpy', 'six']
-# Add install dependency on astropy, unless pyfits is already installed.
-try:
-    import pyfits
-except ImportError:
-    install_requires.append('astropy')
-
-
 setup(name='healpy',
       version=__version__,
       description='Healpix tools package for Python',
@@ -505,7 +496,7 @@ setup(name='healpy',
                     cython_directives=dict(embedsignature=True))
       ],
       package_data = {'healpy': ['data/*.fits', 'data/totcls.dat', 'test/data/*.fits', 'test/data/*.sh']},
-      install_requires=install_requires,
+      install_requires=['matplotlib', 'numpy', 'six', 'astropy'],
       tests_require=['pytest'],
       test_suite='healpy',
       license='GPLv2'


### PR DESCRIPTION
The [days of PyFITS are numbered](http://www.stsci.edu/institute/software_hardware/pyfits)...

> All of the functionality of PyFITS is now available in Astropy as the astropy.io.fits package, which is now publicly available. Although we will continue to release PyFITS separately in the short term, including any critical bug fixes, we will eventually stop releasing new versions of PyFITS as a stand-alone product. The exact timing of when we will discontinue new PyFITS releases is not yet settled, but users should not expect PyFITS releases to extend much past early 2014.