### PR TITLE
Rotate map in spherical harmonics space

### DIFF
--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -373,6 +373,7 @@ class Rotator(object):
         cosalpha = north_pole[2] - vp[2] * np.dot(north_pole, vp)
         return np.arctan2(sinalpha, cosalpha)
 
+    #def rotate_alm(self, alm)
     def rotate_map(self, m):
         """Rotate a HEALPix map to a new reference frame
 

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -30,6 +30,7 @@ coordname = {"G": "Galactic", "E": "Ecliptic", "C": "Equatorial"}
 class ConsistencyWarning(Warning):
     """Warns for a problem in the consistency of data
     """
+
     pass
 
 
@@ -87,6 +88,7 @@ class Rotator(object):
     >>> print(vec_ecl)
     [-0.05488249 -0.99382103 -0.09647625]
     """
+
     ErrMessWrongPar = (
         "rot and coord must be single elements or " "sequence of same size."
     )
@@ -381,7 +383,7 @@ class Rotator(object):
         see hp.rotate_alm, this function **returns** the rotated alms,
         does not rotate in place"""
 
-        rotated_alm = alm.copy() # rotate_alm works inplace
+        rotated_alm = alm.copy()  # rotate_alm works inplace
         rotate_alm(rotated_alm, matrix=self.mat, lmax=lmax, mmax=mmax)
         return rotated_alm
 
@@ -400,10 +402,13 @@ class Rotator(object):
         m_rotated : np.ndarray
             Map in the new reference frame
         """
-        alm = sphtfunc.map2alm(m, use_pixel_weights=use_pixel_weights, lmax=lmax, mmax=mmax)
+        alm = sphtfunc.map2alm(
+            m, use_pixel_weights=use_pixel_weights, lmax=lmax, mmax=mmax
+        )
         rotated_alm = self.rotate_alm(alm, lmax=lmax, mmax=mmax)
-        return sphtfunc.alm2map(rotated_alm, lmax=lmax, mmax=mmax, nside=pixelfunc.get_nside(m))
-
+        return sphtfunc.alm2map(
+            rotated_alm, lmax=lmax, mmax=mmax, nside=pixelfunc.get_nside(m)
+        )
 
     def rotate_map_pixel(self, m):
         """Rotate a HEALPix map to a new reference frame in pixel space

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -378,9 +378,10 @@ class Rotator(object):
         return np.arctan2(sinalpha, cosalpha)
 
     def rotate_alm(self, alm, lmax=None, mmax=None):
-        """Rotate Alm to a new reference frame
+        """Rotate Alms with the transform defined in the Rotator object
 
-        see hp.rotate_alm, this function **returns** the rotated alms,
+        see the docstring of the rotate_alm function defined
+        in the healpy package, this function **returns** the rotated alms,
         does not rotate in place"""
 
         rotated_alm = alm.copy()  # rotate_alm works inplace

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -391,6 +391,12 @@ class Rotator(object):
     def rotate_map_alms(self, m, use_pixel_weights=True, lmax=None, mmax=None):
         """Rotate a HEALPix map to a new reference frame in spherical harmonics space
 
+        This is generally the best strategy to rotate/change reference frame of maps.
+        If the input map is band-limited, i.e. it can be represented exactly by
+        a spherical harmonics transform under a specific lmax, the map rotation
+        will be invertible.
+
+
         Parameters
         ----------
         m : np.ndarray

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -413,8 +413,10 @@ class Rotator(object):
     def rotate_map_pixel(self, m):
         """Rotate a HEALPix map to a new reference frame in pixel space
 
-        It is always better to rotate in spherical harmonics space, see
-        the rotate_map_alms method.
+        It is generally better to rotate in spherical harmonics space, see
+        the rotate_map_alms method. A case where pixel space rotation is
+        better is for heavily masked maps where the spherical harmonics
+        transform is not well defined.
         This function first rotates the pixels centers of the new reference
         frame to the original reference frame, then uses hp.get_interp_val
         to interpolate bilinearly the pixel values, finally fixes Q and U

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -429,6 +429,8 @@ class Rotator(object):
         to interpolate bilinearly the pixel values, finally fixes Q and U
         polarization by the modification to the psi angle caused by
         the Rotator using Rotator.angle_ref.
