### PR TITLE
Resolve deprecated method warning by pyFITS.

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -20,6 +20,7 @@
 """Provides input and output functions for Healpix maps, alm, and cl.
 """
 from __future__ import with_statement
+from __future__ import division
 
 import six
 import gzip
@@ -208,7 +209,7 @@ def write_map(filename,m,nest=False,dtype=np.float32,fits_IDL=True,coord=None,pa
             mm2 = np.asarray(mm)
             cols.append(pf.Column(name=cn,
                                    format='1024%s' % curr_fitsformat,
-                                   array=mm2.reshape(mm2.size/1024,1024),
+                                   array=mm2.reshape(mm2.size//1024,1024),
                                    unit=cu))
         else:
             cols.append(pf.Column(name=cn,
@@ -216,7 +217,11 @@ def write_map(filename,m,nest=False,dtype=np.float32,fits_IDL=True,coord=None,pa
                                    array=mm,
                                    unit=cu))
 
-    tbhdu = pf.new_table(cols)
+    try:
+        tbhdu = pf.BinTableHDU.from_columns( cols )
+    except:
+        # Fall back to the old API
+        tbhdu = pf.new_table(cols)
     # add needed keywords
     tbhdu.header['PIXTYPE'] = ('HEALPIX', 'HEALPIX pixelisation')
     if nest: ordering = 'NESTED'

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -219,7 +219,7 @@ def write_map(filename,m,nest=False,dtype=np.float32,fits_IDL=True,coord=None,pa
 
     try:
         tbhdu = pf.BinTableHDU.from_columns( cols )
-    except:
+    except AttributeError:
         # Fall back to the old API
         tbhdu = pf.new_table(cols)
     # add needed keywords


### PR DESCRIPTION
Also fix non-integer division warning when running with Python 3.