### PR TITLE
Actually use lmax_out keyword for alm2cl

### DIFF
--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -435,7 +435,7 @@ def alm2cl(alms, alms2 = None, lmax = None, mmax = None, lmax_out = None):
                     powspec_[l] += 2 * (alm1_[j].real * alm2_[j].real +
                                         alm1_[j].imag * alm2_[j].imag)
                 powspec_[l] /= (2 * l + 1)
-            spectra.append(powspec_)
+            spectra.append(powspec_[:lmax_out+1])
 
     # if only one alm was given, returns only cl and not a list with one cl
     if alms_lonely:

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -182,6 +182,21 @@ class TestSphtFunc(unittest.TestCase):
         gauss_beam = hp.gauss_beam(np.radians(10. / 60.), lmax=512, pol=True)
         np.testing.assert_allclose(idl_gauss_beam, gauss_beam)
 
+    def test_alm2cl(self):
+        nside = 32
+        lmax = 64
+        lmax_out = 100
+        seed = 12345
+        np.random.seed(seed)
+
+        # Input power spectrum and alm
+        alm_syn = hp.synalm(self.cla, lmax=lmax)
+
+        cl_out = hp.alm2cl(alm_syn, lmax_out=lmax_out-1)
+
+        np.testing.assert_array_almost_equal(
+            cl_out, self.cla[:lmax_out], decimal=4)
+
     def test_map2alm(self):
         nside = 32
         lmax = 64


### PR DESCRIPTION
This address https://github.com/healpy/healpy/issues/474 by actually using the `lmax_out` keyword. 

Right now, I've only truncated the full Cl that we get from `hp.alm2Cl()`. Ideally, we might want to adjust the loop to only go to `lmax_out` instead of `lmax`, but I was somewhat confused by the mixed use of `lmax` and `lmax_`.
Happy to have that reviewed and corrected!