### PR TITLE
Add no_plot Boolean variable to gnomview

### DIFF
--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -386,9 +386,9 @@ def gnomview(
       Default: None
     notext: bool, optional
       If True: do not add resolution info text. Default=False
-    return_projected_map : bool
+    return_projected_map : bool, optional
       if True returns the projected map in a 2d numpy array
-    no_plot : bool
+    no_plot : bool, optional
       if True no figure will be created      
 
     See Also
@@ -545,7 +545,7 @@ def gnomview(
         if wasinteractive:
             pylab.ion()
             # pylab.show()
-        if no_plot is True:        
+        if no_plot:        
             pylab.close(f)  
             f.clf()
             ax.cla()

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -323,6 +323,7 @@ def gnomview(
     margins=None,
     notext=False,
     return_projected_map=False,
+    no_plot=False,
 ):
     """Plot a healpix map (given as an array) in Gnomonic projection.
 
@@ -387,6 +388,8 @@ def gnomview(
       If True: do not add resolution info text. Default=False
     return_projected_map : bool
       if True returns the projected map in a 2d numpy array
+    no_plot : bool
+      if True no figure will be created      
 
     See Also
     --------
@@ -542,6 +545,10 @@ def gnomview(
         if wasinteractive:
             pylab.ion()
             # pylab.show()
+        if no_plot is True:        
+            pylab.close(f)  
+            f.clf()
+            ax.cla()
     if return_projected_map:
         return img
 


### PR DESCRIPTION
This commit adds the Boolean no_plot variable to the gnomview function in visufunc.py. Setting the variable to True will close the automatically generated output figure, which is useful is gnomview is run in a loop i.e. when stacking a large number of maps. Without this option, healpy will consume large amounts of RAM and can crash jupyter notebooks.