### PR TITLE
normalise_rot: fix unnecessary memory reference issue

### DIFF
--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -759,7 +759,7 @@ def normalise_rot(rot, deg=False):
         rot = np.zeros(3)
     else:
         rot = np.array(rot, np.float64).flatten() * convert
-        rot.resize(3)
+        rot.resize(3, refcheck=False)
     return rot
 
 


### PR DESCRIPTION
this change solves the following error which is encountered for example when running healpy with 'python -m memory_profiler':

  File "/usr/local/lib/python2.7/dist-packages/healpy/rotator.py", line 136, in __init__
    rn = normalise_rot(r, deg=deg)
  File "/usr/local/lib/python2.7/dist-packages/healpy/rotator.py", line 762, in normalise_rot
    rot.resize(3)
ValueError: cannot resize an array that references or is referenced
by another array in this way.  Use the resize function


as noted in <https://www.numpy.org/devdocs/reference/generated/numpy.ndarray.resize.html>, this is not a bug but is probably rarely encountered because run-time optimizations avoid reference counting in trivial use cases.