### PR TITLE
Tuple2array

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -391,7 +391,8 @@ def read_map(filename,field=0,dtype=np.float64,nest=False,partial=False,hdu=1,h=
         else:
             return ret[0]
     else:
-        ret = np.array(ret)
+        if all(dt == dtype[0] for dt in dtype):
+            ret = np.array(ret)
         if h:
             return ret, header
         else:

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -56,7 +56,7 @@ def read_cl(filename, dtype=np.float64, h=False):
       the cl array
     """
     fits_hdu = _get_hdu(filename, hdu=1)
-    cl = [fits_hdu.data.field(n) for n in range(len(fits_hdu.columns))]
+    cl = np.array([fits_hdu.data.field(n) for n in range(len(fits_hdu.columns))])
     if len(cl) == 1:
         return cl[0]
     else:
@@ -380,20 +380,25 @@ def read_map(filename,field=0,dtype=np.float64,nest=False,partial=False,hdu=1,h=
             pass
         ret.append(m)
 
+    if h:
+        header = []
+        for (key, value) in fits_hdu.header.items():
+            header.append((key, value))
+
     if len(ret) == 1:
         if h:
-            return ret[0],fits_hdu.header.items()
+            return ret[0], header
         else:
             return ret[0]
     else:
+        ret = np.array(ret)
         if h:
-            ret.append(fits_hdu.header.items())
-            return tuple(ret)
+            return ret, header
         else:
-            return tuple(ret)
+            return ret
 
 
-def write_alm(filename,alms,out_dtype=None,lmax=-1,mmax=-1,mmax_in=-1):
+def write_alm(filename,alms,out_dtype=None,lmax=-1,mmax=-1,mmax_in=-1,overwrite=False):
     """Write alms to a fits file.
 
     In the fits file the alms are written
@@ -463,7 +468,7 @@ def write_alm(filename,alms,out_dtype=None,lmax=-1,mmax=-1,mmax_in=-1):
 
         tbhdu = pf.BinTableHDU.from_columns([cindex,creal,cimag])
         hdulist.append(tbhdu)
-    hdulist.writeto(filename)
+    hdulist.writeto(filename, overwrite=overwrite)
 
 def read_alm(filename,hdu=1,return_mmax=False):
     """Read alm from a fits file.
@@ -477,7 +482,7 @@ def read_alm(filename,hdu=1,return_mmax=False):
     ----------
     filename : str or HDUList or HDU
       The name of the fits file to read
-    hdu : int, optional
+    hdu : int, or tuple of int, optional
       The header to read. Start at 0. Default: hdu=1
     return_mmax : bool, optional
       If true, both the alms and mmax is returned in a tuple. Default: return_mmax=False
@@ -487,17 +492,34 @@ def read_alm(filename,hdu=1,return_mmax=False):
     alms[, mmax] : complex array or tuple of a complex array and an int
       The alms read from the file and optionally mmax read from the file
     """
-    idx, almr, almi = mrdfits(filename,hdu=hdu)
-    l = np.floor(np.sqrt(idx-1)).astype(np.long)
-    m = idx - l**2 - l - 1
-    if (m<0).any():
-        raise ValueError('Negative m value encountered !')
-    lmax = l.max()
-    mmax = m.max()
-    alm = almr*(0+0j)
-    i = Alm.getidx(lmax,l,m)
-    alm.real[i] = almr
-    alm.imag[i] = almi
+    alms = []
+    lmaxtot = None
+    mmaxtot = None
+    for unit in np.atleast_1d(hdu):
+        idx, almr, almi = mrdfits(filename,hdu=unit)
+        l = np.floor(np.sqrt(idx-1)).astype(np.long)
+        m = idx - l**2 - l - 1
+        if (m<0).any():
+            raise ValueError('Negative m value encountered !')
+        lmax = l.max()
+        mmax = m.max()
+        if lmaxtot is None:
+            lmaxtot = lmax
+            mmaxtot = mmax
+        else:
+            if lmaxtot != lmax or mmaxtot != mmax:
+                raise RuntimeError(
+                    'read_alm: harmonic expansion order in {} HDUs {} does not '
+                    'match'.format(filename, unit, hdu))
+        alm = almr*(0+0j)
+        i = Alm.getidx(lmax,l,m)
+        alm.real[i] = almr
+        alm.imag[i] = almi
+        alms.append(alm)
+    if len(alms) == 1:
+        alm = alms[0]
+    else:
+        alm = np.array(alms)
     if return_mmax:
         return alm, mmax
     else:

--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -233,7 +233,7 @@ def ma_to_array(m):
         return m.filled()
     except AttributeError:
         try:
-            return tuple([mm.filled() for mm in m])
+            return np.array([mm.filled() for mm in m])
         except AttributeError:
             pass
     return m
@@ -374,10 +374,7 @@ def ma(m, badval = UNSEEN, rtol = 1e-5, atol = 1e-8, copy = True):
            fill_value = -1.6375e+30)
     <BLANKLINE>
     """
-    if maptype(m) == 0:
-        return np.ma.masked_values(m, badval, rtol = rtol, atol = atol, copy = copy)
-    else:
-        return tuple([ma(mm) for mm in m])
+    return np.ma.masked_values(np.array(m), badval, rtol = rtol, atol = atol, copy = copy)
 
 def ang2pix(nside,theta,phi,nest=False,lonlat=False):
     """ang2pix : nside,theta[rad],phi[rad],nest=False,lonlat=False -> ipix (default:RING)
