### PR TITLE
Add max_nside test to sphtfunc.py functions

### DIFF
--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -76,6 +76,7 @@ from .sphtfunc import (
     gauss_beam,
     bl2beam,
     beam2bl,
+    check_max_nside,
 )
 
 from ._query_disc import query_disc, query_strip, query_polygon, boundaries

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -381,6 +381,18 @@ class TestSphtFunc(unittest.TestCase):
         beam = hp.bl2beam(gaussian_window, theta)
         np.testing.assert_allclose(gaussian_beam, beam, rtol=1e-3)
 
+    def test_max_nside_check(self):
+        """ Test whether the max_nside_check correctly raises ValueErrors for nsides
+        that are too large."""
+
+        # Test an nside that is too large
+        with self.assertRaises(ValueError):
+            hp.check_max_nside(16384)
+        
+        # Test an nside that is valid
+        # hp.check_max_nside will return 0 if no exceptions are raised
+        self.assertEqual(hp.check_max_nside(1024), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Most of the functions in sphtfunc.py are only implemented for nside <= 8192. This PR ensures a graceful exit in case the nside is too large.

Address https://github.com/healpy/healpy/issues/484