### PR TITLE
Fix incorrect data types in pixel ufuncs

### DIFF
--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -446,17 +446,17 @@ def ang2pix(nside, theta, phi, nest=False, lonlat=False):
     >>> hp.ang2pix(16, np.pi/2, 0)
     1440
 
-    >>> hp.ang2pix(16, [np.pi/2, np.pi/4, np.pi/2, 0, np.pi], [0., np.pi/4, np.pi/2, 0, 0])
-    array([1440,  427, 1520,    0, 3068])
+    >>> print(hp.ang2pix(16, [np.pi/2, np.pi/4, np.pi/2, 0, np.pi], [0., np.pi/4, np.pi/2, 0, 0]))
+    [1440  427 1520    0 3068]
 
-    >>> hp.ang2pix(16, np.pi/2, [0, np.pi/2])
-    array([1440, 1520])
+    >>> print(hp.ang2pix(16, np.pi/2, [0, np.pi/2]))
+    [1440 1520]
 
-    >>> hp.ang2pix([1, 2, 4, 8, 16], np.pi/2, 0)
-    array([   4,   12,   72,  336, 1440])
+    >>> print(hp.ang2pix([1, 2, 4, 8, 16], np.pi/2, 0))
+    [   4   12   72  336 1440]
 
-    >>> hp.ang2pix([1, 2, 4, 8, 16], 0, 0, lonlat=True)
-    array([   4,   12,   72,  336, 1440])
+    >>> print(hp.ang2pix([1, 2, 4, 8, 16], 0, 0, lonlat=True))
+    [   4   12   72  336 1440]
     """
 
     check_nside(nside, nest=nest)
@@ -553,8 +553,8 @@ def xyf2pix(nside, x, y, face, nest=False):
     >>> hp.xyf2pix(16, 8, 8, 4)
     1440
 
-    >>> hp.xyf2pix(16, [8, 8, 8, 15, 0], [8, 8, 7, 15, 0], [4, 0, 5, 0, 8])
-    array([1440,  427, 1520,    0, 3068])
+    >>> print(hp.xyf2pix(16, [8, 8, 8, 15, 0], [8, 8, 7, 15, 0], [4, 0, 5, 0, 8]))
+    [1440  427 1520    0 3068]
     """
     check_nside(nside, nest=nest)
     if nest:
@@ -633,11 +633,11 @@ def vec2pix(nside, x, y, z, nest=False):
     >>> hp.vec2pix(16, 1, 0, 0)
     1504
 
-    >>> hp.vec2pix(16, [1, 0], [0, 1], [0, 0])
-    array([1504, 1520])
+    >>> print(hp.vec2pix(16, [1, 0], [0, 1], [0, 0]))
+    [1504 1520]
 
-    >>> hp.vec2pix([1, 2, 4, 8], 1, 0, 0)
-    array([  4,  20,  88, 368])
+    >>> print(hp.vec2pix([1, 2, 4, 8], 1, 0, 0))
+    [  4  20  88 368]
     """
     if nest:
         return pixlib._vec2pix_nest(nside, x, y, z)
@@ -772,11 +772,11 @@ def ring2nest(nside, ipix):
     >>> hp.ring2nest(16, 1504)
     1130
 
-    >>> hp.ring2nest(2, np.arange(10))
-    array([ 3,  7, 11, 15,  2,  1,  6,  5, 10,  9])
+    >>> print(hp.ring2nest(2, np.arange(10)))
+    [ 3  7 11 15  2  1  6  5 10  9]
 
-    >>> hp.ring2nest([1, 2, 4, 8], 11)
-    array([ 11,  13,  61, 253])
+    >>> print(hp.ring2nest([1, 2, 4, 8], 11))
+    [ 11  13  61 253]
     """
     check_nside(nside, nest=True)
     return pixlib._ring2nest(nside, ipix)
@@ -807,11 +807,11 @@ def nest2ring(nside, ipix):
     >>> hp.nest2ring(16, 1130)
     1504
 
