### PR TITLE
Cast argument to sqrt to float to prevent overflow

### DIFF
--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -595,7 +595,7 @@ def alm_getlmmax(a, lmax, mmax):
 @cython.cdivision(True)
 cdef inline int alm_getlmax(int s):
     cdef double x
-    x=(-3+np.sqrt(1+8*s))/2
+    x=(-3+np.sqrt(1.+8.*s))/2
     if x != floor(x):
         return -1
     else:


### PR DESCRIPTION
In _sphtools.alm_getlmax(int s),  the line x=(-3+np.sqrt(1+8*s))/2 results in a negative sqrt for very large sizes (starting at nside=8192). Casting to a float is an easy fix, but we should keep an eye out for similar issues as they'll occur more often in the near future.

Addresses https://github.com/healpy/healpy/issues/572