### PR TITLE
Optional degrees argument for max_pixrad

### DIFF
--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -1342,18 +1342,20 @@ def get_all_neighbours(nside, theta, phi=None, nest=False, lonlat=False):
     res=np.array(r[0:8])
     return res
 
-def max_pixrad(nside):
+def max_pixrad(nside, degrees=False):
     """Maximum angular distance between any pixel center and its corners
 
     Parameters
     ----------
     nside : int
       the nside to work with
+    degrees : bool
+      if True, returns pixel radius in degrees, in radians otherwise
 
     Returns
     -------
     rads: double
-       angular distance (in radians)
+       angular distance (in radians or degrees)
 
     Examples
     --------
@@ -1363,6 +1365,10 @@ def max_pixrad(nside):
     '0.06601476143251'
     """
     check_nside(nside, nest=False)
+
+    if degrees:
+        return np.rad2deg(pixlib._max_pixrad(nside))
+
     return pixlib._max_pixrad(nside)
 
 def fit_dipole(m, nest=False, bad=UNSEEN, gal_cut=0):

--- a/healpy/test/test_pixelfunc.py
+++ b/healpy/test/test_pixelfunc.py
@@ -21,6 +21,10 @@ class TestPixelFunc(unittest.TestCase):
         self.assertAlmostEqual(nside2resol(512,arcmin=True), 6.87097282363) 
         self.assertAlmostEqual(nside2resol(1024,arcmin=True), 3.43548641181) 
 
+    def test_max_pixrad(self):
+        self.assertAlmostEqual(max_pixrad(512),2.0870552355e-03)
+        self.assertAlmostEqual(max_pixrad(512,degrees=True),np.rad2deg(2.0870552355e-03))
+
     def test_nside2pixarea(self):
         self.assertAlmostEqual(nside2pixarea(512), 3.9947416351188569e-06)
 


### PR DESCRIPTION
Added optional 'degrees' argument to pixelfunc.max_pixrad (with associated test) to address #452.