### PR TITLE
Fix warning from floating point division of two integers

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -20,6 +20,7 @@
 """Provides input and output functions for Healpix maps, alm, and cl.
 """
 from __future__ import with_statement
+from __future__ import division
 
 import six
 import gzip
@@ -208,7 +209,7 @@ def write_map(filename,m,nest=False,dtype=np.float32,fits_IDL=True,coord=None,pa
             mm2 = np.asarray(mm)
             cols.append(pf.Column(name=cn,
                                    format='1024%s' % curr_fitsformat,
-                                   array=mm2.reshape(mm2.size/1024,1024),
+                                   array=mm2.reshape(mm2.size//1024,1024),
                                    unit=cu))
         else:
             cols.append(pf.Column(name=cn,


### PR DESCRIPTION
In python3, division operator, "/", produces floating point results even with integer inputs. This produces a warning when the result is used in place of an integer input further on. 

The pull request imports the python3 division and uses it for integer-valued division in fitsfunc.py.

Having the harmless warning removed helps debugging software that uses healpy. This is especially the case when a developer has filtered all warnings to issue exceptions with
```
import warnings
warnings.filterwarnings('error')
```