### PR TITLE
Revert "Set random seed to make test_rotator reproducible"

### DIFF
--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -522,8 +522,6 @@ def synfast(
     cls_lmax = cb.len_array_or_arrays(cls) - 1
     if lmax is None or lmax < 0:
         lmax = min(cls_lmax, 3 * nside - 1)
-    seed = 12345
-    np.random.seed(seed)
     alms = synalm(cls, lmax=lmax, mmax=mmax, new=new, verbose=verbose)
     maps = alm2map(
         alms,


### PR DESCRIPTION
Reverts healpy/healpy#487

I'm guessing this wasn't meant to make it into production (at least not in this way), since it means synfast always produces the same map?

CC @lpsinger 

https://xkcd.com/221/ :) 