### PR TITLE
Fix precision of doctest for non-amd64 archs

### DIFF
--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -1357,10 +1357,10 @@ def max_pixrad(nside):
 
     Examples
     --------
-    >>> '%.15f' % max_pixrad(1)
-    '0.841068670567930'
-    >>> '%.15f' % max_pixrad(16)
-    '0.066014761432513'
+    >>> '%.14f' % max_pixrad(1)
+    '0.84106867056793'
+    >>> '%.14f' % max_pixrad(16)
+    '0.06601476143251'
     """
     check_nside(nside, nest=False)
     return pixlib._max_pixrad(nside)


### PR DESCRIPTION
See:

- https://buildd.debian.org/status/fetch.php?pkg=healpy&arch=arm64&ver=1.10.3-4&stamp=1527055920&raw=0
- https://buildd.debian.org/status/fetch.php?pkg=healpy&arch=ppc64el&ver=1.10.3-4&stamp=1527057719&raw=0