### PR TITLE
Compare to None using is instead of ==

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ healpy/src/_sphtools.cpp
 healpy.egg-info
 dist
 .eggs
+.idea

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -441,7 +441,7 @@ def write_alm(filename,alms,out_dtype=None,lmax=-1,mmax=-1,mmax_in=-1,overwrite=
     if mmax > mmax_in:
         mmax = mmax_in
 
-    if (out_dtype == None):
+    if out_dtype is None:
         out_dtype = alms[0].real.dtype
 
     l,m = Alm.getlm(lmax)


### PR DESCRIPTION
@lpsinger - This is just to follow up to https://github.com/healpy/healpy/pull/387#issuecomment-340307854 , I grepped `healpy` that there are no other cases where you have `==None` except for this one.