### PR TITLE
Remove python 3.4 from supported versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Characteristics
 Requirements
 ------------
 
-* `Python <http://www.python.org>`_ 2.7, 3.4, 3.5, or 3.6
+* `Python <http://www.python.org>`_ 2.7, 3.5, or 3.6
 
 * `Numpy <http://numpy.scipy.org/>`_ (tested with version >=1.5.0)
 


### PR DESCRIPTION
We removed python 3.4 from the CI matrices a while ago, it was causing some trouble. That should be reflected in the docs.