### PR TITLE
Add nside tests for all visu funcs, needed for nested maps.

### DIFF
--- a/healpy/test/test_visufunc.py
+++ b/healpy/test/test_visufunc.py
@@ -10,12 +10,11 @@ from ..zoomtool import mollzoom
 
 
 class TestNoCrash(unittest.TestCase):
-
     def setUp(self):
         self.nside = 16
         self.npix = hp.nside2npix(self.nside)
         self.m = np.arange(self.npix, dtype=np.double)
-        self.m_wrong_npix = np.arange(self.npix+1, dtype=np.double)
+        self.m_wrong_npix = np.arange(self.npix + 1, dtype=np.double)
         self.ma = self.m.copy()
         self.ma[3] = hp.UNSEEN
         self.ma = hp.ma(self.ma)
@@ -57,7 +56,7 @@ class TestNoCrash(unittest.TestCase):
     def test_azeqview_crash(self):
         with self.assertRaises(TypeError):
             azeqview(self.m_wrong_npix)
-    
+
     def test_mollzoom_nocrash(self):
         mollzoom(self.m)
 

--- a/healpy/test/test_visufunc.py
+++ b/healpy/test/test_visufunc.py
@@ -13,7 +13,9 @@ class TestNoCrash(unittest.TestCase):
 
     def setUp(self):
         self.nside = 16
-        self.m = np.arange(hp.nside2npix(self.nside), dtype=np.double)
+        self.npix = hp.nside2npix(self.nside)
+        self.m = np.arange(self.npix, dtype=np.double)
+        self.m_wrong_npix = np.arange(self.npix+1, dtype=np.double)
         self.ma = self.m.copy()
         self.ma[3] = hp.UNSEEN
         self.ma = hp.ma(self.ma)
@@ -24,23 +26,47 @@ class TestNoCrash(unittest.TestCase):
     def test_cartview_nocrash(self):
         cartview(self.m)
 
+    def test_cartview_crash(self):
+        with self.assertRaises(TypeError):
+            cartview(self.m_wrong_npix)
+
     def test_mollview_nocrash(self):
         mollview(self.m)
+
+    def test_mollview_crash(self):
+        with self.assertRaises(TypeError):
+            mollview(self.m_wrong_npix)
 
     def test_gnomview_nocrash(self):
         gnomview(self.m)
 
+    def test_gnomview_crash(self):
+        with self.assertRaises(TypeError):
+            gnomview(self.m_wrong_npix)
+
     def test_orthview_nocrash(self):
         orthview(self.m)
+
+    def test_orthview_crash(self):
+        with self.assertRaises(TypeError):
+            orthview(self.m_wrong_npix)
 
     def test_azeqview_nocrash(self):
         azeqview(self.m)
 
+    def test_azeqview_crash(self):
+        with self.assertRaises(TypeError):
+            azeqview(self.m_wrong_npix)
+    
     def test_mollzoom_nocrash(self):
         mollzoom(self.m)
 
     def test_mollzoom_histnocrash(self):
         mollzoom(self.m, norm="hist")
+
+    def test_mollzoom_crash(self):
+        with self.assertRaises(TypeError):
+            mollzoom(self.m_wrong_npix)
 
     def test_cartview_ma_nocrash(self):
         cartview(self.ma)

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -170,6 +170,10 @@ def mollview(
     # Create the figure
     import pylab
 
+    # Ensure that the nside is valid
+    nside = pixelfunc.get_nside(map)
+    pixelfunc.check_nside(nside, nest=nest)
+
     if not (hold or sub):
         f = pylab.figure(fig, figsize=(8.5, 5.4))
         extent = (0.02, 0.05, 0.96, 0.9)
@@ -393,6 +397,10 @@ def gnomview(
     mollview, cartview, orthview, azeqview
     """
     import pylab
+
+    # Ensure that the nside is valid
+    nside = pixelfunc.get_nside(map)
+    pixelfunc.check_nside(nside, nest=nest)
 
     if not (hold or sub):
         f = pylab.figure(fig, figsize=(5.8, 6.4))
@@ -651,6 +659,10 @@ def cartview(
     """
     import pylab
 
+    # Ensure that the nside is valid
+    nside = pixelfunc.get_nside(map)
+    pixelfunc.check_nside(nside, nest=nest)
+
     if not (hold or sub):
         f = pylab.figure(fig, figsize=(8.5, 5.4))
         if not margins:
@@ -889,6 +901,10 @@ def orthview(
     """
     # Create the figure
     import pylab
+
+    # Ensure that the nside is valid
+    nside = pixelfunc.get_nside(map)
+    pixelfunc.check_nside(nside, nest=nest)
 
     if not (hold or sub):
         f = pylab.figure(fig, figsize=(8.5, 5.4))
@@ -1130,6 +1146,10 @@ def azeqview(
     """
     # Create the figure
     import pylab
+
+    # Ensure that the nside is valid
+    nside = pixelfunc.get_nside(map)
+    pixelfunc.check_nside(nside, nest=nest)
 
     if not (hold or sub):
         f = pylab.figure(fig, figsize=(8.5, 5.4))

--- a/healpy/zoomtool.py
+++ b/healpy/zoomtool.py
@@ -98,6 +98,10 @@ def mollzoom(
     """
     import pylab
 
+    # Ensure that the nside is valid
+    nside = pixelfunc.get_nside(map)
+    pixelfunc.check_nside(nside, nest=nest)
+
     # create the figure (if interactive, it will open the window now)
     f = pylab.figure(fig, figsize=(10.5, 5.4))
     extent = (0.02, 0.25, 0.56, 0.72)


### PR DESCRIPTION
Addresses #482 

Nested maps are only defined for nsides that are a power of 2. This is caught, but not in the python layer. This PR allows a graceful exit with a meaningful error in e.g. notebooks and ipython.