### PR TITLE
map2alm pixel weights

### DIFF
--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -24,6 +24,8 @@ pi = np.pi
 import warnings
 import astropy.io.fits as pf
 from scipy.integrate import simps
+from astropy.utils import data
+data.conf.dataurl = "https://healpy.github.io/healpy-data/"
 
 from . import _healpy_sph_transform_lib as sphtlib
 from . import _sphtools as _sphtools
@@ -112,7 +114,8 @@ def anafast(map1, map2 = None, nspec = None, lmax = None, mmax = None,
         return cls
 
 def map2alm(maps, lmax = None, mmax = None, iter = 3, pol = True,
-            use_weights = False, datapath = None, gal_cut = 0):
+            use_weights = False, datapath = None, gal_cut = 0,
+            use_pixel_weights = False):
     """Computes the alm of a Healpix map. The input maps must all be
     in ring ordering.
 
@@ -138,6 +141,8 @@ def map2alm(maps, lmax = None, mmax = None, iter = 3, pol = True,
       If given, the directory where to find the weights data.
     gal_cut : float [degrees]
       pixels at latitude in [-gal_cut;+gal_cut] are not taken into account
+    use_pixel_weights: bool, optional
+      If True, use pixel by pixel weighting, healpy will automatically download the weights, if needed
 
     Returns
     -------
@@ -153,15 +158,26 @@ def map2alm(maps, lmax = None, mmax = None, iter = 3, pol = True,
     """
     maps = ma_to_array(maps)
     info = maptype(maps)
+    if use_pixel_weights:
+        if use_weights:
+            raise RuntimeError("Either use pixel or ring weights")
+        nside = pixelfunc.get_nside(maps)
+        pixel_weights_filename = data.get_pkg_data_filename(
+                "full_weights/healpix_full_weights_nside_%04d.fits" % nside,
+                package="healpy")
+    else:
+        pixel_weights_filename = None
+
+
     if pol or info in (0, 1):
         alms = _sphtools.map2alm(maps, niter = iter,
                                  datapath = datapath, use_weights = use_weights,
-                                 lmax = lmax, mmax = mmax, gal_cut = gal_cut)
+                                 lmax = lmax, mmax = mmax, gal_cut = gal_cut, pixel_weights_filename=pixel_weights_filename)
     else:
         # info >= 2 and pol is False : spin 0 spht for each map
         alms = [_sphtools.map2alm(mm, niter = iter,
                                   datapath = datapath, use_weights = use_weights,
-                                  lmax = lmax, mmax = mmax, gal_cut = gal_cut)
+                                  lmax = lmax, mmax = mmax, gal_cut = gal_cut, pixel_weights_filename=pixel_weights_filename)
                for mm in maps]
     return np.array(alms)
 

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -44,7 +44,7 @@ DATAPATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 # Spherical harmonics transformation
 def anafast(map1, map2 = None, nspec = None, lmax = None, mmax = None,
             iter = 3, alm = False, pol = True, use_weights = False,
-            datapath = None, gal_cut = 0):
+            datapath = None, gal_cut = 0, use_pixel_weights = False):
     """Computes the power spectrum of a Healpix map, or the cross-spectrum
     between two maps if *map2* is given.
     No removal of monopole or dipole is performed. The input maps must be
@@ -79,6 +79,8 @@ def anafast(map1, map2 = None, nspec = None, lmax = None, mmax = None,
       If given, the directory where to find the weights data.
     gal_cut : float [degrees]
       pixels at latitude in [-gal_cut;+gal_cut] are not taken into account
+    use_pixel_weights: bool, optional
+      If True, use pixel by pixel weighting, healpy will automatically download the weights, if needed
 
     Returns
     -------
@@ -93,12 +95,12 @@ def anafast(map1, map2 = None, nspec = None, lmax = None, mmax = None,
     map1 = ma_to_array(map1)
     alms1 = map2alm(map1, lmax = lmax, mmax = mmax, pol = pol, iter = iter,
                     use_weights = use_weights,
-                    datapath = datapath, gal_cut = gal_cut)
+                    datapath = datapath, gal_cut = gal_cut, use_pixel_weights=use_pixel_weights)
     if map2 is not None:
         map2 = ma_to_array(map2)
         alms2 = map2alm(map2, lmax = lmax, mmax = mmax, pol = pol,
                         iter = iter, use_weights = use_weights,
-                        datapath = datapath, gal_cut = gal_cut)
+                        datapath = datapath, gal_cut = gal_cut, use_pixel_weights=use_pixel_weights)
     else:
         alms2 = None
 

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -4,6 +4,7 @@
 import numpy as np
 cimport numpy as np
 from libcpp.string cimport string
+from libcpp.vector cimport vector
 from libc.math cimport sqrt, floor, fabs
 cimport libc
 from healpy import npix2nside, nside2npix
@@ -48,6 +49,11 @@ cdef extern from "alm_powspec_tools.h":
 
 cdef extern from "healpix_data_io.h":
     cdef void read_weight_ring (string &dir, int nside, arr[double] &weight)
+    cdef vector[double] read_fullweights_from_fits(string &weightfile, int nside)
+
+cdef extern from "weight_utils.h":
+    cdef void apply_fullweights (Healpix_Map[double] &map,
+            vector[double] &wgt)
 
 DATAPATH = None
 
@@ -176,7 +182,7 @@ def alm2map_spin_healpy(alms, nside, spin, lmax, mmax=None):
     return maps
 
 def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
-            datapath = None, gal_cut = 0):
+            datapath = None, gal_cut = 0, pixel_weights_filename=None):
     """Computes the alm of a Healpix map.
 
     Parameters
