### PR TITLE
Update sphtfunc.py

### DIFF
--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -24,7 +24,7 @@ import six
 pi = np.pi
 import warnings
 import astropy.io.fits as pf
-from scipy.integrate import simps
+from scipy.integrate import trapz
 from astropy.utils import data
 
 DATAURL = "https://healpy.github.io/healpy-data/"
@@ -1175,12 +1175,12 @@ def beam2bl(beam, theta, lmax):
     p0 = np.ones(nx)
     p1 = np.copy(x)
 
-    window[0] = simps(beam * p0 * st, theta)
-    window[1] = simps(beam * p1 * st, theta)
+    window[0] = trapz(beam * p0 * st, theta)
+    window[1] = trapz(beam * p1 * st, theta)
 
     for l in np.arange(2, lmax + 1):
         p2 = x * p1 * (2 * l - 1) / l - p0 * (l - 1) / l
-        window[l] = simps(beam * p2 * st, theta)
+        window[l] = trapz(beam * p2 * st, theta)
         p0 = p1
         p1 = p2
 

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -378,7 +378,7 @@ class TestSphtFunc(unittest.TestCase):
         gaussian_window = np.exp(-0.5 * ell * (ell + 1) * sigma ** 2)
 
         bl = hp.beam2bl(gaussian_beam, theta, 512)
-        np.testing.assert_allclose(gaussian_window, bl, rtol=1e-5)
+        np.testing.assert_allclose(gaussian_window, bl, rtol=1e-4)
 
     def test_bl2beam(self):
         """ Test bl2beam against analytical transform of Gaussian beam. """


### PR DESCRIPTION
Simpson's rule is unstable for integrating noisy beams, while the trapezoidal rule doesn't throw an error. The difference should be negligible in the high signal-to-noise case.