### PR TITLE
Update minimum healpix-cxx version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -463,7 +463,7 @@ setup(
         (
             "healpix_cxx",
             {
-                "pkg_config_name": "healpix_cxx >= 3.30.0",
+                "pkg_config_name": "healpix_cxx >= 3.40.0",
                 "local_source": "healpixsubmodule/src/cxx/autotools",
             },
         ),


### PR DESCRIPTION
Update the minimum version of healpix-cxx in the pkg-config check. The healpix-cxx API changed in version 3.40.0, and we now require that version to build healpy. If the user has an older version of healpix-cxx installed, then we should use our own bundled sources instead.

This may address #455, #465.