### PR TITLE
Make docstrings reproducible with bleeding-edge versions of Numpy

### DIFF
--- a/healpy/test/conftest.py
+++ b/healpy/test/conftest.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pytest
+
+
+def pytest_configure():
+    """Set the Numpy print style to a fixed version to make doctest outputs
+    reproducible."""
+    try:
+        np.set_printoptions(legacy='1.13')
+    except TypeError:
+        # On older versions of Numpy, the unrecognized 'legacy' option will
+        # raise a TypeError.
+        pass


### PR DESCRIPTION
Numpy's string representation of arrays changed significantly from 1.13 to 1.14. See the [changelog]. We have to set the legacy representation mode for our doctests to be reproducible across both old and new versions of Numpy.

There is a lingering issue with the doctest for `hp.reorder` that is due to a regression in Numpy. See numpy/numpy#11112.

[changelog]: https://docs.scipy.org/doc/numpy-1.14.0/release.html#many-changes-to-array-printing-disableable-with-the-new-legacy-printing-mode