@@ -819,16 +816,16 @@ def reorder(map_in, inp=None, out=None, r2n=None, n2r=None):
     >>> m[2][2] = hp.UNSEEN
     >>> m = hp.ma(m)
     >>> hp.reorder(m, n2r = True)
-    (masked_array(data = [0.0 1.0 -- 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0],
-                 mask = [False False  True False False False False False False False False False],
+    masked_array(data =
+     [[0.0 1.0 -- 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0]
+     [0.0 1.0 -- 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0]
+     [0.0 1.0 -- 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0]],
+                 mask =
+     [[False False  True False False False False False False False False False]
+     [False False  True False False False False False False False False False]
+     [False False  True False False False False False False False False False]],
            fill_value = -1.6375e+30)
-    , masked_array(data = [0.0 1.0 -- 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0],
-                 mask = [False False  True False False False False False False False False False],
-           fill_value = -1.6375e+30)
-    , masked_array(data = [0.0 1.0 -- 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0],
-                 mask = [False False  True False False False False False False False False False],
-           fill_value = -1.6375e+30)
-    )
+    <BLANKLINE>
     """
     typ = maptype(map_in)
     if typ == 0:
@@ -877,7 +874,7 @@ def reorder(map_in, inp=None, out=None, r2n=None, n2r=None):
     if typ == 0:
         return mapout[0]
     else:
-        return mapout
+        return np.array(mapout)
 
 def nside2npix(nside):
     """Give the number of pixels for the given nside.
@@ -1765,7 +1762,7 @@ def ud_grade(map_in,nside_out,pess=False,order_in='RING',order_out=None,
     if typ == 0:
         return mapout[0]
     else:
-        return mapout
+        return np.array(mapout)
 
 def _ud_grade_core(m,nside_out,pess=False,power=None, dtype=None):
     """Internal routine used by ud_grade. It assumes that the map is NESTED

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -29,18 +29,18 @@ cdef extern from "alm_healpix_tools.h":
                                Alm[xcomplex[double]] &almC,
                                int num_iter,
                                arr[double] &weight)
-    cdef void map2alm_spin(    Healpix_Map[double] &map1, 
+    cdef void map2alm_spin(    Healpix_Map[double] &map1,
                                Healpix_Map[double] &map2,
-                               Alm[xcomplex[double]] &alm1, 
-                               Alm[xcomplex[double]] &alm2, 
-                               int spin, 
-                               arr[double] &weight, 
+                               Alm[xcomplex[double]] &alm1,
+                               Alm[xcomplex[double]] &alm2,
+                               int spin,
+                               arr[double] &weight,
                                cbool add_alm)
-    cdef void alm2map_spin(    Alm[xcomplex[double]] &alm1, 
-                               Alm[xcomplex[double]] &alm2, 
-                               Healpix_Map[double] &map1, 
+    cdef void alm2map_spin(    Alm[xcomplex[double]] &alm1,
+                               Alm[xcomplex[double]] &alm2,
+                               Healpix_Map[double] &map1,
                                Healpix_Map[double] &map2,
-                               int spin) 
+                               int spin)
 
 cdef extern from "alm_powspec_tools.h":
     cdef void c_rotate_alm "rotate_alm" (Alm[xcomplex[double]] &alm, double psi, double theta, double phi)
@@ -70,7 +70,7 @@ def map2alm_spin_healpy(maps, spin, lmax = None, mmax = None):
       Maximum l of the power spectrum. Default: 3*nside-1
     mmax : int, scalar, optional
       Maximum m of the alm. Default: lmax
-    
+
     Returns
     -------
     alms : list of 2 arrays
@@ -97,7 +97,7 @@ def map2alm_spin_healpy(maps, spin, lmax = None, mmax = None):
     # Check all maps have same npix
     if maps_c[1].size != npix:
         raise ValueError("Input maps must have same size")
-    
+
     # View the ndarray as a Healpix_Map
     M1 = ndarray2map(maps_c[0], RING)
     M2 = ndarray2map(maps_c[1], RING)
@@ -113,17 +113,17 @@ def map2alm_spin_healpy(maps, spin, lmax = None, mmax = None):
 
     # View the ndarray as an Alm
     # Alms = [ndarray2alm(alm, lmax_, mmax_) for alm in alms]
-    A1 = ndarray2alm(alms[0], lmax_, mmax_) 
-    A2 = ndarray2alm(alms[1], lmax_, mmax_) 
-    
+    A1 = ndarray2alm(alms[0], lmax_, mmax_)
+    A2 = ndarray2alm(alms[1], lmax_, mmax_)
+
     # ring weights
     cdef arr[double] * w_arr = new arr[double]()
     cdef int i
     cdef char *c_datapath
     w_arr.allocAndFill(2 * nside, 1.)
-    
+
     map2alm_spin(M1[0], M2[0], A1[0], A2[0], spin, w_arr[0], False)
-    
+
     # restore input map with UNSEEN pixels
     for m, mask in zip(maps_c, masks):
         if mask:
@@ -141,14 +141,14 @@ def alm2map_spin_healpy(alms, nside, spin, lmax, mmax=None):
     alms : list of 2 arrays
       list of 2 alms
     nside : int
-        requested nside of the output map 
+        requested nside of the output map
     spin : int
         spin of the alms (either 1, 2 or 3)
     lmax : int, scalar
       Maximum l of the power spectrum.
     mmax : int, scalar, optional
       Maximum m of the alm. Default: lmax
-    
+
     Returns
     -------
     m : list of 2 arrays
@@ -167,22 +167,22 @@ def alm2map_spin_healpy(alms, nside, spin, lmax, mmax=None):
         mmax = lmax
 
     # View the ndarray as an Alm
-    A1 = ndarray2alm(alms_c[0], lmax, mmax) 
-    A2 = ndarray2alm(alms_c[1], lmax, mmax) 
-    
+    A1 = ndarray2alm(alms_c[0], lmax, mmax)
+    A2 = ndarray2alm(alms_c[1], lmax, mmax)
+
     alm2map_spin(A1[0], A2[0], M1[0], M2[0], spin)
-    
+
     del M1, M2, A1, A2
     return maps
 
-def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False, 
+def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
             datapath = None):
     """Computes the alm of a Healpix map.
 
     Parameters
     ----------
     m : array-like, shape (Npix,) or (3, Npix)
-      The input map or a list of 3 input maps (polariztion).
+      The input map or a list of 3 input maps (polarization).
     lmax : int, scalar, optional
       Maximum l of the power spectrum. Default: 3*nside-1
     mmax : int, scalar, optional
@@ -191,7 +191,7 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
       Number of iteration (default: 1)
     use_weights: bool, scalar, optional
       If True, use the ring weighting. Default: False.
-    
+
     Returns
     -------
     alm : array or tuple of arrays
@@ -238,7 +238,7 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
     if polarization:
         if mq.size != npix or mu.size != npix:
             raise ValueError("Input maps must have same size")
-    
+
     # View the ndarray as a Healpix_Map
     MI = ndarray2map(mi, RING)
     if polarization:
@@ -267,7 +267,7 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
     if polarization:
         AG = ndarray2alm(almG, lmax_, mmax_)
         AC = ndarray2alm(almC, lmax_, mmax_)
-    
+
     # ring weights
     cdef arr[double] * w_arr = new arr[double]()
     cdef int i
@@ -290,12 +290,12 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
             w_arr[0][i] += 1
     else:
         w_arr.allocAndFill(2 * nside, 1.)
-    
+
     if polarization:
         map2alm_pol_iter(MI[0], MQ[0], MU[0], AI[0], AG[0], AC[0], niter, w_arr[0])
     else:
         map2alm_iter(MI[0], AI[0], niter, w_arr[0])
-    
+
     # restore input map with UNSEEN pixels
     if mask_mi is not False:
         mi[mask_mi] = UNSEEN
@@ -304,11 +304,11 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
             mq[mask_mq] = UNSEEN
         if mask_mu is not False:
             mu[mask_mu] = UNSEEN
-    
+
     del w_arr
     if polarization:
         del MI, MQ, MU, AI, AG, AC
-        return almI, almG, almC
+        return np.array([almI, almG, almC])
     else:
         del MI, AI
         return almI
@@ -339,7 +339,7 @@ def alm2cl(alms, alms2 = None, lmax = None, mmax = None, lmax_out = None):
     Returns
     -------
     cl : array or tuple of n(n+1)/2 arrays
-      the spectrum <*alm* x *alm2*> if *alm* (and *alm2*) is one alm, or 
+      the spectrum <*alm* x *alm2*> if *alm* (and *alm2*) is one alm, or
       the auto- and cross-spectra <*alm*[i] x *alm2*[j]> if alm (and alm2)
       contains more than one spectra.
       If more than one spectrum is returned, they are ordered by diagonal.
@@ -362,16 +362,16 @@ def alm2cl(alms, alms2 = None, lmax = None, mmax = None, lmax_out = None):
 
     if alms2 is None:
         alms2 = alms
-    
+
     if not hasattr(alms2, '__len__'):
         raise ValueError('alms2 must be an array or a sequence of arrays')
     if not hasattr(alms2[0], '__len__'):
         alms2 = [alms2]
     Nspec2 = len(alms2)
-    
+
     if Nspec != Nspec2:
         raise ValueError('alms and alms2 must have same number of spectra')
-    
+
     ##############################################
     # Check sizes of alm's and lmax/mmax/lmax_out
     #
@@ -416,12 +416,12 @@ def alm2cl(alms, alms2 = None, lmax = None, mmax = None, lmax_out = None):
                                         alm1_[j].imag * alm2_[j].imag)
                 powspec_[l] /= (2 * l + 1)
             spectra.append(powspec_)
-    
+
     # if only one alm was given, returns only cl and not a list with one cl
     if alms_lonely:
         spectra = spectra[0]
 
-    return spectra
+    return np.array(spectra)
 
 
 @cython.wraparound(False)
@@ -455,13 +455,13 @@ def almxfl(alm, fl, mmax = None, inplace = False):
         alm_ = np.ascontiguousarray(alm, dtype = np.complex128)
     else:
         alm_ = np.array(alm, dtype = np.complex128, copy = True)
-    
+
     fl_ = np.ascontiguousarray(fl, dtype = np.complex128)
 
     cdef int lmax_, mmax_
     cdef int l, m
     lmax_, mmax_ = alm_getlmmax(alm_, None, mmax)
-    
+
     cdef np.complex128_t f
     cdef int maxm, i
     cdef int flsize = fl_.size
@@ -596,7 +596,7 @@ cpdef mkmask(np.ndarray[double, ndim=1] m):
                 mask[i] = 1
     mask.dtype = bool
     return mask
-            
+
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cpdef int count_bad(np.ndarray[double, ndim=1] m):

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -68,6 +68,26 @@ class TestFitsFunc(unittest.TestCase):
         for rm in read_m:
             np.testing.assert_array_almost_equal(self.m, rm)
 
+    def test_read_map_multiple_dtype(self):
+        dtypes = [np.int32, np.float32, np.float64]
+        m = []
+        for dtype in dtypes:
+            m.append(self.m.astype(dtype))
+        write_map(self.filename, m, overwrite=True)
+        read_m = read_map(self.filename, None, dtype=dtypes)
+        for rm, dtype in zip(read_m, dtypes):
+            self.assertEqual(rm.dtype, dtype)
+
+    def test_read_map_single_dtype(self):
+        dtypes = [np.int32, np.float32, np.float64]
+        m = []
+        for dtype in dtypes:
+            m.append(self.m.astype(dtype))
+        write_map(self.filename, m, overwrite=True)
+        dtype = np.float32
+        read_m = read_map(self.filename, None, dtype=dtype)
+        self.assertEqual(read_m.dtype, dtype)
+
     def test_read_map_all_with_header(self):
         write_map(self.filename, [self.m, self.m, self.m], overwrite=True)
         read_m, h = read_map(self.filename, None, h=True)

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -46,6 +46,12 @@ class TestFitsFunc(unittest.TestCase):
         write_map(self.filename, self.m)
         read_map(self.filename)
 
+    def test_read_map_filename_with_header(self):
+        write_map(self.filename, self.m)
+        m, h = read_map(self.filename, h=True)
+        header = dict(h)
+        self.assertEqual(header['NSIDE'], 512)
+
     def test_read_map_hdulist(self):
         write_map(self.filename, self.m)
         hdulist = pf.open(self.filename)
@@ -59,6 +65,14 @@ class TestFitsFunc(unittest.TestCase):
     def test_read_map_all(self):
         write_map(self.filename, [self.m, self.m, self.m], overwrite=True)
         read_m = read_map(self.filename, None)
+        for rm in read_m:
+            np.testing.assert_array_almost_equal(self.m, rm)
+
+    def test_read_map_all_with_header(self):
+        write_map(self.filename, [self.m, self.m, self.m], overwrite=True)
+        read_m, h = read_map(self.filename, None, h=True)
+        header = dict(h)
+        self.assertEqual(header['NSIDE'], 512)
         for rm in read_m:
             np.testing.assert_array_almost_equal(self.m, rm)
 
@@ -92,7 +106,7 @@ class TestFitsFunc(unittest.TestCase):
         write_map(self.filename, [self.m, self.m, self.m], dtype=[np.float64,
                                                                   np.float32,
                                                                   np.int32])
-        read_m = read_map(self.filename, field=(0, 1, 2), 
+        read_m = read_map(self.filename, field=(0, 1, 2),
                           dtype=[np.float32, np.int32, np.float64])
         for rm, dtype in zip(read_m, [np.float32, np.int32, np.float64]):
             np.testing.assert_almost_equal(dtype(self.m), rm)
@@ -168,6 +182,12 @@ class TestReadWriteAlm(unittest.TestCase):
     def test_read_alm_filename(self):
         write_alm('testalm_128.fits',self.alms,lmax=128,mmax=128)
         read_alm('testalm_128.fits')
+
+    def test_read_alm_filename_array(self):
+        write_alm('testalm_256.fits',self.alms,overwrite=True)
+        testalm1 = np.array(self.alms)
+        testalm2 = read_alm('testalm_256.fits', [1,2,3])
+        np.testing.assert_array_almost_equal(testalm1, testalm2)
 
     def test_read_alm_hdulist(self):
         write_alm('testalm_128.fits',self.alms,lmax=128,mmax=128)

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -89,10 +89,8 @@ class TestSphtFunc(unittest.TestCase):
         smoothed_f90 = hp.ma(hp.read_map(os.path.join(self.path, 'data',
                   'wmap_band_iqumap_r9_7yr_W_v4_udgraded32_masked_smoothed10deg_fortran.fits'), (0,1,2)))
         # fortran does not restore the mask
-        for mm in smoothed_f90:
-            mm.mask = smoothed[0].mask
-        for i in range(3):
-            np.testing.assert_array_almost_equal(smoothed[i].filled(), smoothed_f90[i].filled(), decimal=6)
+        smoothed_f90.mask = smoothed.mask
+        np.testing.assert_array_almost_equal(smoothed.filled(), smoothed_f90.filled(), decimal=6)
 
     def test_gauss_beam(self):
         idl_gauss_beam = np.array(pf.open(os.path.join(self.path, 'data', 'gaussbeam_10arcmin_lmax512_pol.fits'))[0].data).T


### PR DESCRIPTION
This pull request addresses #113. All multi-component map and alm return values are changed into 2D numpy arrays instead of tuples. For the user, the change is mostly transparent as the 2D arrays handle like tuples in almost all cases. The tuple concatenation (referenced in #113) is an exception and demonstrates that the 2D array behavior is more intuitive. 

The change makes it unnecessary to cast the maps and alms into arrays in the client side for basic operations like addition and multiplication and should result in cleaner client code.

There is one use of read_map that may break existing codes. When the header is requested (h=True), old read_map would return a tuple of map components and the header appended last. The new code returns a 2-element tuple: (map, header) regardless of the number of map components. There was no unit test for this particular way of calling read_map but one was added.

In addition:
- read_alm is extended to accept multiple HDU:s to read from
- write_alm is extended to accept the "overwrite" keyword to match write_map.
- two instances of pixelfunc.npix2nside(len(map_in[0])) were replaced with the shorthand get_nside(map_in) in smoothing
- added unit test for the the variant of read_map that also returns the header
- modified the reorder doctest to account for the fact that a masked multidimensional map is also a single object rather than a tuple of masked components
- fixed one typo and number of trivial white space issues
