### PR TITLE
Add overwrite keyword to write_map

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+Next Release Candidate
+
+* Change in write_map default behavior: <https://github.com/healpy/healpy/pull/379> and <https://github.com/healpy/healpy/pull/386>
+
 Release 1.10.1, 8 Nov 2016
 
 * Removed support for Python 2.6
@@ -68,7 +72,7 @@ Release 1.7.1, 23 Jan 2014
 
 Release 1.7.0, 14 Jan 2014 
 
-* rewritten spherical armonics unit tests, now it uses low res maps included in the repository
+* rewritten spherical harmonics unit tests, now it uses low res maps included in the repository
 * fix in HEALPix C++ build flags allows easier install on MAC-OSX and other python environments (e.g. anaconda)
 * orthview: orthografic projection
 * fixed bug in monopole removal in anafast

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -130,7 +130,7 @@ def write_map(filename,m,nest=False,dtype=np.float32,fits_IDL=True,coord=None,pa
       Default: np.float32.
     overwrite : bool, optional
       If True, existing file is silently overwritten. Otherwise trying to write
-      an existing file causes an IOError to be raised.
+      an existing file raises an OSError (IOError for Python 2).
     """
     if not hasattr(m, '__len__'):
         raise TypeError('The map must be a sequence')

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -89,7 +89,7 @@ def write_cl(filename, cl, dtype=np.float64):
     tbhdu.header['CREATOR'] = 'healpy'
     tbhdu.writeto(filename)
 
-def write_map(filename,m,nest=False,dtype=np.float32,fits_IDL=True,coord=None,partial=False,column_names=None,column_units=None,extra_header=()):
+def write_map(filename,m,nest=False,dtype=np.float32,fits_IDL=True,coord=None,partial=False,column_names=None,column_units=None,extra_header=(),overwrite=False):
     """Writes an healpix map into an healpix file.
 
     Parameters
@@ -128,6 +128,9 @@ def write_map(filename,m,nest=False,dtype=np.float32,fits_IDL=True,coord=None,pa
       internally from the numpy datatype to the fits convention. If a list,
       the length must correspond to the number of map arrays. 
       Default: np.float32.
+    overwrite : bool, optional
+      If True, existing file is silently overwritten. Otherwise trying to write
+      an existing file causes an IOError to be raised.
     """
     if not hasattr(m, '__len__'):
         raise TypeError('The map must be a sequence')
@@ -219,7 +222,7 @@ def write_map(filename,m,nest=False,dtype=np.float32,fits_IDL=True,coord=None,pa
     for args in extra_header:
         tbhdu.header[args[0]] = args[1:]
 
-    tbhdu.writeto(filename)
+    tbhdu.writeto(filename, overwrite=overwrite)
 
 
 def read_map(filename,field=0,dtype=np.float64,nest=False,partial=False,hdu=1,h=False,

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -57,7 +57,7 @@ class TestFitsFunc(unittest.TestCase):
         read_map(hdu)
 
     def test_read_map_all(self):
-        write_map(self.filename, [self.m, self.m, self.m])
+        write_map(self.filename, [self.m, self.m, self.m], overwrite=True)
         read_m = read_map(self.filename, None)
         for rm in read_m:
             np.testing.assert_array_almost_equal(self.m, rm)


### PR DESCRIPTION
Changes to fitsfunc.py in 443855896acfbbc1602a96e55126b022c677a133 caused a change in write_map() behavior. Prior, trying to write to a file that already existed caused the file to be silently overwritten.

After the change, write_map throws an IOError when the user attempts to write to an existing file. The only way to avoid the error is to check for the file existence and remove it before write_map().

It seems unnecessary to require users to check file existence every time they write a map. This pull request implements a keyword argument to write_map() called "overwrite". The current default behavior (fail when file exists) can be retained by setting overwrite=False by default. Defaulting it to True would restore the old default behavior and not require packages that depend on Healpy to be changed everywhere write_map() is called. Either way, user can choose to overwrite existing files without explicitly checking their existence.