### PR TITLE
Fix bug in write_alm

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -479,7 +479,7 @@ def write_alm(filename,alms,out_dtype=None,lmax=-1,mmax=-1,mmax_in=-1):
 
         tbhdu = pf.new_table([cindex,creal,cimag])
         hdulist.append(tbhdu)
-    writeto(tbhdu, filename)
+    writeto(hdulist, filename)
 
 def read_alm(filename,hdu=1,return_mmax=False):
     """Read alm from a fits file.


### PR DESCRIPTION
Commit 29c7ff4777557754aa1cd163eb03d3a6133b5d03 removed `write_alm`'s ability to write multiple alms. This commit restores that functionality.