### PR TITLE
Add beam_window variable to smoothing routines in sphtfunc.py

### DIFF
--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -42,7 +42,7 @@ from .pixelfunc import (ma, mask_good, mask_bad,
 from .sphtfunc import (anafast, map2alm,
                       alm2map, Alm, synalm, synfast,
                       smoothing, smoothalm, almxfl, alm2cl,
-                      pixwin, alm2map_der1, gauss_beam)
+                      pixwin, alm2map_der1, gauss_beam, bl2beam, beam2bl)
 
 from ._query_disc import query_disc, query_strip, query_polygon, boundaries
 from ._pixelfunc import ringinfo, pix2ring

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -600,7 +600,7 @@ def smoothalm(alms, fwhm = 0.0, sigma = None, beam_window = None,
       The sigma of the Gaussian. Override fwhm.
       [in radians]
     beam_window: array, optional
-      Custom beam window function. Override fwhm and sigma
+      Custom beam window function. Override fwhm and sigma.
     pol : bool, optional
       If True, assumes input alms are TEB. Output will be TQU maps.
       (input must be 1 or 3 alms)
@@ -700,7 +700,7 @@ def smoothing(map_in, fwhm = 0.0, sigma = None, beam_window = None, pol = True,
     sigma : float, optional
       The sigma of the Gaussian [in radians]. Override fwhm.
     beam_window: array, optional
-      Custom beam window function. Override fwhm and sigma
+      Custom beam window function. Override fwhm and sigma.
     pol : bool, optional
       If True, assumes input maps are TQU. Output will be TQU maps.
       (input must be 1 or 3 alms)
@@ -904,20 +904,20 @@ def gauss_beam(fwhm, lmax=512, pol=False):
     
 def bl2beam(bl, theta):
     """Computes a circular beam profile b(theta) from its 
-    transfer (or window) function b(l)
+    transfer (or window) function b(l).
 
     Parameters
     ----------
     bl : array
-        b(l) window function of beam        
+        b(l) window function of beam.        
     theta : array
-        angle at which the beam profile will be computed
-        Has to be given in radians
+        Angle at which the beam profile will be computed.
+        Has to be given in radians.
 
     Returns
     -------
     beam : array
-        (circular) beam profile value at radius theta
+        (Circular) Beam profile value at radius theta.
     """
     lmax = len(bl)-1
     nx = len(theta)
@@ -940,23 +940,23 @@ def bl2beam(bl, theta):
 
 def beam2bl(beam, theta, lmax):
     """Computes a transfer (or window) function from its 
-    circular beam profile b(theta)
+    circular beam profile b(theta).
 
     Parameters
     ----------
     beam : array
-        Circular beam profile in theta       
+        Circular beam profile in theta.       
     theta : array
-        Radius at which the beam profile is given
+        Radius at which the beam profile is given.
         Has to be given in radians with same size
-        as beam
+        as beam.
     lmax : integer
-        Maximum multipole of bl
+        Maximum multipole of bl.
 
     Returns
     -------
     bl : array
-        beam window function B(l)
+        Beam window function B(l).
     """
     
     nx = len(theta)
@@ -974,7 +974,7 @@ def beam2bl(beam, theta, lmax):
     window[0] = simps(beam*p0*st,theta)
     window[1] = simps(beam*p1*st,theta)
 
-    for l in np.arange(2, lmax):
+    for l in np.arange(2, lmax+1):
         p2 = x * p1 * (2*l-1)/l - p0 * (l-1)/l
         window[l] = simps(beam*p2*st,theta)
         p0 = p1

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -583,8 +583,8 @@ def almxfl(alm, fl, mmax = None, inplace = False):
     almout = _sphtools.almxfl(alm, fl, mmax = mmax, inplace = inplace)
     return almout
 
-def smoothalm(alms, fwhm = 0.0, sigma = None,  pol = True,
-              mmax = None, verbose = True, inplace = True):
+def smoothalm(alms, fwhm = 0.0, sigma = None, beam_window = None,  
+              pol = True, mmax = None, verbose = True, inplace = True):
     """Smooth alm with a Gaussian symmetric beam function.
 
     Parameters
@@ -598,6 +598,8 @@ def smoothalm(alms, fwhm = 0.0, sigma = None,  pol = True,
     sigma : float, optional
       The sigma of the Gaussian. Override fwhm.
       [in radians]
+    beam_window: array, optional
+      Custom beam window function. Override fwhm and sigma
     pol : bool, optional
       If True, assumes input alms are TEB. Output will be TQU maps.
       (input must be 1 or 3 alms)
@@ -619,18 +621,21 @@ def smoothalm(alms, fwhm = 0.0, sigma = None,  pol = True,
       and *inplace* is True the smoothing is applied inplace.
       Otherwise, a copy is made.
     """
-    if sigma is None:
+    if (sigma is None) & (beam_window is None):
         sigma = fwhm / (2.*np.sqrt(2.*np.log(2.)))
 
     if verbose:
-        print("Sigma is {0:f} arcmin ({1:f} rad) ".format(sigma*60*180/pi,sigma))
-        print("-> fwhm is {0:f} arcmin".format(sigma*60*180/pi*(2.*np.sqrt(2.*np.log(2.)))))
+        if beam_window is None:
+            print("Sigma is {0:f} arcmin ({1:f} rad) ".format(sigma*60*180/pi,sigma))
+            print("-> fwhm is {0:f} arcmin".format(sigma*60*180/pi*(2.*np.sqrt(2.*np.log(2.)))))
+        else:
+            print("Using provided beam window function")
 
     # Check alms
     if not cb.is_seq(alms):
         raise ValueError("alm must be a sequence")
 
-    if sigma == 0:
+    if (sigma == 0) & (beam_window is None):
         # nothing to be done
         return alms
 
@@ -652,7 +657,10 @@ def smoothalm(alms, fwhm = 0.0, sigma = None,  pol = True,
                             'mmax (len(alms[%d]) = %d).'%(ialm, len(alm)))
         ell = np.arange(lmax + 1.)
         s = 2 if ialm >= 1 and pol else 0
-        fact = np.exp(-0.5 * (ell * (ell + 1) - s ** 2) * sigma ** 2)
+        if beam_window is None:
+            fact = np.exp(-0.5 * (ell * (ell + 1) - s ** 2) * sigma ** 2)
+        else:
+            fact = np.copy(beam_window)
         res = almxfl(alm, fact, mmax = mmax, inplace = inplace)
         retalm.append(res)
     # Test what to return (inplace/not inplace...)
@@ -673,7 +681,7 @@ def smoothalm(alms, fwhm = 0.0, sigma = None,  pol = True,
     return alms
 
 @accept_ma
-def smoothing(map_in, fwhm = 0.0, sigma = None,  pol = True,
+def smoothing(map_in, fwhm = 0.0, sigma = None, beam_window = None, pol = True,
               iter = 3, lmax = None, mmax = None, use_weights = False,
               datapath = None, verbose = True):
     """Smooth a map with a Gaussian symmetric beam.
@@ -690,6 +698,8 @@ def smoothing(map_in, fwhm = 0.0, sigma = None,  pol = True,
       radians]. Default:0.0
     sigma : float, optional
       The sigma of the Gaussian [in radians]. Override fwhm.
+    beam_window: array, optional
+      Custom beam window function. Override fwhm and sigma
     pol : bool, optional
       If True, assumes input maps are TQU. Output will be TQU maps.
       (input must be 1 or 3 alms)
@@ -733,7 +743,7 @@ def smoothing(map_in, fwhm = 0.0, sigma = None,  pol = True,
         alms = map2alm(map_in, lmax = lmax, mmax = mmax, iter = iter,
                        pol = pol, use_weights = use_weights,
                        datapath = datapath)
-        smoothalm(alms, fwhm = fwhm, sigma = sigma,
+        smoothalm(alms, fwhm = fwhm, sigma = sigma, beam_window = beam_window,
                   inplace = True, verbose = verbose)
         output_map = alm2map(alms, nside, pixwin = False, verbose=verbose)
     else:
@@ -742,7 +752,7 @@ def smoothing(map_in, fwhm = 0.0, sigma = None,  pol = True,
         for m in map_in:
             alm = map2alm(m, lmax = lmax, mmax = mmax, iter = iter, pol = pol,
                           use_weights = use_weights, datapath = datapath)
-            smoothalm(alm, fwhm = fwhm, sigma = sigma,
+            smoothalm(alm, fwhm = fwhm, sigma = sigma, beam_window = beam_window,
                       inplace = True, verbose = verbose)
             output_map.append(alm2map(alm, nside, pixwin = False, verbose=verbose))
         output_map = np.array(output_map)

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -223,7 +223,7 @@ class TestSphtFunc(unittest.TestCase):
             self.fail()
 
     def test_beam2bl(self):
-		""" Test beam2bl against analytical transform of Gaussian beam. """
+        """ Test beam2bl against analytical transform of Gaussian beam. """
 
         theta = np.linspace(0, np.radians(1.), 1000)
         sigma = np.radians(10./60.) / np.sqrt(8. * np.log(2.))
@@ -236,7 +236,7 @@ class TestSphtFunc(unittest.TestCase):
         np.testing.assert_allclose(gaussian_window, bl, rtol = 1e-5)
 
     def test_bl2beam(self):
-		""" Test bl2beam against analytical transform of Gaussian beam. """
+        """ Test bl2beam against analytical transform of Gaussian beam. """
 
         theta = np.linspace(0, np.radians(3.), 1000)
         sigma = np.radians(1.) / np.sqrt(8. * np.log(2.))

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -222,5 +222,31 @@ class TestSphtFunc(unittest.TestCase):
         except IndexError:
             self.fail()
 
+    def test_beam2bl(self):
+		""" Test beam2bl against analytical transform of Gaussian beam. """
+
+        theta = np.linspace(0, np.radians(1.), 1000)
+        sigma = np.radians(10./60.) / np.sqrt(8. * np.log(2.))
+        gaussian_beam = np.exp(-.5 * (theta/sigma)**2) / (2*np.pi*sigma**2)    
+
+        ell = np.arange(512 + 1.)
+        gaussian_window = np.exp(-.5 * ell * (ell + 1) * sigma**2)
+
+        bl = hp.beam2bl(gaussian_beam, theta, 512)
+        np.testing.assert_allclose(gaussian_window, bl, rtol = 1e-5)
+
+    def test_bl2beam(self):
+		""" Test bl2beam against analytical transform of Gaussian beam. """
+
+        theta = np.linspace(0, np.radians(3.), 1000)
+        sigma = np.radians(1.) / np.sqrt(8. * np.log(2.))
+        gaussian_beam = np.exp(-.5 * (theta/sigma)**2) / (2*np.pi*sigma**2)    
+
+        ell = np.arange(2048 + 1.)
+        gaussian_window = np.exp(-.5 * ell * (ell + 1) * sigma**2)
+
+        beam = hp.bl2beam(gaussian_window, theta)
+        np.testing.assert_allclose(gaussian_beam, beam, rtol = 1e-3)            
+            
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Small modification to allow to pass custom beam window functions like e.g. matched filters to the smoothing routines in sphtfunc.py. Adds new optional variable beam_window to sphtfunc.smoothing and sphtfunc.smoothalm.

Second commit adds translations of the healpix functions beam2bl and bl2beam. These functions allow transformations of beams to window functions and vise versa.