### PR TITLE
Allow user to set the background and UNSEEN colors in calls to *view()

### DIFF
--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -139,6 +139,8 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         vmin=None,
         vmax=None,
         badval=UNSEEN,
+        badcolor="gray",
+        bgcolor="white",
         cmap=None,
         norm=None,
         rot=None,
@@ -157,6 +159,10 @@ class SphericalProjAxes(matplotlib.axes.Axes):
           min and max value to use instead of min max of the map
         badval : float
           The value of the bad pixels
+        badcolor : str
+          Color to use to plot bad values
+        bgcolor : str
+          Color to use for background
         cmap : a color map
           The colormap to use (see matplotlib.cm)
         rot : sequence
@@ -187,7 +193,8 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         if vmin == vmax:
             vmin -= 1.0
             vmax += 1.0
-        cm, nn = get_color_table(vmin, vmax, img[w], cmap=cmap, norm=norm)
+        cm, nn = get_color_table(vmin, vmax, img[w], cmap=cmap, norm=norm,
+                                 badcolor=badcolor, bgcolor=bgcolor)
         ext = self.proj.get_extent()
         img = np.ma.masked_values(img, badval)
         aximg = self.imshow(
@@ -860,9 +867,10 @@ class HpxAzimuthalAxes(AzimuthalAxes):
 #   http://matplotlib.org/examples/pylab_examples/custom_cmap.html
 
 
-def get_color_table(vmin, vmax, val, cmap=None, norm=None):
+def get_color_table(vmin, vmax, val, cmap=None, norm=None,
+                    badcolor="gray", bgcolor="white"):
     # Create color table
-    newcmap = create_colormap(cmap)
+    newcmap = create_colormap(cmap, badcolor=badcolor, bgcolor=bgcolor)
     if type(norm) is str:
         if norm.lower().startswith("log"):
             norm = LogNorm2(clip=False)
@@ -880,7 +888,7 @@ def get_color_table(vmin, vmax, val, cmap=None, norm=None):
     return newcmap, norm
 
 
-def create_colormap(cmap):
+def create_colormap(cmap, badcolor="gray", bgcolor="white"):
     if type(cmap) == str:
         cmap0 = matplotlib.cm.get_cmap(cmap)
     elif type(cmap) in [
@@ -897,8 +905,8 @@ def create_colormap(cmap):
     else:
         newcm = cmap0
     newcm.set_over(newcm(1.0))
-    newcm.set_under("w")
-    newcm.set_bad("gray")
+    newcm.set_under(bgcolor)
+    newcm.set_bad(badcolor)
     return newcm
 
 

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -89,6 +89,8 @@ def mollview(
     format2="%g",
     cbar=True,
     cmap=None,
+    badcolor="gray",
+    bgcolor="white",
     notext=False,
     norm=None,
     hold=False,
@@ -148,6 +150,12 @@ def mollview(
     norm : {'hist', 'log', None}
       Color normalization, hist= histogram equalized color mapping,
       log= logarithmic color mapping, default: None (linear color mapping)
+    cmap : a color map
+       The colormap to use (see matplotlib.cm)
+    badcolor : str
+      Color to use to plot bad values
+    bgcolor : str
+      Color to use for background
     hold : bool, optional
       If True, replace the current Axes by a MollweideAxes.
       use this if you want to have multiple maps on the same
@@ -236,6 +244,8 @@ def mollview(
             vmin=min,
             vmax=max,
             cmap=cmap,
+            badcolor=badcolor,
+            bgcolor=bgcolor,
             norm=norm,
         )
         if cbar:
@@ -321,6 +331,8 @@ def gnomview(
     format="%.3g",
     cbar=True,
     cmap=None,
+    badcolor="gray",
+    bgcolor="white",
     norm=None,
     hold=False,
     sub=None,
@@ -376,6 +388,12 @@ def gnomview(
       Removes points in latitude range [-gal_cut, +gal_cut]
     format : str, optional
       The format of the scale label. Default: '%g'
+    cmap : a color map
+       The colormap to use (see matplotlib.cm)
+    badcolor : str
+      Color to use to plot bad values
+    bgcolor : str
+      Color to use for background
     hold : bool, optional
       If True, replace the current Axes by a MollweideAxes.
       use this if you want to have multiple maps on the same
@@ -469,6 +487,8 @@ def gnomview(
             reso=reso,
             cmap=cmap,
             norm=norm,
+            badcolor=badcolor,
+            bgcolor=bgcolor,
         )
         if cbar:
             im = ax.get_images()[0]
@@ -583,6 +603,8 @@ def cartview(
     format="%.3g",
     cbar=True,
     cmap=None,
+    badcolor="gray",
+    bgcolor="white",
     norm=None,
     aspect=None,
     hold=False,
@@ -645,6 +667,12 @@ def cartview(
     norm : {'hist', 'log', None}, optional
       Color normalization, hist= histogram equalized color mapping,
       log= logarithmic color mapping, default: None (linear color mapping)
+    cmap : a color map
+       The colormap to use (see matplotlib.cm)
+    badcolor : str
+      Color to use to plot bad values
+    bgcolor : str
+      Color to use for background
     hold : bool, optional
       If True, replace the current Axes by a CartesianAxes.
       use this if you want to have multiple maps on the same
@@ -740,6 +768,8 @@ def cartview(
             lonra=lonra,
             latra=latra,
             cmap=cmap,
+            badcolor=badcolor,
+            bgcolor=bgcolor,
             norm=norm,
             aspect=aspect,
         )
@@ -827,6 +857,8 @@ def orthview(
     format2="%g",
     cbar=True,
     cmap=None,
+    badcolor="gray",
+    bgcolor="white",
     notext=False,
     norm=None,
     hold=False,
@@ -887,6 +919,12 @@ def orthview(
     norm : {'hist', 'log', None}
       Color normalization, hist= histogram equalized color mapping,
       log= logarithmic color mapping, default: None (linear color mapping)
+    cmap : a color map
+       The colormap to use (see matplotlib.cm)
+    badcolor : str
+      Color to use to plot bad values
+    bgcolor : str
+      Color to use for background
     hold : bool, optional
       If True, replace the current Axes by an OrthographicAxes.
       use this if you want to have multiple maps on the same
@@ -975,6 +1013,8 @@ def orthview(
             vmin=min,
             vmax=max,
             cmap=cmap,
+            badcolor=badcolor,
+            bgcolor=bgcolor,
             norm=norm,
         )
         if cbar:
@@ -1063,6 +1103,8 @@ def azeqview(
     format="%.3g",
     cbar=True,
     cmap=None,
+    badcolor="gray",
+    bgcolor="white",
     norm=None,
     aspect=None,
     hold=False,
@@ -1132,6 +1174,12 @@ def azeqview(
     norm : {'hist', 'log', None}
       Color normalization, hist= histogram equalized color mapping,
       log= logarithmic color mapping, default: None (linear color mapping)
+    cmap : a color map
+       The colormap to use (see matplotlib.cm)
+    badcolor : str
+      Color to use to plot bad values
+    bgcolor : str
+      Color to use for background
     hold : bool, optional
       If True, replace the current Axes by an Equidistant AzimuthalAxes.
       use this if you want to have multiple maps on the same
@@ -1223,6 +1271,8 @@ def azeqview(
             vmin=min,
             vmax=max,
             cmap=cmap,
+            badcolor=badcolor,
+            bgcolor=bgcolor,
             norm=norm,
         )
         if cbar:


### PR DESCRIPTION
Users can set the color map used to plot the Healpix maps but they have no way to adjust the way the background and UNSEEN pixels are plotted.

This pull request adds two keyword parameters to mollview, orthview, gnomview and azeqview:
* badcolor to set the value used to plot bad values
* bgcolor to set the value of the background
both of these values default to the current library defaults: "gray" for UNSEEN values and "white" for background.