### PR TITLE
Add nlocs argument to the mollview to control the number of ticks in…

### DIFF
--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -795,17 +795,23 @@ def create_colormap(cmap):
 #   A Locator that gives the bounds of the interval
 #
 class BoundaryLocator(matplotlib.ticker.Locator):
-    def __init__(self,N=2):
+    def __init__(self,N=2,norm=None):
         if N < 2:
             raise ValueError("Number of locs must be greater than 1")
         self.Nlocs=N
+        self.norm=norm
 
     def __call__(self):
         if matplotlib.__version__ < '0.98':
             vmin,vmax = self.viewInterval.get_bounds()
         else:
             vmin, vmax = self.axis.get_view_interval()
-        locs = vmin + np.arange(self.Nlocs)*(vmax-vmin)/(self.Nlocs-1.)
+        if self.norm=='log':
+            locs = np.log10(vmin) + np.arange(self.Nlocs)*(
+                np.log10(vmax)-np.log10(vmin))/(self.Nlocs-1.)
+            locs = 10**(locs)
+        else:
+            locs = vmin + np.arange(self.Nlocs)*(vmax-vmin)/(self.Nlocs-1.)
         return locs
 
     def autoscale(self):

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -67,7 +67,7 @@ def mollview(map=None,fig=None,rot=None,coord=None,unit='',
              gal_cut=0,
              format='%g',format2='%g',
              cbar=True,cmap=None, notext=False,
-             norm=None,hold=False,margins=None,sub=None,
+             norm=None,hold=False,margins=None,sub=None,nlocs=2,
              return_projected_map=False):
     """Plot a healpix map (given as an array) in Mollweide projection.
     
@@ -200,13 +200,13 @@ def mollview(map=None,fig=None,rot=None,coord=None,unit='',
             if matplotlib.__version__ >= '0.91.0':
                 cb=f.colorbar(im,ax=ax,
                               orientation='horizontal',
-                              shrink=0.5,aspect=25,ticks=PA.BoundaryLocator(),
+                              shrink=0.5,aspect=25,ticks=PA.BoundaryLocator(nlocs, norm),
                               pad=0.05,fraction=0.1,boundaries=b,values=v,
                               format=format)
             else:
                 # for older matplotlib versions, no ax kwarg
                 cb=f.colorbar(im,orientation='horizontal',
-                              shrink=0.5,aspect=25,ticks=PA.BoundaryLocator(),
+                              shrink=0.5,aspect=25,ticks=PA.BoundaryLocator(nlocs, norm),
                               pad=0.05,fraction=0.1,boundaries=b,values=v,
                               format=format)
             cb.solids.set_rasterized(True)


### PR DESCRIPTION
… the colorbar

I did the following modification to visufunc.mollview and projaxes.BaundaryLocator:
    1. Add an argument "nlocs=2" to mollview to set the number of ticks
    2. Add an argument "norm=None" to projaxes.BaundaryLocator so that it can
properly set the ticks in both linear and log scale.

If you find this useful, you may want to improve this feature by adding norm="hist" to projaxes.BaundaryLocator and also fixe other functions in visufunc.py