### PR TITLE
Add gal_cut keyword to anafast and map2alm

### DIFF
--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -1373,7 +1373,7 @@ def fit_dipole(m, nest=False, bad=UNSEEN, gal_cut=0):
       if ``False`` m is assumed in RING scheme, otherwise map is NESTED
     bad : float
       bad values of pixel, default to :const:`UNSEEN`.
-    gal_cut : float
+    gal_cut : float [degrees]
       pixels at latitude in [-gal_cut;+gal_cut] degrees are not taken into account
 
     Returns
@@ -1444,7 +1444,7 @@ def remove_dipole(m,nest=False,bad=UNSEEN,gal_cut=0,fitval=False,
       if ``False`` m is assumed in RING scheme, otherwise map is NESTED
     bad : float
       bad values of pixel, default to :const:`UNSEEN`.
-    gal_cut : float
+    gal_cut : float [degrees]
       pixels at latitude in [-gal_cut;+gal_cut] are not taken into account
     fitval : bool
       whether to return or not the fitted values of monopole and dipole
@@ -1508,7 +1508,7 @@ def fit_monopole(m,nest=False,bad=UNSEEN,gal_cut=0):
       if ``False`` m is assumed in RING scheme, otherwise map is NESTED
     bad : float
       bad values of pixel, default to :const:`UNSEEN`.
-    gal_cut : float
+    gal_cut : float [degrees]
       pixels at latitude in [-gal_cut;+gal_cut] degrees are not taken into account
 
     Returns
@@ -1558,7 +1558,7 @@ def remove_monopole(m,nest=False,bad=UNSEEN,gal_cut=0,fitval=False,
       if ``False`` m is assumed in RING scheme, otherwise map is NESTED
     bad : float
       bad values of pixel, default to :const:`UNSEEN`.
-    gal_cut : float
+    gal_cut : float [degrees]
       pixels at latitude in [-gal_cut;+gal_cut] are not taken into account
     fitval : bool
       whether to return or not the fitted value of monopole

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -41,7 +41,7 @@ DATAPATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 # Spherical harmonics transformation
 def anafast(map1, map2 = None, nspec = None, lmax = None, mmax = None,
             iter = 3, alm = False, pol = True, use_weights = False,
-            datapath = None):
+            datapath = None, gal_cut = 0):
     """Computes the power spectrum of an Healpix map, or the cross-spectrum
     between two maps if *map2* is given.
     No removal of monopole or dipole is performed.
@@ -73,6 +73,8 @@ def anafast(map1, map2 = None, nspec = None, lmax = None, mmax = None,
       If there is only one input map, it has no effect. Default: True.
     datapath : None or str, optional
       If given, the directory where to find the weights data.
+    gal_cut : float [degrees]
+      pixels at latitude in [-gal_cut;+gal_cut] are not taken into account
 
     Returns
     -------
@@ -87,12 +89,12 @@ def anafast(map1, map2 = None, nspec = None, lmax = None, mmax = None,
     map1 = ma_to_array(map1)
     alms1 = map2alm(map1, lmax = lmax, mmax = mmax, pol = pol, iter = iter,
                     use_weights = use_weights,
-                    datapath = datapath)
+                    datapath = datapath, gal_cut = gal_cut)
     if map2 is not None:
         map2 = ma_to_array(map2)
         alms2 = map2alm(map2, lmax = lmax, mmax = mmax, pol = pol,
                         iter = iter, use_weights = use_weights,
-                        datapath = datapath)
+                        datapath = datapath, gal_cut = gal_cut)
     else:
         alms2 = None
 
@@ -108,7 +110,7 @@ def anafast(map1, map2 = None, nspec = None, lmax = None, mmax = None,
         return cls
 
 def map2alm(maps, lmax = None, mmax = None, iter = 3, pol = True,
-            use_weights = False, datapath = None):
+            use_weights = False, datapath = None, gal_cut = 0):
     """Computes the alm of an Healpix map.
 
     Parameters
@@ -131,6 +133,8 @@ def map2alm(maps, lmax = None, mmax = None, iter = 3, pol = True,
       If True, use the ring weighting. Default: False.
     datapath : None or str, optional
       If given, the directory where to find the weights data.
+    gal_cut : float [degrees]
+      pixels at latitude in [-gal_cut;+gal_cut] are not taken into account
 
     Returns
     -------
@@ -149,12 +153,12 @@ def map2alm(maps, lmax = None, mmax = None, iter = 3, pol = True,
     if pol or info in (0, 1):
         alms = _sphtools.map2alm(maps, niter = iter,
                                  datapath = datapath, use_weights = use_weights,
-                                 lmax = lmax, mmax = mmax)
+                                 lmax = lmax, mmax = mmax, gal_cut = gal_cut)
     else:
         # info >= 2 and pol is False : spin 0 spht for each map
         alms = [_sphtools.map2alm(mm, niter = iter,
                                   datapath = datapath, use_weights = use_weights,
-                                  lmax = lmax, mmax = mmax)
+                                  lmax = lmax, mmax = mmax, gal_cut = gal_cut)
                for mm in maps]
     return np.array(alms)
 

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -7,7 +7,7 @@ from libcpp.string cimport string
 from libc.math cimport sqrt, floor, fabs
 cimport libc
 from healpy import npix2nside, nside2npix
-from healpy.pixelfunc import maptype
+from healpy.pixelfunc import maptype, pix2ang
 import os
 import cython
 from libcpp cimport bool as cbool
@@ -176,7 +176,7 @@ def alm2map_spin_healpy(alms, nside, spin, lmax, mmax=None):
     return maps
 
 def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
-            datapath = None):
+            datapath = None, gal_cut = 0):
     """Computes the alm of a Healpix map.
 
     Parameters
@@ -191,6 +191,8 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
       Number of iteration (default: 1)
     use_weights: bool, scalar, optional
       If True, use the ring weighting. Default: False.
+    gal_cut : float [degrees]
+      pixels at latitude in [-gal_cut;+gal_cut] are not taken into account
 
     Returns
     -------
@@ -201,30 +203,41 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
     info = maptype(m)
     if info == 0:
         polarization = False
-        mi = np.ascontiguousarray(m, dtype=np.float64)
+        mi = m.astype(np.float64, order='C', copy=True)
     elif info == 1:
         polarization = False
-        mi = np.ascontiguousarray(m[0], dtype=np.float64)
+        mi = m[0].astype(np.float64, order='C', copy=True)
     elif info == 3:
         polarization = True
-        mi = np.ascontiguousarray(m[0], dtype=np.float64)
-        mq = np.ascontiguousarray(m[1], dtype=np.float64)
-        mu = np.ascontiguousarray(m[2], dtype=np.float64)
+        mi = m[0].astype(np.float64, order='C', copy=True)
+        mq = m[1].astype(np.float64, order='C', copy=True)
+        mu = m[2].astype(np.float64, order='C', copy=True)
     else:
         raise ValueError("Wrong input map (must be a valid healpix map "
                          "or a sequence of 1 or 3 maps)")
 
-    # create UNSEEN mask for I map
-    mask_mi = False if count_bad(mi) == 0 else mkmask(mi)
-    # same for polarization maps if needed
+    # replace UNSEEN pixels with zeros
+    mi[mkmask(mi)] = 0
     if polarization:
-        mask_mq = False if count_bad(mq) == 0 else mkmask(mq)
-        mask_mu = False if count_bad(mu) == 0 else mkmask(mu)
+        mq[mkmask(mq)] = 0
+        mu[mkmask(mu)] = 0
 
-    # Adjust lmax and mmax
-    cdef int lmax_, mmax_, nside, npix
+    cdef int nside, npix
     npix = mi.size
     nside = npix2nside(npix)
+
+    # Optionally apply a galactic cut
+    if gal_cut is not None and gal_cut > 0:
+        mask_gal = pix2ang(nside, np.arange(npix), lonlat=True)[1]
+        mask_gal = np.abs(mask_gal) < gal_cut
+        mi[mask_gal] = 0
+        if polarization:
+            mq[mask_gal] = 0
+            mu[mask_gal] = 0
+        del mask_gal
+
+    # Adjust lmax and mmax
+    cdef int lmax_, mmax_
     if lmax is None:
         lmax_ = 3 * nside - 1
     else:
@@ -244,15 +257,6 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
     if polarization:
         MQ = ndarray2map(mq, RING)
         MU = ndarray2map(mu, RING)
-
-    # replace UNSEEN pixels with zeros
-    if mask_mi is not False:
-        mi[mask_mi] = 0.0
-    if polarization:
-        if mask_mq is not False:
-            mq[mask_mq] = 0.0
-        if mask_mu is not False:
-            mu[mask_mu] = 0.0
 
 
     # Create an ndarray object that will contain the alm for output (to be returned)
@@ -295,15 +299,6 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
         map2alm_pol_iter(MI[0], MQ[0], MU[0], AI[0], AG[0], AC[0], niter, w_arr[0])
     else:
         map2alm_iter(MI[0], AI[0], niter, w_arr[0])
-
-    # restore input map with UNSEEN pixels
-    if mask_mi is not False:
-        mi[mask_mi] = UNSEEN
-    if polarization:
-        if mask_mq is not False:
-            mq[mask_mq] = UNSEEN
-        if mask_mu is not False:
-            mu[mask_mu] = UNSEEN
 
     del w_arr
     if polarization:

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -217,10 +217,16 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
                          "or a sequence of 1 or 3 maps)")
 
     # replace UNSEEN pixels with zeros
-    mi[mkmask(mi)] = 0
+    mask = mkmask(mi)
+    if mask is not False:
+        mi[mask] = 0
     if polarization:
-        mq[mkmask(mq)] = 0
-        mu[mkmask(mu)] = 0
+        mask = mkmask(mq)
+        if mask is not False:
+            mq[mask] = 0
+        mask = mkmask(mu)
+        if mask is not False:
+            mu[mask] = 0
 
     cdef int nside, npix
     npix = mi.size


### PR DESCRIPTION
This commit adds the gal_cut keyword to `anafast` and `map2alm` in sphtfunc.py. The same keyword was already supported by a number of methods in pixelfunc.py such as `remove_dipole`. Galactic cut is also supported by the IDL interface to anafast as `theta_cut_deg`.

The pull request also fixes a side effect in `map2alm` in _sphtools.pyx. The input map was being copied if and only if it was not contiguous 64bit float and pixels close to the UNSEEN value were set to zero and then to UNSEEN. While this may be desirable, it is unexpected for the map to be altered in place and even possibly slightly altered upon return.

The pull request also implements a unit test for map2alm with the galactic cut.