### PR TITLE
Improve the quality of the rotation in E/B spectra

### DIFF
--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -406,11 +406,18 @@ class Rotator(object):
             theta_pix_center, phi_pix_center
         )
 
-        # Interpolate the original map to the pixels centers in the new ref frame
+        # Apply rotation
         m_rotated = [
             pixelfunc.get_interp_val(each, theta_pix_center_rot, phi_pix_center_rot)
             for each in m
         ]
+
+        # Perform an interpolation over all the pixels of the maps
+        m_rotated = [each[pixelfunc.ang2pix(nside, theta_pix_center_rot, phi_pix_center_rot)]
+                     for each in m]
+        pixidx, w = pixelfunc.get_interp_weights(nside, theta_pix_center_rot, phi_pix_center_rot)
+        for idx in range(len(m_rotated)):
+            m_rotated[idx] = np.sum(m_rotated[idx] * w, axis=0)
 
         # Rotate polarization
         if len(m_rotated) > 1:


### PR DESCRIPTION
This improves the quality of the polarization maps after rotation. Here are the spectra:
![tt](https://user-images.githubusercontent.com/377795/42390868-b101085a-814d-11e8-84a6-e29a9e138e7a.png)
![ee](https://user-images.githubusercontent.com/377795/42390867-b0bb1228-814d-11e8-8cfc-ce7115397b83.png)
![bb](https://user-images.githubusercontent.com/377795/42390866-b07b89b4-814d-11e8-8e74-48466a726d4f.png)
