### PR TITLE
Work around Numpy formatting glitch in doctest

### DIFF
--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -1139,8 +1139,8 @@ def order2nside(order):
     >>> hp.order2nside(7)
     128
 
-    >>> hp.order2nside(np.arange(8))
-    array([  1,   2,   4,   8,  16,  32,  64, 128])
+    >>> print(hp.order2nside(np.arange(8)))
+    [  1   2   4   8  16  32  64 128]
 
     >>> hp.order2nside(31)
     Traceback (most recent call last):


### PR DESCRIPTION
A Numpy string formatting bug causes this doctest to fail on
certain 32-bit platforms (e.g. armhf). The bug is evident in the
following example:

    >>> np.arange(8)
    array([0, 1, 2, 3, 4, 5, 6, 7])
    >>> 1 << np.arange(8)
    array([  1,   2,   4,   8,  16,  32,  64, 128], dtype=int32)

The `dtype=int32` should be supressed in both cases, but it is not.
This might get fixed upstream in Numpy 1.17. See numpy/numpy#9799,
numpy/numpy#10151.