### PR TITLE
Add support for pathlib

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@ import sys, os
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
-sys.path.append(os.path.abspath('.'))
+sys.path.append(os.path.abspath("."))
 
 # General configuration
 # ---------------------
@@ -24,48 +24,49 @@ sys.path.append(os.path.abspath('.'))
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 
-extensions = ['sphinx.ext.autosummary', 'sphinx.ext.autodoc', 'numpydoc']
+extensions = ["sphinx.ext.autosummary", "sphinx.ext.autodoc", "numpydoc"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['templates/']
+templates_path = ["templates/"]
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General substitutions.
-project = u'healpy'
-copyright = u'CC/BY/4.0/International'
+project = u"healpy"
+copyright = u"CC/BY/4.0/International"
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
 #
 # The short X.Y version.
 import healpy
+
 version = healpy.__version__
 # The full version, including alpha/beta/rc tags.
 release = version
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-today_fmt = '%B %d, %Y'
+today_fmt = "%B %d, %Y"
 
 # List of documents that shouldn't be included in the build.
-#unused_docs = []
+# unused_docs = []
 
 # List of directories, relative to source directories, that shouldn't be searched
 # for source files.
-exclude_patterns = ['.build/*', 'templates/*', 'ext/*.rst']
+exclude_patterns = [".build/*", "templates/*", "ext/*.rst"]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
@@ -73,120 +74,117 @@ exclude_patterns = ['.build/*', 'templates/*', 'ext/*.rst']
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-#pygments_style = 'sphinx'
+# pygments_style = 'sphinx'
 
 
 # Options for HTML output
 # -----------------------
 
 
-#html_theme = 'default'
+# html_theme = 'default'
 
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.
-#html_style = 'default.css'
+# html_style = 'default.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['static']
+html_static_path = ["static"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = "%b %d, %Y"
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-#    'index': 'indexsidebar.html'
+    #    'index': 'indexsidebar.html'
 }
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
 html_additional_pages = {
-#    'index': 'indexcontent.html',
+    #    'index': 'indexcontent.html',
 }
 
 # If false, no module index is generated.
-#html_use_modindex = True
+# html_use_modindex = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
-#html_copy_source = True
+# html_copy_source = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = ''
+# html_file_suffix = ''
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'healpydoc'
+htmlhelp_basename = "healpydoc"
 
 
 # Options for LaTeX output
 # ------------------------
 
 # The paper size ('letter' or 'a4').
-#latex_paper_size = 'letter'
+# latex_paper_size = 'letter'
 
 # The font size ('10pt', '11pt' or '12pt').
-#latex_font_size = '10pt'
+# latex_font_size = '10pt'
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
-latex_documents = [
-  ('index', 'healpy.tex', u'healpy Documentation',
-   u'', 'manual'),
-]
+latex_documents = [("index", "healpy.tex", u"healpy Documentation", u"", "manual")]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # Additional stuff for the LaTeX preamble.
-#latex_preamble = ''
+# latex_preamble = ''
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_use_modindex = True
+# latex_use_modindex = True
 
 import glob
-autosummary_generate = glob.glob('*.rst')
 
+autosummary_generate = glob.glob("*.rst")

--- a/doc/create_images.py
+++ b/doc/create_images.py
@@ -6,26 +6,39 @@ SIZE = 400
 DPI = 60
 
 m = np.arange(hp.nside2npix(32))
-hp.mollview(m, nest = True, xsize=SIZE, title='Mollview image NESTED')
-plt.savefig('static/moll_nside32_nest.png', dpi=DPI)
+hp.mollview(m, nest=True, xsize=SIZE, title="Mollview image NESTED")
+plt.savefig("static/moll_nside32_nest.png", dpi=DPI)
 
-hp.mollview(m, nest = False, xsize=SIZE, title='Mollview image RING')
-plt.savefig('static/moll_nside32_ring.png', dpi=DPI)
+hp.mollview(m, nest=False, xsize=SIZE, title="Mollview image RING")
+plt.savefig("static/moll_nside32_ring.png", dpi=DPI)
 
-wmap_map_I = hp.read_map('../healpy/test/data/wmap_band_imap_r9_7yr_W_v4.fits')
+wmap_map_I = hp.read_map("../healpy/test/data/wmap_band_imap_r9_7yr_W_v4.fits")
 
-hp.mollview(wmap_map_I, coord=['G','E'], title='Histogram equalized Ecliptic', unit='mK', norm='hist', min=-1,max=1, xsize=SIZE) 
+hp.mollview(
+    wmap_map_I,
+    coord=["G", "E"],
+    title="Histogram equalized Ecliptic",
+    unit="mK",
+    norm="hist",
+    min=-1,
+    max=1,
+    xsize=SIZE,
+)
 hp.graticule()
 
-plt.savefig('static/wmap_histeq_ecl.png', dpi=DPI)
-mask = hp.read_map('../healpy/test/data/wmap_temperature_analysis_mask_r9_7yr_v4.fits').astype(np.bool)
+plt.savefig("static/wmap_histeq_ecl.png", dpi=DPI)
+mask = hp.read_map(
+    "../healpy/test/data/wmap_temperature_analysis_mask_r9_7yr_v4.fits"
+).astype(np.bool)
 wmap_map_I_masked = hp.ma(wmap_map_I)
 wmap_map_I_masked.mask = np.logical_not(mask)
 LMAX = 1024
 cl = hp.anafast(wmap_map_I_masked.filled(), lmax=LMAX)
 ell = np.arange(len(cl))
 plt.figure()
-plt.plot(ell, ell * (ell+1) * cl)
-plt.xlabel('ell'); plt.ylabel('ell(ell+1)cl'); plt.grid()
+plt.plot(ell, ell * (ell + 1) * cl)
+plt.xlabel("ell")
+plt.ylabel("ell(ell+1)cl")
+plt.grid()
 
-plt.savefig('static/wmap_powspec.png', dpi=DPI)
+plt.savefig("static/wmap_powspec.png", dpi=DPI)

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -22,7 +22,11 @@
 from __future__ import division
 
 import six
+import sys
 import warnings
+
+if sys.version >= "3.4":
+    import pathlib
 import astropy.io.fits as pf
 import numpy as np
 
@@ -48,7 +52,7 @@ def read_cl(filename, dtype=np.float64, h=False):
 
     Parameters
     ----------
-    filename : str or HDUList or HDU
+    filename : str or HDUList or HDU or pathlib.Path instance
       the fits file name
     dtype : data type, optional
       the data type of the returned array
@@ -277,7 +281,7 @@ def read_map(
 
     Parameters
     ----------
-    filename : str or HDU or HDUList
+    filename : str or HDU or HDUList or pathlib.Path instance
       the fits file name
     field : int or tuple of int, or None, optional
       The column to read. Default: 0.
@@ -543,7 +547,7 @@ def read_alm(filename, hdu=1, return_mmax=False):
 
     Parameters
     ----------
-    filename : str or HDUList or HDU
+    filename : str or HDUList or HDU or pathlib.Path instance
       The name of the fits file to read
     hdu : int, or tuple of int, optional
       The header to read. Start at 0. Default: hdu=1
@@ -607,8 +611,11 @@ def _get_hdu(input_data, hdu=None, memmap=None):
     fits_hdu : HDU
         The extracted HDU
     """
+    allowed_paths = tuple(six.string_types)
+    if sys.version >= "3.4":
+        allowed_paths += (pathlib.Path, pathlib.PosixPath)
 
-    if isinstance(input_data, six.string_types):
+    if isinstance(input_data, allowed_paths):
         hdulist = pf.open(input_data, memmap=memmap)
         return _get_hdu(hdulist, hdu=hdu)
 
@@ -624,7 +631,7 @@ def _get_hdu(input_data, hdu=None, memmap=None):
         fits_hdu = input_data
     else:
         raise TypeError(
-            "First argument should be a input_data, HDUList instance, or HDU instance"
+            "First argument should be a input_data (str or pathlib.Path), HDUList instance, or HDU instance"
         )
 
     return fits_hdu

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -613,7 +613,6 @@ class SphericalProjAxes(matplotlib.axes.Axes):
             del self._graticules
 
     def _get_interv_graticule(self, pmin, pmax, dpar, mmin, mmax, dmer, verbose=True):
-
         def set_prec(d, n, nn=2):
             arcmin = False
             if d / n < 1.:
@@ -681,7 +680,6 @@ class GnomonicAxes(SphericalProjAxes):
 
 
 class HpxGnomonicAxes(GnomonicAxes):
-
     def projmap(self, map, nest=False, **kwds):
         nside = pixelfunc.npix2nside(pixelfunc.get_map_size(map))
         f = lambda x, y, z: pixelfunc.vec2pix(nside, x, y, z, nest=nest)
@@ -719,7 +717,6 @@ class MollweideAxes(SphericalProjAxes):
 
 
 class HpxMollweideAxes(MollweideAxes):
-
     def projmap(self, map, nest=False, **kwds):
         nside = pixelfunc.npix2nside(pixelfunc.get_map_size(map))
         f = lambda x, y, z: pixelfunc.vec2pix(nside, x, y, z, nest=nest)
@@ -747,7 +744,6 @@ class CartesianAxes(SphericalProjAxes):
 
 
 class HpxCartesianAxes(CartesianAxes):
-
     def projmap(self, map, nest=False, **kwds):
         nside = pixelfunc.npix2nside(pixelfunc.get_map_size(map))
         f = lambda x, y, z: pixelfunc.vec2pix(nside, x, y, z, nest=nest)
@@ -784,7 +780,6 @@ class OrthographicAxes(SphericalProjAxes):
 
 
 class HpxOrthographicAxes(OrthographicAxes):
-
     def projmap(self, map, nest=False, **kwds):
         nside = pixelfunc.npix2nside(len(map))
         f = lambda x, y, z: pixelfunc.vec2pix(nside, x, y, z, nest=nest)
@@ -826,7 +821,6 @@ class AzimuthalAxes(SphericalProjAxes):
 
 
 class HpxAzimuthalAxes(AzimuthalAxes):
-
     def projmap(self, map, nest=False, **kwds):
         nside = pixelfunc.npix2nside(pixelfunc.get_map_size(map))
         f = lambda x, y, z: pixelfunc.vec2pix(nside, x, y, z, nest=nest)
@@ -888,7 +882,7 @@ def create_colormap(cmap):
     elif type(cmap) == matplotlib.colors.LinearSegmentedColormap:
         cmap0 = cmap
     else:
-        cmap0 = matplotlib.cm.get_cmap(matplotlib.rcParams['image.cmap'])
+        cmap0 = matplotlib.cm.get_cmap(matplotlib.rcParams["image.cmap"])
     if hasattr(cmap0, "_segmentdata"):
         newcm = matplotlib.colors.LinearSegmentedColormap(
             "newcm", cmap0._segmentdata, cmap0.N
@@ -906,7 +900,6 @@ def create_colormap(cmap):
 #   A Locator that gives the bounds of the interval
 #
 class BoundaryLocator(matplotlib.ticker.Locator):
-
     def __init__(self, N=2, norm=None):
         if N < 2:
             raise ValueError("Number of locs must be greater than 1")
@@ -946,7 +939,6 @@ class BoundaryLocator(matplotlib.ticker.Locator):
 
 
 class HistEqNorm(matplotlib.colors.Normalize):
-
     def __init__(self, vmin=None, vmax=None, clip=False):
         matplotlib.colors.Normalize.__init__(self, vmin, vmax, clip)
         self.xval = None

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -44,7 +44,9 @@ class FutureChangeWarning(UserWarning):
 
 
 DATAPATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
-MAX_NSIDE = 8192  # The maximum nside up to which most operations (e.g. map2alm) will work
+MAX_NSIDE = (
+    8192
+)  # The maximum nside up to which most operations (e.g. map2alm) will work
 
 # Spherical harmonics transformation
 def anafast(
@@ -1106,7 +1108,7 @@ def bl2beam(bl, theta):
     beam : array
         (Circular) beam profile b(theta).
     """
-    
+
     lmax = len(bl) - 1
     nx = len(theta)
     x = np.cos(theta)
@@ -1185,8 +1187,8 @@ def check_max_nside(nside):
 
     if nside > MAX_NSIDE:
         raise ValueError(
-            'nside {nside} of map cannot be larger than '
-            'MAX_NSIDE {max_nside}'.format(
-                nside=nside, max_nside=MAX_NSIDE))
+            "nside {nside} of map cannot be larger than "
+            "MAX_NSIDE {max_nside}".format(nside=nside, max_nside=MAX_NSIDE)
+        )
 
     return 0

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 if sys.version >= "3.4":
     from pathlib import Path
 import astropy.io.fits as pf
@@ -13,7 +14,6 @@ from ..sphtfunc import *
 
 
 class TestFitsFunc(unittest.TestCase):
-
     def setUp(self):
         self.nside = 512
         self.m = np.arange(healpy.nside2npix(self.nside))
@@ -158,7 +158,6 @@ class TestFitsFunc(unittest.TestCase):
 
 
 class TestFitsFuncGzip(unittest.TestCase):
-
     def setUp(self):
         self.nside = 4
         self.m = np.arange(healpy.nside2npix(self.nside))
@@ -178,7 +177,6 @@ class TestFitsFuncGzip(unittest.TestCase):
 
 
 class TestReadWriteAlm(unittest.TestCase):
-
     def setUp(self):
 
         s = Alm.getsize(256)
@@ -255,7 +253,6 @@ class TestReadWriteAlm(unittest.TestCase):
 
 
 class TestReadWriteCl(unittest.TestCase):
-
     def setUp(self):
         self.filename = "test_cl.fits"
 

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -1,4 +1,7 @@
 import os
+import sys
+if sys.version >= "3.4":
+    from pathlib import Path
 import astropy.io.fits as pf
 import unittest
 import numpy as np
@@ -27,6 +30,13 @@ class TestFitsFunc(unittest.TestCase):
         write_map(self.filename, self.m, column_units="K")
         read_m = pf.open(self.filename)[1].data.field(0)
 
+    def test_write_map_pathlib(self):
+        if sys.version < "3.4":
+            return
+        path = Path(self.filename)
+        write_map(path, self.m)
+        read_m = pf.open(path)[1].data.field(0)
+
     def test_write_map_units_list(self):
         write_map(self.filename, [self.m, self.m], column_units=["K", "K"])
         read_m = pf.open(self.filename)[1].data.field(0)
@@ -46,6 +56,13 @@ class TestFitsFunc(unittest.TestCase):
     def test_read_map_filename(self):
         write_map(self.filename, self.m)
         read_map(self.filename)
+
+    def test_read_map_filename_pathlib(self):
+        if sys.version < "3.4":
+            return
+        path = Path(self.filename)
+        write_map(path, self.m)
+        read_map(path)
 
     def test_read_map_filename_with_header(self):
         write_map(self.filename, self.m)
@@ -136,7 +153,8 @@ class TestFitsFunc(unittest.TestCase):
             np.testing.assert_almost_equal(dtype(self.m), rm)
 
     def tearDown(self):
-        os.remove(self.filename)
+        if os.path.exists(self.filename):
+            os.remove(self.filename)
 
 
 class TestFitsFuncGzip(unittest.TestCase):
@@ -155,7 +173,8 @@ class TestFitsFuncGzip(unittest.TestCase):
         read_m = pf.open(self.filename)[1].data.field(0)
 
     def tearDown(self):
-        os.remove(self.filename)
+        if os.path.exists(self.filename):
+            os.remove(self.filename)
 
 
 class TestReadWriteAlm(unittest.TestCase):
@@ -211,6 +230,13 @@ class TestReadWriteAlm(unittest.TestCase):
         write_alm("testalm_128.fits", self.alms, lmax=128, mmax=128)
         read_alm("testalm_128.fits")
 
+    def test_read_alm_pathlib(self):
+        if sys.version < "3.4":
+            return
+        path = Path("testalm_128.fits")
+        write_alm(path, self.alms, lmax=128, mmax=128)
+        read_alm(path)
+
     def test_read_alm_filename_array(self):
         write_alm("testalm_256.fits", self.alms, overwrite=True)
         testalm1 = np.array(self.alms)
@@ -230,33 +256,37 @@ class TestReadWriteAlm(unittest.TestCase):
 
 class TestReadWriteCl(unittest.TestCase):
 
+    def setUp(self):
+        self.filename = "test_cl.fits"
+
     def tearDown(self):
-        os.remove("test_cl.fits")
+        if os.path.exists(self.filename):
+            os.remove(self.filename)
 
     def test_write_read_cl_II(self):
         cl = np.arange(1025, dtype=np.double)
-        write_cl("test_cl.fits", cl)
-        cl_read = read_cl("test_cl.fits")
+        write_cl(self.filename, cl)
+        cl_read = read_cl(self.filename)
         np.testing.assert_array_almost_equal(cl, cl_read)
 
     def test_write_read_cl_4comp(self):
         cl = [np.arange(1025, dtype=np.double) for n in range(4)]
-        write_cl("test_cl.fits", cl)
-        cl_read = read_cl("test_cl.fits")
+        write_cl(self.filename, cl)
+        cl_read = read_cl(self.filename)
         for cl_column, cl_read_column in zip(cl, cl_read):
             np.testing.assert_array_almost_equal(cl_column, cl_read_column)
 
     def test_write_read_cl_6comp(self):
         cl = [np.arange(1025, dtype=np.double) for n in range(6)]
-        write_cl("test_cl.fits", cl)
-        cl_read = read_cl("test_cl.fits")
+        write_cl(self.filename, cl)
+        cl_read = read_cl(self.filename)
         for cl_column, cl_read_column in zip(cl, cl_read):
             np.testing.assert_array_almost_equal(cl_column, cl_read_column)
 
     def test_read_cl_filename(self):
         cl = np.arange(1025, dtype=np.double)
-        write_cl("test_cl.fits", cl)
-        read_cl("test_cl.fits")
+        write_cl(self.filename, cl)
+        read_cl(self.filename)
 
     def test_read_cl_hdulist(self):
         cl = np.arange(1025, dtype=np.double)

--- a/healpy/test/test_pixelfunc.py
+++ b/healpy/test/test_pixelfunc.py
@@ -6,7 +6,6 @@ import unittest
 
 
 class TestPixelFunc(unittest.TestCase):
-
     def setUp(self):
         # data fixture
         self.theta0 = [1.52911759, 0.78550497, 1.57079633, 0.05103658, 3.09055608]

--- a/healpy/test/test_pixelweights.py
+++ b/healpy/test/test_pixelweights.py
@@ -12,7 +12,6 @@ warnings.filterwarnings("ignore")
 
 
 class TestMap2Alm(unittest.TestCase):
-
     def setUp(self):
         self.nside = 64
         self.lmax = 96

--- a/healpy/test/test_query_disc.py
+++ b/healpy/test/test_query_disc.py
@@ -10,7 +10,6 @@ except:
 
 
 class TestQueryDisc(unittest.TestCase):
-
     def setUp(self):
         self.NSIDE = 8
         self.vec = np.array([0.17101007, 0.03015369, 0.98480775])

--- a/healpy/test/test_rotator.py
+++ b/healpy/test/test_rotator.py
@@ -18,6 +18,7 @@ def set_random_seed():
     seed = 12345
     np.random.seed(seed)
 
+
 def test_rotate_map_polarization():
     """Compare to a rotation from Galactic to Ecliptic of
     a map of pure Q polarization, the expected value was computed with HEALPix IDL:

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -191,10 +191,9 @@ class TestSphtFunc(unittest.TestCase):
         # Input power spectrum and alm
         alm_syn = hp.synalm(self.cla, lmax=lmax)
 
-        cl_out = hp.alm2cl(alm_syn, lmax_out=lmax_out-1)
+        cl_out = hp.alm2cl(alm_syn, lmax_out=lmax_out - 1)
 
-        np.testing.assert_array_almost_equal(
-            cl_out, self.cla[:lmax_out], decimal=4)
+        np.testing.assert_array_almost_equal(cl_out, self.cla[:lmax_out], decimal=4)
 
     def test_map2alm(self):
         nside = 32
@@ -401,7 +400,7 @@ class TestSphtFunc(unittest.TestCase):
         # Test an nside that is too large
         with self.assertRaises(ValueError):
             hp.check_max_nside(16384)
-        
+
         # Test an nside that is valid
         # hp.check_max_nside will return 0 if no exceptions are raised
         self.assertEqual(hp.check_max_nside(1024), 0)

--- a/healpy/test/test_spinfunc.py
+++ b/healpy/test/test_spinfunc.py
@@ -1010,7 +1010,6 @@ clms = {
 
 
 class TestSpinFunc(unittest.TestCase):
-
     def setUp(self):
         self.nside = 64
         self.lmax = self.nside

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -553,8 +553,8 @@ def gnomview(
         if wasinteractive:
             pylab.ion()
             # pylab.show()
-        if no_plot:        
-            pylab.close(f)  
+        if no_plot:
+            pylab.close(f)
             f.clf()
             ax.cla()
     if return_projected_map:

--- a/setup.py
+++ b/setup.py
@@ -387,7 +387,6 @@ class build_external_clib(build_clib):
 
 
 class custom_build_ext(build_ext):
-
     def finalize_options(self):
         build_ext.finalize_options(self)
 
@@ -423,8 +422,9 @@ class custom_build_ext(build_ext):
 
 exec(open("healpy/version.py").read())
 
+
 def readme():
-    with open('README.rst') as f:
+    with open("README.rst") as f:
         return f.read()
 
 


### PR DESCRIPTION
The preferred way to handle paths in python>=3.4 is by using pathlib.

```python
from pathlib import Path

path = Path('/home/data/')

hpxmap = hp.read_map(
    path.joinpath('myfile.fits')
)
```

If we try to use hp.read_map() with a `Path` instance, it is not parsed correctly and an exception is raised:

`TypeError: First argument should be a input_data, HDUList instance, or HDU instance`

This PR addresses this; astropy.io.fits already supports pathlib, I just had to add a `Path` instance to the allowed types for `pf.read()`.