### PR TITLE
Fix for strings in Python 2/3

### DIFF
--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -276,13 +276,11 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
         if datapath is None:
             datapath = get_datapath()
         # For Python3: datapath must be a str, bdatapath must be bytes
-        if type(datapath) is unicode :
-          bdatapath = datapath.encode('UTF-8')
-        elif isinstance(datapath,bytes) :
-          bdatapath = datapath
-          datapath = datapath.decode('UTF-8')
+        if isinstance(datapath, unicode) :
+            bdatapath = datapath.encode('UTF-8')
         else :
-          print("Now What?")
+            bdatapath = datapath
+            datapath = datapath.decode('UTF-8')
         c_datapath = bdatapath
         weightfile = 'weight_ring_n%05d.fits' % (nside)
         if not os.path.isfile(os.path.join(datapath, weightfile)):

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -11,7 +11,6 @@ from healpy.pixelfunc import maptype
 import os
 import cython
 from libcpp cimport bool as cbool
-import six
 
 from _common cimport tsize, arr, xcomplex, Healpix_Ordering_Scheme, RING, NEST, Healpix_Map, Alm, ndarray2map, ndarray2alm
 
@@ -276,9 +275,15 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
     if use_weights:
         if datapath is None:
             datapath = get_datapath()
-        # b_datapath must be bytes
-        b_datapath = six.b(datapath)
-        c_datapath = b_datapath
+        # For Python3: datapath must be a str, bdatapath must be bytes
+        if type(datapath) is unicode :
+          bdatapath = datapath.encode('UTF-8')
+        elif isinstance(datapath,bytes) :
+          bdatapath = datapath
+          datapath = datapath.decode('UTF-8')
+        else :
+          print("Now What?")
+        c_datapath = bdatapath
         weightfile = 'weight_ring_n%05d.fits' % (nside)
         if not os.path.isfile(os.path.join(datapath, weightfile)):
             raise IOError('Weight file not found in %s' % (datapath))

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -11,6 +11,7 @@ from healpy.pixelfunc import maptype
 import os
 import cython
 from libcpp cimport bool as cbool
+import six
 
 from _common cimport tsize, arr, xcomplex, Healpix_Ordering_Scheme, RING, NEST, Healpix_Map, Alm, ndarray2map, ndarray2alm
 
@@ -275,15 +276,9 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
     if use_weights:
         if datapath is None:
             datapath = get_datapath()
-        # For Python3: datapath must be a str, bdatapath must be bytes
-        if type(datapath) is unicode :
-          bdatapath = datapath.encode('UTF-8')
-        elif isinstance(datapath,bytes) :
-          bdatapath = datapath
-          datapath = datapath.decode('UTF-8')
-        else :
-          print("Now What?")
-        c_datapath = bdatapath
+        # b_datapath must be bytes
+        b_datapath = six.b(datapath)
+        c_datapath = b_datapath
         weightfile = 'weight_ring_n%05d.fits' % (nside)
         if not os.path.isfile(os.path.join(datapath, weightfile)):
             raise IOError('Weight file not found in %s' % (datapath))

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -275,7 +275,15 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
     if use_weights:
         if datapath is None:
             datapath = get_datapath()
-        c_datapath = datapath
+        # For Python3: datapath must be a str, bdatapath must be bytes
+        if type(datapath) is unicode :
+          bdatapath = datapath.encode('UTF-8')
+        elif isinstance(datapath,bytes) :
+          bdatapath = datapath
+          datapath = datapath.decode('UTF-8')
+        else :
+          print("Now What?")
+        c_datapath = bdatapath
         weightfile = 'weight_ring_n%05d.fits' % (nside)
         if not os.path.isfile(os.path.join(datapath, weightfile)):
             raise IOError('Weight file not found in %s' % (datapath))

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -110,10 +110,11 @@ class TestSphtFunc(unittest.TestCase):
         tmp = np.empty(orig.size * 2)
         tmp[::2] = orig
         maps = [orig, orig.astype(np.float32), tmp[::2]]
-        for input in maps:
-            alm = hp.map2alm(input, iter=10)
-            output = hp.alm2map(alm, nside)
-            np.testing.assert_allclose(input, output, atol=1e-4)
+        for use_weights in [False, True]:
+            for input in maps:
+                alm = hp.map2alm(input, iter=10, use_weights=use_weights)
+                output = hp.alm2map(alm, nside)
+                np.testing.assert_allclose(input, output, atol=1e-4)
 
     def test_map2alm_pol(self):
         tmp = [np.empty(o.size*2) for o in self.mapiqu]
@@ -121,11 +122,12 @@ class TestSphtFunc(unittest.TestCase):
             t[::2] = o
         maps = [self.mapiqu, [o.astype(np.float32) for o in self.mapiqu],
                 [t[::2] for t in tmp]]
-        for input in maps:
-            alm = hp.map2alm(input, iter=10)
-            output = hp.alm2map(alm, 32)
-            for i, o in zip(input, output):
-                np.testing.assert_allclose(i, o, atol=1e-4)
+        for use_weights in [False, True]:
+            for input in maps:
+                alm = hp.map2alm(input, iter=10, use_weights=use_weights)
+                output = hp.alm2map(alm, 32)
+                for i, o in zip(input, output):
+                    np.testing.assert_allclose(i, o, atol=1e-4)
 
     def test_rotate_alm(self):
         almigc = hp.map2alm(self.mapiqu)


### PR DESCRIPTION
This is a proof of concept/description of issue #363 regarding use_weights in map2alm.  I do not expect it is a complete solution.  It has not been tested with Python 2 (I do not have such a test environment) so it may break Python 2.  There are also other cases/assumptions which may be missing.  I do not know much about cython in general or strings+cython at all!

The general idea is that the Python string (datapath variable) is in one format and the C string (c_datapath) needs to be in bytes.  In Python 3 these are different formats and seem to not be automagically converted.

If datapath is a "normal" Python string (unicode and/or type str), then it can be encoded into bytes.  This is the first part of the patch.

If datapath is already in bytes then it is good for the C code, but not for the rest of the Python code, in particular the os.path.join will fail with bytes.  This can be corrected too and is done in the elif block.  This may not be necessary.  It would only come up if the datapath were stored in bytes or if the user provided a path as bytes, instead of a Python string.  I included this because it came up while I was trying to debug the issue.

Finally, I don't know what other possibilities my occur and/or if the user should be protected from not just using a Python string in the first place.

The simplest fix (possibly with a wrapper for Python 2)  is to just use the datapath.encode('UTF-8').  I do think you need to go through a temporary since directly assigning this to c_datapath does not work.  If this were done, then non-Python string input would just fail.