@@ -193,6 +199,8 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
       If True, use the ring weighting. Default: False.
     gal_cut : float [degrees]
       pixels at latitude in [-gal_cut;+gal_cut] are not taken into account
+    pixel_weights_filename : str
+      filename of the pixel by pixel weights
 
     Returns
     -------
@@ -300,6 +308,16 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
             w_arr[0][i] += 1
     else:
         w_arr.allocAndFill(2 * nside, 1.)
+
+    cdef vector[double] full_weights
+    if pixel_weights_filename is not None:
+
+        full_weights = read_fullweights_from_fits(pixel_weights_filename.encode("UTF-8"), nside)
+
+        apply_fullweights(MI[0], full_weights)
+        if polarization:
+            apply_fullweights(MQ[0], full_weights)
+            apply_fullweights(MU[0], full_weights)
 
     if polarization:
         map2alm_pol_iter(MI[0], MQ[0], MU[0], AI[0], AG[0], AC[0], niter, w_arr[0])

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -313,7 +313,8 @@ def map2alm(m, lmax = None, mmax = None, niter = 3, use_weights = False,
     if pixel_weights_filename is not None:
 
         full_weights = read_fullweights_from_fits(pixel_weights_filename.encode("UTF-8"), nside)
-
+        # pixel weighting requires 0 iterations
+        niter = 0
         apply_fullweights(MI[0], full_weights)
         if polarization:
             apply_fullweights(MQ[0], full_weights)

--- a/healpy/test/test_pixelweights.py
+++ b/healpy/test/test_pixelweights.py
@@ -22,7 +22,7 @@ class TestMap2Alm(unittest.TestCase):
 
     def test_astropy_download_file(self):
         data.conf.dataurl = "https://healpy.github.io/healpy-data/"
-        print(data.get_pkg_data_filename("full_weights/healpix_full_weights_nside_0032.fits"))
+        print(data.get_pkg_data_filename("full_weights/healpix_full_weights_nside_0032.fits", package="healpy"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/healpy/test/test_pixelweights.py
+++ b/healpy/test/test_pixelweights.py
@@ -3,6 +3,7 @@ import numpy as np
 import unittest
 
 import healpy as hp
+from astropy.utils import data
 
 import warnings
 # disable new order warnings in tests
@@ -19,9 +20,9 @@ class TestMap2Alm(unittest.TestCase):
         self.m = hp.alm2map(self.input_alm, nside=self.nside, lmax=self.lmax)
 
 
-    def test_pixelweights(self):
-        alm = hp.map2alm(self.m, lmax=self.lmax, use_pixel_weights=True)
-        np.testing.assert_allclose(self.input_alm, alm, rtol=1e-7)
+    def test_astropy_download_file(self):
+        data.conf.dataurl = "https://healpy.github.io/healpy-data/"
+        print(data.get_pkg_data_filename("full_weights/healpix_full_weights_nside_0032.fits"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/healpy/test/test_pixelweights.py
+++ b/healpy/test/test_pixelweights.py
@@ -11,9 +11,9 @@ warnings.filterwarnings('ignore')
 class TestMap2Alm(unittest.TestCase):
 
     def setUp(self):
-        self.lmax = 96
         self.nside = 32
-        self.input_alm = np.ones(4753, dtype=np.complex)
+        self.lmax = 32
+        self.input_alm = np.ones(561, dtype=np.complex)
         self.m = hp.alm2map(self.input_alm, nside=self.nside, lmax=self.lmax)
 
 

--- a/healpy/test/test_pixelweights.py
+++ b/healpy/test/test_pixelweights.py
@@ -15,10 +15,10 @@ class TestMap2Alm(unittest.TestCase):
         self.lmax = 96
         alm_size = 4753
         np.random.seed(123)
-        self.input_alm = np.random.normal(size=alm_size) + 1j * np.random.normal(size=alm_size)
+        self.input_alm = np.ones(alm_size, dtype=np.complex)
         self.m = hp.alm2map(self.input_alm, nside=self.nside, lmax=self.lmax)
 
 
     def test_pixelweights(self):
         alm = hp.map2alm(self.m, lmax=self.lmax, use_pixel_weights=True)
-        np.testing.assert_allclose(self.input_alm, alm, rtol=1e-4)
+        np.testing.assert_allclose(self.input_alm, alm, rtol=1e-7)

--- a/healpy/test/test_pixelweights.py
+++ b/healpy/test/test_pixelweights.py
@@ -14,9 +14,9 @@ class TestMap2Alm(unittest.TestCase):
         self.lmax = 96
         self.nside = 32
         self.input_alm = np.ones(4753, dtype=np.complex)
-        self.m = hp.alm2map(self.input_alm, nside=self.nside)
+        self.m = hp.alm2map(self.input_alm, nside=self.nside, lmax=self.lmax)
 
 
     def test_pixelweights(self):
-        alm = hp.map2alm(self.m, lmax=self.lmax)
-        np.testing.assert_allclose(self.input_alm, alm)
+        alm = hp.map2alm(self.m, lmax=self.lmax, use_pixel_weights=True)
+        np.testing.assert_allclose(self.input_alm, alm, rtol=1e-4)

--- a/healpy/test/test_pixelweights.py
+++ b/healpy/test/test_pixelweights.py
@@ -22,3 +22,6 @@ class TestMap2Alm(unittest.TestCase):
     def test_pixelweights(self):
         alm = hp.map2alm(self.m, lmax=self.lmax, use_pixel_weights=True)
         np.testing.assert_allclose(self.input_alm, alm, rtol=1e-7)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/healpy/test/test_pixelweights.py
+++ b/healpy/test/test_pixelweights.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+import unittest
+
+import healpy as hp
+
+import warnings
+# disable new order warnings in tests
+warnings.filterwarnings('ignore')
+
+class TestMap2Alm(unittest.TestCase):
+
+    def setUp(self):
+        self.lmax = 96
+        self.nside = 32
+        self.input_alm = np.ones(4753, dtype=np.complex)
+        self.m = hp.alm2map(self.input_alm, nside=self.nside)
+
+
+    def test_pixelweights(self):
+        alm = hp.map2alm(self.m, lmax=self.lmax)
+        np.testing.assert_allclose(self.input_alm, alm)

--- a/healpy/test/test_pixelweights.py
+++ b/healpy/test/test_pixelweights.py
@@ -11,9 +11,11 @@ warnings.filterwarnings('ignore')
 class TestMap2Alm(unittest.TestCase):
 
     def setUp(self):
-        self.nside = 32
-        self.lmax = 32
-        self.input_alm = np.ones(561, dtype=np.complex)
+        self.nside = 64
+        self.lmax = 96
+        alm_size = 4753
+        np.random.seed(123)
+        self.input_alm = np.random.normal(size=alm_size) + 1j * np.random.normal(size=alm_size)
         self.m = hp.alm2map(self.input_alm, nside=self.nside, lmax=self.lmax)
 
 


### PR DESCRIPTION
Implementation of #356.

* Automatically download pixel weights file the first time `map2alm` is used with a specific nside using `astropy.data`
* Apply them before the call to the `map2alm` transform