+        Due to interpolation, this function generally suppresses the signal at
+        high angular scales.
 
         Parameters
         ----------

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -395,7 +395,7 @@ class Rotator(object):
         ----------
         m : np.ndarray
             Input map, 1 map is considered I, 2 maps:[Q,U], 3 maps:[I,Q,U]
-        use_pixel_weights : bool, default True
+        use_pixel_weights : bool, optional
             Use pixel weights in map2alm
 
         Returns

--- a/healpy/src/_common.pxd
+++ b/healpy/src/_common.pxd
@@ -121,6 +121,11 @@ cdef extern from "alm.h":
         void Set (arr[T] &data, int lmax_, int mmax_)
         tsize Num_Alms (int l, int m)
 
+cdef extern from "rotmatrix.h":
+    cdef cppclass rotmatrix:
+        rotmatrix()
+        rotmatrix (double a00, double a01, double a02,double a10, double a11, double a12,double a20, double a21, double a22)
+
 cdef inline Healpix_Map[double]* ndarray2map(np.ndarray[np.float64_t, ndim=1, mode='c'] array, Healpix_Ordering_Scheme scheme) except *:
     """ View a contiguous ndarray as a Healpix Map. """
     # To ensure that the output map is a view of the input array, the latter

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -46,6 +46,8 @@ cdef extern from "alm_healpix_tools.h":
 cdef extern from "alm_powspec_tools.h":
     cdef void c_rotate_alm "rotate_alm" (Alm[xcomplex[double]] &alm, double psi, double theta, double phi)
     cdef void c_rotate_alm "rotate_alm" (Alm[xcomplex[double]] &ai, Alm[xcomplex[double]] &ag, Alm[xcomplex[double]] &ac, double psi, double theta, double phi)
+    cdef void c_rotate_alm "rotate_alm" (Alm[xcomplex[double]] &alm, rotmatrix &mat)
+    cdef void c_rotate_alm "rotate_alm" (Alm[xcomplex[double]] &ai, Alm[xcomplex[double]] &ag, Alm[xcomplex[double]] &ac, rotmatrix &mat)
 
 cdef extern from "healpix_data_io.h":
     cdef void read_weight_ring (string &dir, int nside, arr[double] &weight)
