### PR TITLE
Add scipy to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ install:
   # Then make source distribution
   # Uninstall things that are only needed when building from git
   # Finally, install from the source distribution using pip
+  pip install scipy
   - |
     if $USE_PIP; then
       python setup.py build && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,12 +67,12 @@ before_install:
       bash miniconda.sh -b -p ~/miniconda && \
       ~/miniconda/bin/conda create --yes -n anaconda_env \
         python=$TRAVIS_PYTHON_VERSION \
-        setuptools pip numpy matplotlib astropy cython pytest && \
+        setuptools pip numpy matplotlib astropy cython pytest scipy && \
       source ~/miniconda/bin/activate anaconda_env
     else
      sudo apt-get -y install pkg-config && \
      travis_retry pip install --upgrade setuptools && \
-     travis_retry pip install numpy matplotlib astropy cython pytest
+     travis_retry pip install numpy matplotlib astropy cython pytest scipy
     fi
 
   # Install cfitsio if necessary
@@ -83,7 +83,6 @@ install:
   # Then make source distribution
   # Uninstall things that are only needed when building from git
   # Finally, install from the source distribution using pip
-  pip install scipy
   - |
     if $USE_PIP; then
       python setup.py build && \


### PR DESCRIPTION
Install scipy for travis CI, address #437 and fixes most of the builds.
For Python 3.4, there are still incompatibility issues due to the version of `setuptools`.