-    >>> hp.nest2ring(2, np.arange(10))
-    array([13,  5,  4,  0, 15,  7,  6,  1, 17,  9])
+    >>> print(hp.nest2ring(2, np.arange(10)))
+    [13  5  4  0 15  7  6  1 17  9]
 
-    >>> hp.nest2ring([1, 2, 4, 8], 11)
-    array([ 11,   2,  12, 211])
+    >>> print(hp.nest2ring([1, 2, 4, 8], 11))
+    [ 11   2  12 211]
     """
     check_nside(nside, nest=True)
     return pixlib._nest2ring(nside, ipix)
@@ -1321,23 +1321,35 @@ def get_interp_weights(nside, theta, phi=None, nest=False, lonlat=False):
     Examples
     --------
     >>> import healpy as hp
-    >>> hp.get_interp_weights(1, 0)
-    (array([0, 1, 4, 5]), array([ 1.,  0.,  0.,  0.]))
+    >>> pix, weights = hp.get_interp_weights(1, 0)
+    >>> print(pix)
+    [0 1 4 5]
+    >>> weights
+    array([ 1.,  0.,  0.,  0.])
 
-    >>> hp.get_interp_weights(1, 0, 0)
-    (array([1, 2, 3, 0]), array([ 0.25,  0.25,  0.25,  0.25]))
+    >>> pix, weights = hp.get_interp_weights(1, 0, 0)
+    >>> print(pix)
+    [1 2 3 0]
+    >>> weights
+    array([ 0.25,  0.25,  0.25,  0.25])
 
-    >>> hp.get_interp_weights(1, 0, 90, lonlat=True)
-    (array([1, 2, 3, 0]), array([ 0.25,  0.25,  0.25,  0.25]))
+    >>> pix, weights = hp.get_interp_weights(1, 0, 90, lonlat=True)
+    >>> print(pix)
+    [1 2 3 0]
+    >>> weights
+    array([ 0.25,  0.25,  0.25,  0.25])
 
-    >>> hp.get_interp_weights(1, [0, np.pi/2], 0)
-    (array([[ 1,  4],
-           [ 2,  5],
-           [ 3, 11],
-           [ 0,  8]]), array([[ 0.25,  1.  ],
+    >>> pix, weights = hp.get_interp_weights(1, [0, np.pi/2], 0)
+    >>> print(pix)
+    [[ 1  4]
+     [ 2  5]
+     [ 3 11]
+     [ 0  8]]
+    >>> weights
+    array([[ 0.25,  1.  ],
            [ 0.25,  0.  ],
            [ 0.25,  0.  ],
-           [ 0.25,  0.  ]]))
+           [ 0.25,  0.  ]])
     """
     check_nside(nside, nest=nest)
     if phi is None:
@@ -1384,14 +1396,14 @@ def get_all_neighbours(nside, theta, phi=None, nest=False, lonlat=False):
     Examples
     --------
     >>> import healpy as hp
-    >>> hp.get_all_neighbours(1, 4)
-    array([11,  7,  3, -1,  0,  5,  8, -1])
+    >>> print(hp.get_all_neighbours(1, 4))
+    [11  7  3 -1  0  5  8 -1]
 
-    >>> hp.get_all_neighbours(1, np.pi/2, np.pi/2)
-    array([ 8,  4,  0, -1,  1,  6,  9, -1])
+    >>> print(hp.get_all_neighbours(1, np.pi/2, np.pi/2))
+    [ 8  4  0 -1  1  6  9 -1]
 
