### PR TITLE
Complete conversion of deprecated calls: matplotlib.cbook.iterable -> np.iterable.

### DIFF
--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -963,7 +963,7 @@ class HistEqNorm(matplotlib.colors.Normalize):
         if clip is None:
             clip = self.clip
 
-        if matplotlib.cbook.iterable(value):
+        if np.iterable(value):
             vtype = "array"
             val = np.ma.asarray(value).astype(np.float)
         else:
@@ -993,7 +993,7 @@ class HistEqNorm(matplotlib.colors.Normalize):
         if not self.scaled():
             raise ValueError("Not invertible until scaled")
 
-        if matplotlib.cbook.iterable(value):
+        if np.iterable(value):
             vtype = "array"
             val = np.ma.array(value)
         else:
@@ -1096,7 +1096,7 @@ class LogNorm2(matplotlib.colors.Normalize):
         if clip is None:
             clip = self.clip
 
-        if matplotlib.cbook.iterable(value):
+        if np.iterable(value):
             vtype = "array"
             val = np.ma.asarray(value).astype(np.float)
         else:


### PR DESCRIPTION
This completes the work from a previous merged pull request https://github.com/healpy/healpy/pull/563 by replacing the remaining matplotlib.cbook.iterable calls with np.iterable calls.