### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ standard numeric and visualisation tools for Python, Numpy and matplotlib.
 To find more information about HEALPix, please visit its home page at
 http://healpix.sourceforge.net/.
 
-The documentation can be found at http://healpy.readthedocs.org, tutorial at
-http://healpy.readthedocs.org/en/latest/tutorial.html.
+The documentation can be found at https://healpy.readthedocs.io, tutorial at
+https://healpy.readthedocs.io/en/latest/tutorial.html.
 
 Characteristics
 ---------------

--- a/doc/HOWTO_DOC
+++ b/doc/HOWTO_DOC
@@ -14,7 +14,7 @@ This will create the documentation in doc/.build/html.
 
 The documentation of the master branch is also available at readthedoc :
 
-    http://healpy.readthedocs.org/en/latest/index.html
+    https://healpy.readthedocs.io/en/latest/index.html
 
 It is rebuild from the master branch at each commit (so it is always the latest version). 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.