@@ -518,6 +520,8 @@ def rotate_alm(alm not None, double psi, double theta, double phi, lmax=None,
         Second rotation: angle θ about the original (unrotated) y-axis
     phi : float.
         Third rotation: angle φ about the original (unrotated) z-axis.
+    rot : np.ndarray
+        Rotation matrix, for example created by 
     lmax : int
         Maximum multipole order l of the data set.
     mmax : int

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -497,7 +497,7 @@ def almxfl(alm, fl, mmax = None, inplace = False):
     return alm_
 
 
-def rotate_alm(alm not None, double psi=None, double theta=None, double phi=None, matrix=None, lmax=None,
+def rotate_alm(alm not None, double psi=0, double theta=0, double phi=0, matrix=None, lmax=None,
                mmax=None):
     """
     This routine transforms the scalar (and tensor) a_lm coefficients
@@ -531,13 +531,13 @@ def rotate_alm(alm not None, double psi=None, double theta=None, double phi=None
     if isinstance(alm, np.ndarray) and alm.ndim == 1:
         alm = [alm]
 
-    assert (matrix is not None) or (psi is not None), "Either matrix or angles should be given, not both"
+    cdef rotmatrix rotation_matrix
+    if matrix is not None:
+        assert matrix.shape == (3,3), "Rotation matrix should be a 3x3 array"
 
-    assert matrix.shape == (3,3), "Rotation matrix should be a 3x3 array"
-
-    rotmatrix rotation_matrix = rotmatrix(matrix[0,0], matrix[0,1], matrix[0,2],
-                                matrix[1,0], matrix[1,1], matrix[1,2],
-                                matrix[2,0], matrix[2,1], matrix[2,2])
+        rotation_matrix = rotmatrix(matrix[0,0], matrix[0,1], matrix[0,2],
+                                    matrix[1,0], matrix[1,1], matrix[1,2],
+                                    matrix[2,0], matrix[2,1], matrix[2,2])
 
     if not isinstance(alm, (list, tuple, np.ndarray)) or len(alm) == 0:
         raise ValueError('Invalid input.')
@@ -550,7 +550,7 @@ def rotate_alm(alm not None, double psi=None, double theta=None, double phi=None
             if matrix is None:
                 rotate_alm(a, psi, theta, phi)
             else:
-                rotate_alm(a, rotation_matrix)
+                rotate_alm(a, matrix)
         return
 
     lmax, mmax = alm_getlmmax(alm[0], lmax, mmax)

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -535,7 +535,7 @@ def rotate_alm(alm not None, double psi=None, double theta=None, double phi=None
 
     assert matrix.shape == (3,3), "Rotation matrix should be a 3x3 array"
 
-    rotation_matrix = rotmatrix(matrix[0,0], matrix[0,1], matrix[0,2],
+    rotmatrix rotation_matrix = rotmatrix(matrix[0,0], matrix[0,1], matrix[0,2],
                                 matrix[1,0], matrix[1,1], matrix[1,2],
                                 matrix[2,0], matrix[2,1], matrix[2,2])
 

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -13,7 +13,7 @@ import os
 import cython
 from libcpp cimport bool as cbool
 
-from _common cimport tsize, arr, xcomplex, Healpix_Ordering_Scheme, RING, NEST, Healpix_Map, Alm, ndarray2map, ndarray2alm
+from _common cimport tsize, arr, xcomplex, Healpix_Ordering_Scheme, RING, NEST, Healpix_Map, Alm, ndarray2map, ndarray2alm, rotmatrix
 
 cdef double UNSEEN = -1.6375e30
 cdef double rtol_UNSEEN = 1.e-7 * 1.6375e30
@@ -497,7 +497,7 @@ def almxfl(alm, fl, mmax = None, inplace = False):
     return alm_
 
 
-def rotate_alm(alm not None, double psi, double theta, double phi, lmax=None,
+def rotate_alm(alm not None, double psi=None, double theta=None, double phi=None, matrix=None, lmax=None,
                mmax=None):
     """
     This routine transforms the scalar (and tensor) a_lm coefficients
@@ -520,8 +520,8 @@ def rotate_alm(alm not None, double psi, double theta, double phi, lmax=None,
         Second rotation: angle θ about the original (unrotated) y-axis
     phi : float.
         Third rotation: angle φ about the original (unrotated) z-axis.
-    rot : np.ndarray
-        Rotation matrix, for example created by 
+    matrix : np.ndarray
+        Rotation matrix instead of angles, for example the output of hp.Rotator.mat
     lmax : int
         Maximum multipole order l of the data set.
     mmax : int
@@ -531,6 +531,14 @@ def rotate_alm(alm not None, double psi, double theta, double phi, lmax=None,
     if isinstance(alm, np.ndarray) and alm.ndim == 1:
         alm = [alm]
 
+    assert (matrix is not None) or (psi is not None), "Either matrix or angles should be given, not both"
+
+    assert matrix.shape == (3,3), "Rotation matrix should be a 3x3 array"
+
+    rotation_matrix = rotmatrix(matrix[0,0], matrix[0,1], matrix[0,2],
+                                matrix[1,0], matrix[1,1], matrix[1,2],
+                                matrix[2,0], matrix[2,1], matrix[2,2])
+
     if not isinstance(alm, (list, tuple, np.ndarray)) or len(alm) == 0:
         raise ValueError('Invalid input.')
 
@@ -539,21 +547,30 @@ def rotate_alm(alm not None, double psi, double theta, double phi, lmax=None,
     # results.
     if len(alm) not in (1, 3):
         for a in alm:
-            rotate_alm(a, psi, theta, phi)
+            if matrix is None:
+                rotate_alm(a, psi, theta, phi)
+            else:
+                rotate_alm(a, rotation_matrix)
         return
 
     lmax, mmax = alm_getlmmax(alm[0], lmax, mmax)
     ai = np.ascontiguousarray(alm[0], dtype=np.complex128)
     AI = ndarray2alm(ai, lmax, mmax)
     if len(alm) == 1:
-        c_rotate_alm(AI[0], psi, theta, phi)
+        if matrix is None:
+            c_rotate_alm(AI[0], psi, theta, phi)
+        else:
+            c_rotate_alm(AI[0], rotation_matrix)
         del AI
     else:
         ag = np.ascontiguousarray(alm[1], dtype=np.complex128)
         ac = np.ascontiguousarray(alm[2], dtype=np.complex128)
         AG = ndarray2alm(ag, lmax, mmax)
         AC = ndarray2alm(ac, lmax, mmax)
-        c_rotate_alm(AI[0], AG[0], AC[0], psi, theta, phi)
+        if matrix is None:
+            c_rotate_alm(AI[0], AG[0], AC[0], psi, theta, phi)
+        else:
+            c_rotate_alm(AI[0], AG[0], AC[0], rotation_matrix)
         del AI, AG, AC
 
 

--- a/healpy/test/test_rotator.py
+++ b/healpy/test/test_rotator.py
@@ -20,7 +20,7 @@ def test_rotate_map_polarization():
     QU_gal = np.zeros((2, npix), dtype=np.double)
     QU_gal[0, : npix // 2] = 1
     gal2ecl = Rotator(coord=["G", "E"])
-    QU_ecl = gal2ecl.rotate_map(QU_gal)
+    QU_ecl = gal2ecl.rotate_map_pixel(QU_gal)
 
     expected = hp.ma(
         hp.read_map(os.path.join(path, "data", "justq_gal2ecl.fits.gz"), [0, 1])
@@ -34,6 +34,27 @@ def test_rotate_map_polarization():
             / np.logical_not(expected[i_pol].mask).sum()
         ) > .9, (pol + " comparison failed in rotate_map")
 
+def test_rotate_map_polarization_alms():
+    lmax = 64
+    path = os.path.dirname(os.path.realpath(__file__))
+    map1 = hp.read_map(
+            os.path.join(
+                path, "data", "wmap_band_iqumap_r9_7yr_W_v4_udgraded32.fits"
+            ),
+            (0, 1, 2),
+        )
+
+    # do the rotation with hp.rotate_alm
+    angles = hp.rotator.coordsys2euler_zyz(coord = ["G", "E"])
+    alm = hp.map2alm(map1, lmax=lmax, use_pixel_weights=True)
+    hp.rotate_alm(alm, *angles)
+    rotated_map1 = hp.alm2map(alm, nside=hp.get_nside(map1), lmax=lmax)
+
+    # do the rotation with hp.Rotator
+    gal2ecl = hp.Rotator(coord = ["G", "E"])
+    rotate_map1_rotate_map_alms = gal2ecl.rotate_map_alms(map1, lmax=lmax)
+
+    np.testing.assert_allclose(rotate_map1_rotate_map_alms, rotated_map1, rtol=1e-5)
 
 def test_rotate_map_polarization_with_spectrum():
     """Rotation of reference frame should not change the angular power spectrum.
@@ -48,7 +69,7 @@ def test_rotate_map_polarization_with_spectrum():
     gal2ecl = Rotator(coord=["G", "E"])
     m_original = hp.synfast(cl, nside=nside, new=True)
     cl_from_m_original = hp.anafast(m_original)
-    m_rotated = gal2ecl.rotate_map(m_original)
+    m_rotated = gal2ecl.rotate_map_pixel(m_original)
     cl_from_m_rotated = hp.anafast(m_rotated)
 
     assert np.abs(cl_from_m_rotated - cl_from_m_original).sum() < 1e-2
@@ -65,7 +86,7 @@ def test_rotate_dipole_and_back():
     m_gal = np.dot(vec.T, dip_dir)
     gal2ecl = Rotator(coord=["C", "E"])
     ecl2gal = Rotator(coord=["E", "C"])
-    m_ecl = gal2ecl.rotate_map(m_gal)
+    m_ecl = gal2ecl.rotate_map_pixel(m_gal)
     # Remove 10 deg along equator because dipole signal is so low that relative error is
     # too large
     cut_equator_deg = 5
@@ -73,5 +94,5 @@ def test_rotate_dipole_and_back():
         nside, np.radians(90 + cut_equator_deg), np.radians(90 - cut_equator_deg)
     )
     np.testing.assert_allclose(
-        m_gal[no_equator], ecl2gal.rotate_map(m_ecl)[no_equator], rtol=1e-3
+        m_gal[no_equator], ecl2gal.rotate_map_pixel(m_ecl)[no_equator], rtol=1e-3
     )

--- a/healpy/test/test_rotator.py
+++ b/healpy/test/test_rotator.py
@@ -34,27 +34,27 @@ def test_rotate_map_polarization():
             / np.logical_not(expected[i_pol].mask).sum()
         ) > .9, (pol + " comparison failed in rotate_map")
 
+
 def test_rotate_map_polarization_alms():
     lmax = 64
     path = os.path.dirname(os.path.realpath(__file__))
     map1 = hp.read_map(
-            os.path.join(
-                path, "data", "wmap_band_iqumap_r9_7yr_W_v4_udgraded32.fits"
-            ),
-            (0, 1, 2),
-        )
+        os.path.join(path, "data", "wmap_band_iqumap_r9_7yr_W_v4_udgraded32.fits"),
+        (0, 1, 2),
+    )
 
     # do the rotation with hp.rotate_alm
-    angles = hp.rotator.coordsys2euler_zyz(coord = ["G", "E"])
+    angles = hp.rotator.coordsys2euler_zyz(coord=["G", "E"])
     alm = hp.map2alm(map1, lmax=lmax, use_pixel_weights=True)
     hp.rotate_alm(alm, *angles)
     rotated_map1 = hp.alm2map(alm, nside=hp.get_nside(map1), lmax=lmax)
 
     # do the rotation with hp.Rotator
-    gal2ecl = hp.Rotator(coord = ["G", "E"])
+    gal2ecl = hp.Rotator(coord=["G", "E"])
     rotate_map1_rotate_map_alms = gal2ecl.rotate_map_alms(map1, lmax=lmax)
 
     np.testing.assert_allclose(rotate_map1_rotate_map_alms, rotated_map1, rtol=1e-5)
+
 
 def test_rotate_map_polarization_with_spectrum():
     """Rotation of reference frame should not change the angular power spectrum.

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -15,7 +15,6 @@ warnings.filterwarnings("ignore")
 
 
 class TestSphtFunc(unittest.TestCase):
-
     def setUp(self):
         self.lmax = 64
         self.path = os.path.dirname(os.path.realpath(__file__))
@@ -278,12 +277,12 @@ class TestSphtFunc(unittest.TestCase):
         lmax = 32
         nalm = hp.Alm.getsize(lmax)
         alm = np.zeros([3, nalm], dtype=np.complex)
-        alm[0,1] = 1
-        alm[1,2] = 1
+        alm[0, 1] = 1
+        alm[1, 2] = 1
         alm_rotated_angles = alm.copy()
-        angles = hp.rotator.coordsys2euler_zyz(coord = ["G", "E"])
+        angles = hp.rotator.coordsys2euler_zyz(coord=["G", "E"])
         hp.rotate_alm(alm_rotated_angles, *angles)
-        gal2ecl = hp.Rotator(coord = ["G", "E"])
+        gal2ecl = hp.Rotator(coord=["G", "E"])
         hp.rotate_alm(alm, matrix=gal2ecl.mat)
         np.testing.assert_allclose(alm_rotated_angles, alm)
 

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -273,6 +273,20 @@ class TestSphtFunc(unittest.TestCase):
             # FIXME: rtol=1e-6 works here, except on Debian with Python 3.4.
             np.testing.assert_allclose(i, o, rtol=1e-5)
 
+    def test_rotate_alm_rotmatrix(self):
+        """rotate_alm also support rotation matrix instead of angles"""
+        lmax = 32
+        nalm = hp.Alm.getsize(lmax)
+        alm = np.zeros([3, nalm], dtype=np.complex)
+        alm[0,1] = 1
+        alm[1,2] = 1
+        alm_rotated_angles = alm.copy()
+        angles = hp.rotator.coordsys2euler_zyz(coord = ["G", "E"])
+        hp.rotate_alm(alm_rotated_angles, *angles)
+        gal2ecl = hp.Rotator(coord = ["G", "E"])
+        hp.rotate_alm(alm, matrix=gal2ecl.mat)
+        np.testing.assert_allclose(alm_rotated_angles, alm)
+
     def test_rotate_alm2(self):
         # Test rotate_alm against the Fortran library
         lmax = 64


### PR DESCRIPTION
* Added support in `hp.rotate_alm` for rotation matrices, originally healpy only wrapped the version of the function with angles (this was reported in #399)
* Renamed the `rotate_map` function to `rotate_map_pixel` as it is working in pixel space
* Added new function `rotate_map_alms` that does the rotation in harmonics space, see discussion in #460 

See an example: https://gist.github.com/zonca/67a0fec459de5b9bed007f1ec071a4b5

@ziotom78 would you like to provide some feedback?