-    >>> hp.get_all_neighbours(1, 90, 0, lonlat=True)
-    array([ 8,  4,  0, -1,  1,  6,  9, -1])
+    >>> print(hp.get_all_neighbours(1, 90, 0, lonlat=True))
+    [ 8  4  0 -1  1  6  9 -1]
     """
     check_nside(nside, nest=nest)
     if phi is not None:

--- a/healpy/src/_healpy_pixel_lib.cc
+++ b/healpy/src/_healpy_pixel_lib.cc
@@ -47,19 +47,19 @@ template<Healpix_Ordering_Scheme scheme>static void
   char *ip1=args[0], *ip2=args[1], *ip3=args[2], *op=args[3];
 
   Healpix_Base2 hb;
-  long oldnside=-1;
+  int64 oldnside=-1;
 
   for(npy_intp i=0; i<n; i++, ip1+=is1, ip2+=is2, ip3+=is3, op+=os)
     {
-      long nside = *(long*)ip1;
+      int64 nside = *(int64*)ip1;
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, scheme); }
       try {
         pointing ptg = pointing(*(double *)ip2,*(double *)ip3);
         ptg.normalize();
-        *(long *)op = hb.ang2pix(ptg);
+        *(int64 *)op = hb.ang2pix(ptg);
       } catch(PlanckError &e) {
-        *(long *)op = -1;
+        *(int64 *)op = -1;
       }
   }
 }
@@ -75,15 +75,15 @@ template<Healpix_Ordering_Scheme scheme> static void
   char *ip1=args[0], *ip2=args[1], *op1=args[2], *op2=args[3];
 
   Healpix_Base2 hb;
-  long oldnside=-1;
+  int64 oldnside=-1;
 
   for(i=0; i<n; i++, ip1+=is1, ip2+=is2, op1+=os1, op2+=os2)
     {
-      long nside = *(long*)ip1;
+      int64 nside = *(int64*)ip1;
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, scheme); }
       try {
-        pointing ptg = hb.pix2ang(*(long *)ip2);
+        pointing ptg = hb.pix2ang(*(int64 *)ip2);
         *(double *)op1 = ptg.theta;
         *(double *)op2 = ptg.phi;
       } catch (PlanckError & e) {
@@ -105,17 +105,17 @@ template<Healpix_Ordering_Scheme scheme>static void
   char *ip1=args[0], *ip2=args[1], *ip3=args[2], *ip4=args[3], *op=args[4];
 
   Healpix_Base2 hb;
-  long oldnside=-1;
+  int64 oldnside=-1;
 
   for(npy_intp i=0; i<n; i++, ip1+=is1, ip2+=is2, ip3+=is3, ip4+=is4, op+=os)
     {
-      long nside = *(long*)ip1;
+      int64 nside = *(int64*)ip1;
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, scheme); }
       try {
-        *(long *)op = hb.xyf2pix((int)*(long *)ip2,(int)*(long *)ip3,(int)*(long *)ip4);
+        *(int64 *)op = hb.xyf2pix((int)*(long *)ip2,(int)*(long *)ip3,(int)*(long *)ip4);
       } catch(PlanckError &e) {
-        *(long *)op = -1;
+        *(int64 *)op = -1;
       }
   }
 }
@@ -131,16 +131,16 @@ template<Healpix_Ordering_Scheme scheme> static void
   char *ip1=args[0], *ip2=args[1], *op1=args[2], *op2=args[3], *op3=args[4];
 
   Healpix_Base2 hb;
-  long oldnside=-1;
+  int64 oldnside=-1;
 
   for(i=0; i<n; i++, ip1+=is1, ip2+=is2, op1+=os1, op2+=os2, op3+=os3)
     {
-      long nside = *(long*)ip1;
+      int64 nside = *(int64*)ip1;
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, scheme); }
       try {
         int x, y, f;
-        hb.pix2xyf(*(long *)ip2, x, y, f);
+        hb.pix2xyf(*(int64 *)ip2, x, y, f);
         *(long *)op1 = x;
         *(long *)op2 = y;
         *(long *)op3 = f;
@@ -163,17 +163,17 @@ ufunc_ring2nest(char **args, npy_intp *dimensions, npy_intp *steps, void *func)
   char *ip1=args[0], *ip2=args[1], *op=args[2];
 
   Healpix_Base2 hb;
-  long oldnside=-1;
+  int64 oldnside=-1;
 
   for(i=0; i<n; i++, ip1+=is1, ip2+=is2, op+=os)
     {
-      long nside = *(long*)ip1;
+      int64 nside = *(int64*)ip1;
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, RING); }
       try {
-        *(long *)op = hb.ring2nest(*(long *)ip2);
+        *(int64 *)op = hb.ring2nest(*(int64 *)ip2);
       } catch(PlanckError & e) {
-        *(long *)op = -1;
+        *(int64 *)op = -1;
       }
     }
 }
@@ -189,17 +189,17 @@ static void
   char *ip1=args[0], *ip2=args[1], *op=args[2];
 
   Healpix_Base2 hb;
-  long oldnside=-1;
+  int64 oldnside=-1;
 
   for(i=0; i<n; i++, ip1+=is1, ip2+=is2, op+=os)
     {
-      long nside = *(long*)ip1;
+      int64 nside = *(int64*)ip1;
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, NEST); }
       try {
-        *(long *)op = hb.nest2ring(*(long *)ip2);
+        *(int64 *)op = hb.nest2ring(*(int64 *)ip2);
       } catch(PlanckError & e) {
-        *(long *)op = -1;
+        *(int64 *)op = -1;
       }
     }
 }
@@ -216,15 +216,15 @@ template<Healpix_Ordering_Scheme scheme> static void
   char *ip1=args[0], *ip2=args[1], *op1=args[2], *op2=args[3], *op3=args[4];
 
   Healpix_Base2 hb;
-  long oldnside=-1;
+  int64 oldnside=-1;
 
   for(i=0; i<n; i++, ip1+=is1, ip2+=is2, op1+=os1, op2+=os2, op3+=os3)
     {
-      long nside = *(long*)ip1;
+      int64 nside = *(int64*)ip1;
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, scheme); }
       try {
-        vec3 v = hb.pix2vec(*(long *)ip2);
+        vec3 v = hb.pix2vec(*(int64 *)ip2);
         *(double *)op1 = v.x;
         *(double *)op2 = v.y;
         *(double *)op3 = v.z;
@@ -247,19 +247,19 @@ template<Healpix_Ordering_Scheme scheme> static void
   char *ip1=args[0], *ip2=args[1], *ip3=args[2], *ip4=args[3], *op1=args[4];
 
   Healpix_Base2 hb;
-  long oldnside=-1;
+  int64 oldnside=-1;
 
   for(i=0; i<n; i++, ip1+=is1, ip2+=is2, ip3+=is3, ip4+=is4, op1+=os1)
     {
-      long nside = *(long*)ip1;
+      int64 nside = *(int64*)ip1;
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, scheme); }
       vec3 v (*(double *)ip2,*(double *)ip3,*(double *)ip4);
       try {
-        long ipix = hb.vec2pix(v);
-        *(long *)op1 = ipix;
+        int64 ipix = hb.vec2pix(v);
+        *(int64 *)op1 = ipix;
       } catch (PlanckError &e) {
-        *(long *)op1 = -1;
+        *(int64 *)op1 = -1;
       }
     }
 }
@@ -280,7 +280,7 @@ template<Healpix_Ordering_Scheme scheme> static void
     *op5=args[7],*op6=args[8],*op7=args[9],*op8=args[10];
 
   Healpix_Base2 hb;
-  long oldnside=-1;
+  int64 oldnside=-1;
 
   for(i=0; i<n; i++, ip1+=is1, ip2+=is2, ip3+=is3,
         op1+=os1,op2+=os2,op3+=os3,op4+=os4,
@@ -288,26 +288,26 @@ template<Healpix_Ordering_Scheme scheme> static void
     {
       fix_arr<int64,4> pix;
       fix_arr<double,4> wgt;
-      long nside = *(long*)ip1;
+      int64 nside = *(int64*)ip1;
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, scheme); }
       try {
         pointing ptg = pointing(*(double*)ip2, *(double*)ip3);
         ptg.normalize();
         hb.get_interpol(ptg, pix, wgt);
-        *(long*)op1 = (long)pix[0];
-        *(long*)op2 = (long)pix[1];
-        *(long*)op3 = (long)pix[2];
-        *(long*)op4 = (long)pix[3];
+        *(int64*)op1 = (int64)pix[0];
+        *(int64*)op2 = (int64)pix[1];
+        *(int64*)op3 = (int64)pix[2];
+        *(int64*)op4 = (int64)pix[3];
         *(double*)op5 = wgt[0];
         *(double*)op6 = wgt[1];
         *(double*)op7 = wgt[2];
         *(double*)op8 = wgt[3];
       } catch (PlanckError &e) {
-        *(long*)op1 = -1;
-        *(long*)op2 = -1;
-        *(long*)op3 = -1;
-        *(long*)op4 = -1;
+        *(int64*)op1 = -1;
+        *(int64*)op2 = -1;
+        *(int64*)op3 = -1;
+        *(int64*)op4 = -1;
         *(double*)op5 = NAN;
         *(double*)op6 = NAN;
         *(double*)op7 = NAN;
@@ -337,26 +337,26 @@ template<Healpix_Ordering_Scheme scheme> static void
         op5+=os5,op6+=os6,op7+=os7,op8+=os8 )
     {
       fix_arr<int64,8> pix;
-      hb.SetNside(*(long*)ip1, scheme);
+      hb.SetNside(*(int64*)ip1, scheme);
       try {
-        hb.neighbors(*(long*)ip2, pix);
-        *(long*)op1 = (long)pix[0];
-        *(long*)op2 = (long)pix[1];
-        *(long*)op3 = (long)pix[2];
-        *(long*)op4 = (long)pix[3];
-        *(long*)op5 = (long)pix[4];
-        *(long*)op6 = (long)pix[5];
-        *(long*)op7 = (long)pix[6];
-        *(long*)op8 = (long)pix[7];
+        hb.neighbors(*(int64*)ip2, pix);
+        *(int64*)op1 = (int64)pix[0];
+        *(int64*)op2 = (int64)pix[1];
+        *(int64*)op3 = (int64)pix[2];
+        *(int64*)op4 = (int64)pix[3];
+        *(int64*)op5 = (int64)pix[4];
+        *(int64*)op6 = (int64)pix[5];
+        *(int64*)op7 = (int64)pix[6];
+        *(int64*)op8 = (int64)pix[7];
       } catch (PlanckError & e) {
-        *(long*)op1 = -1;
-        *(long*)op2 = -1;
-        *(long*)op3 = -1;
-        *(long*)op4 = -1;
-        *(long*)op5 = -1;
-        *(long*)op6 = -1;
-        *(long*)op7 = -1;
-        *(long*)op8 = -1;
+        *(int64*)op1 = -1;
+        *(int64*)op2 = -1;
+        *(int64*)op3 = -1;
+        *(int64*)op4 = -1;
+        *(int64*)op5 = -1;
+        *(int64*)op6 = -1;
+        *(int64*)op7 = -1;
+        *(int64*)op8 = -1;
       }
     }
 }
@@ -372,11 +372,11 @@ static void
   char *ip1=args[0], *op1=args[1];
 
   Healpix_Base2 hb;
-  long oldnside=-1;
+  int64 oldnside=-1;
 
   for(i=0; i<n; i++, ip1+=is1, op1+=os1)
     {
-      long nside = *(long*)ip1;
+      int64 nside = *(int64*)ip1;
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, NEST);
         	/* ring and nest should give the same result */
@@ -458,43 +458,43 @@ static PyUFuncGenericFunction max_pixrad_functions[] = {
 static void * blank_data[] = { (void *)NULL };
 
 static char ang2pix_signatures[] = {
-  PyArray_LONG, PyArray_DOUBLE, PyArray_DOUBLE, PyArray_LONG
+  PyArray_INT64, PyArray_DOUBLE, PyArray_DOUBLE, PyArray_INT64
 };
 static char pix2ang_signatures[] = {
-  PyArray_LONG, PyArray_LONG, PyArray_DOUBLE, PyArray_DOUBLE
+  PyArray_INT64, PyArray_INT64, PyArray_DOUBLE, PyArray_DOUBLE
 };
 static char xyf2pix_signatures[] = {
-  PyArray_LONG, PyArray_LONG, PyArray_LONG, PyArray_LONG, PyArray_LONG
+  PyArray_INT64, PyArray_LONG, PyArray_LONG, PyArray_LONG, PyArray_INT64
 };
 static char pix2xyf_signatures[] = {
-  PyArray_LONG, PyArray_LONG, PyArray_LONG, PyArray_LONG, PyArray_LONG
+  PyArray_INT64, PyArray_INT64, PyArray_LONG, PyArray_LONG, PyArray_LONG
 };
 static char pix2vec_signatures[] = {
-  PyArray_LONG, PyArray_LONG, PyArray_DOUBLE, PyArray_DOUBLE, PyArray_DOUBLE
+  PyArray_INT64, PyArray_INT64, PyArray_DOUBLE, PyArray_DOUBLE, PyArray_DOUBLE
 };
 static char vec2pix_signatures[] = {
-  PyArray_LONG, PyArray_DOUBLE, PyArray_DOUBLE, PyArray_DOUBLE, PyArray_LONG
+  PyArray_INT64, PyArray_DOUBLE, PyArray_DOUBLE, PyArray_DOUBLE, PyArray_INT64
 };
 static char ring2nest_signatures[] = {
-  PyArray_LONG, PyArray_LONG, PyArray_LONG
+  PyArray_INT64, PyArray_INT64, PyArray_INT64
 };
 static char get_interpol_signatures[] = {
-  PyArray_LONG, PyArray_DOUBLE, PyArray_DOUBLE,
-  PyArray_LONG, PyArray_LONG, PyArray_LONG, PyArray_LONG,
+  PyArray_INT64, PyArray_DOUBLE, PyArray_DOUBLE,
+  PyArray_INT64, PyArray_INT64, PyArray_INT64, PyArray_INT64,
   PyArray_DOUBLE, PyArray_DOUBLE, PyArray_DOUBLE, PyArray_DOUBLE
 };
 static char get_neighbors_ring_signatures[] = {
-  PyArray_LONG, PyArray_LONG, // input
-  PyArray_LONG, PyArray_LONG, PyArray_LONG, PyArray_LONG, // output
-  PyArray_LONG, PyArray_LONG, PyArray_LONG, PyArray_LONG // output
+  PyArray_INT64, PyArray_INT64, // input
+  PyArray_INT64, PyArray_INT64, PyArray_INT64, PyArray_INT64, // output
+  PyArray_INT64, PyArray_INT64, PyArray_INT64, PyArray_INT64 // output
 };
 static char get_neighbors_nest_signatures[] = {
-  PyArray_LONG, PyArray_LONG, // input
-  PyArray_LONG, PyArray_LONG, PyArray_LONG, PyArray_LONG, // output
-  PyArray_LONG, PyArray_LONG, PyArray_LONG, PyArray_LONG // output
+  PyArray_INT64, PyArray_INT64, // input
+  PyArray_INT64, PyArray_INT64, PyArray_INT64, PyArray_INT64, // output
+  PyArray_INT64, PyArray_INT64, PyArray_INT64, PyArray_INT64 // output
 };
 static char max_pixrad_signatures[] = {
-  PyArray_LONG, PyArray_DOUBLE
+  PyArray_INT64, PyArray_DOUBLE
 };
 
 #if PY_MAJOR_VERSION >= 3

--- a/healpy/test/test_pixelfunc.py
+++ b/healpy/test/test_pixelfunc.py
@@ -162,7 +162,7 @@ class TestPixelFunc(unittest.TestCase):
             numPix = nside2npix(nside)
             numRings = 4 * nside - 1  # Expected number of rings
             for nest in (True, False):
-                pix = np.arange(numPix)
+                pix = np.arange(numPix, dtype=np.int64)
                 ring = pix2ring(nside, pix, nest=nest)
                 self.assertTrue(pix.shape == ring.shape)
                 self.assertTrue(len(set(ring)) == numRings)


### PR DESCRIPTION
All of the pixel ufuncs use Healpix_Base2, which has 64 bit pixel
indices. However, it declares arguments as longs, which are not
necessarily a 64 bit data type (on armhf, they are 32 bit).

Fixing this allows us to manipulate 64 bit pixel indices even on
32 bit machines.