### PR TITLE
Allow non-power-of-two nside values when the pixel scheme is RING

### DIFF
--- a/healpy/src/_pixelfunc.pyx
+++ b/healpy/src/_pixelfunc.pyx
@@ -6,6 +6,8 @@ from libcpp cimport bool
 cimport cython
 from _common cimport int64, Healpix_Ordering_Scheme, RING, NEST, SET_NSIDE, T_Healpix_Base
 
+from pixelfunc import isnsideok
+
 def ringinfo(nside, np.ndarray[int64, ndim=1] ring not None):
     """Get information for rings
 
@@ -97,16 +99,3 @@ def pix2ring(nside, np.ndarray[int64, ndim=1] pix not None, nest=False):
     for i in range(num):
         ring[i] = hb.pix2ring(pix[i])
     return ring
-
-
-def isnsideok(int nside, bool nest=False):
-    """
-        Check whether the nside value is sensible.
-        If nest is true, then it should be a power of 2
-        otherwise just positive.
-    """
-    if nest:
-        return nside > 0 and ((nside & (nside -1))==0)
-    else:
-        return nside > 0
-    

--- a/healpy/src/_pixelfunc.pyx
+++ b/healpy/src/_pixelfunc.pyx
@@ -99,5 +99,14 @@ def pix2ring(nside, np.ndarray[int64, ndim=1] pix not None, nest=False):
     return ring
 
 
-cdef bool isnsideok(int nside, bool nest=False):
-    return (nside > 0) and ((not nest) or ((nside&(nside-1))==0))
+def isnsideok(int nside, bool nest=False):
+    """
+        Check whether the nside value is sensible.
+        If nest is true, then it should be a power of 2
+        otherwise just positive.
+    """
+    if nest:
+        return nside > 0 and ((nside & (nside -1))==0)
+    else:
+        return nside > 0
+    

--- a/healpy/src/_query_disc.pyx
+++ b/healpy/src/_query_disc.pyx
@@ -50,7 +50,7 @@ def query_disc(nside, vec, radius, inclusive = False, fact = 4, nest = False, np
     are returned, at the cost of increased run time.
     """
     # Check Nside value
-    if not isnsideok(nside):
+    if not isnsideok(nside, nest):
         raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     cdef vec3 v = vec3(vec[0], vec[1], vec[2])
     cdef Healpix_Ordering_Scheme scheme
@@ -113,7 +113,7 @@ def query_polygon(nside, vertices, inclusive = False, fact = 4, nest = False, np
     are returned, at the cost of increased run time.
     """
     # Check Nside value
-    if not isnsideok(nside):
+    if not isnsideok(nside, nest):
         raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     # Create vector of vertices
     cdef vector[pointing] vert
@@ -174,7 +174,7 @@ def query_strip(nside, theta1, theta2, inclusive = False, nest = False, np.ndarr
       The pixels which lie within the given strip.
     """
     # Check Nside value
-    if not isnsideok(nside):
+    if not isnsideok(nside, nest):
         raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     # Create the Healpix_Base2 structure
     cdef Healpix_Ordering_Scheme scheme
@@ -275,7 +275,7 @@ def boundaries(nside, pix, step=1, nest=False):
     # doctest moved to test_query_disc.py
     """
 
-    if not isnsideok(nside):
+    if not isnsideok(nside, nest):
         raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     if np.isscalar(pix):
         if not np.can_cast(type(pix), np.int):
@@ -295,7 +295,7 @@ def boundaries(nside, pix, step=1, nest=False):
 ### @cython.wraparound(False)
 ### def pix2ang(nside, ipix, nest = False):
 ###     # Check Nside value
-###     if not isnsideok(nside):
+###     if not isnsideok(nside, nest):
 ###         raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
 ###     # Create the Healpix_Base2 structure
 ###     cdef Healpix_Ordering_Scheme scheme
@@ -344,8 +344,11 @@ cdef pixset_to_array(rangeset[int64] &pixset, buff=None):
             ii += 1
     return ipix
 
-cdef bool isnsideok(int nside):
-     return nside > 0 and ((nside & (nside -1))==0)
+cdef bool isnsideok(int nside, bool nest):
+    if nest:
+        return nside > 0 and ((nside & (nside -1))==0)
+    else:
+        return nside > 0
     
 
 

--- a/healpy/src/_query_disc.pyx
+++ b/healpy/src/_query_disc.pyx
@@ -7,6 +7,7 @@ from libcpp.vector cimport vector
 cimport cython
 
 from _common cimport int64, pointing, rangeset, vec3, Healpix_Ordering_Scheme, RING, NEST, SET_NSIDE, T_Healpix_Base
+from _pixelfunc import isnsideok
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -344,11 +345,5 @@ cdef pixset_to_array(rangeset[int64] &pixset, buff=None):
             ii += 1
     return ipix
 
-cdef bool isnsideok(int nside, bool nest):
-    if nest:
-        return nside > 0 and ((nside & (nside -1))==0)
-    else:
-        return nside > 0
-    
 
 

--- a/healpy/test/test_pixelfunc.py
+++ b/healpy/test/test_pixelfunc.py
@@ -1,6 +1,6 @@
 from ..pixelfunc import *
 from .._query_disc import boundaries
-from .._pixelfunc import ringinfo, pix2ring
+from .._pixelfunc import ringinfo, pix2ring, isnsideok
 import numpy as np
 import unittest
 
@@ -180,6 +180,15 @@ class TestPixelFunc(unittest.TestCase):
             ud_grade(map_in=ma, nside_out=32)
         except IndexError:
             self.fail("IndexError raised")
+
+    def test_isnsideok(self):
+        """ Test the isnsideok."""
+        self.assertTrue(isnsideok(nside=1, nest=False))
+        self.assertTrue(isnsideok(nside=16, nest=True))
+
+        self.assertTrue(not isnsideok(nside=-16, nest=True))
+        self.assertTrue(not isnsideok(nside=-16, nest=False))
+        self.assertTrue(not isnsideok(nside=13, nest=True))
 
 
 if __name__ == "__main__":

--- a/healpy/test/test_query_disc.py
+++ b/healpy/test/test_query_disc.py
@@ -73,8 +73,8 @@ class TestQueryDisc(unittest.TestCase):
             corners, self.nside2_55_corners_precomp, decimal=8
         )
 
-    # For RING scheme, nside should not need to be a power of two.
     def test_nside_non_power_of_two(self):
+        # For RING scheme, nside should not need to be a power of two.
 
         nside = 1
         resolution = 1.0

--- a/healpy/test/test_query_disc.py
+++ b/healpy/test/test_query_disc.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from .. import query_disc, boundaries, nside2npix
+from .. import query_disc, boundaries, nside2npix, nside2resol, ang2vec
 
 try:
     from exceptions import ValueError
@@ -73,6 +73,28 @@ class TestQueryDisc(unittest.TestCase):
             corners, self.nside2_55_corners_precomp, decimal=8
         )
 
+    # For RING scheme, nside should not need to be a power of two.
+    def test_nside_non_power_of_two(self):
+
+        nside = 1
+        resolution = 1.0
+        theta=0.0
+        phi=0.0
+        radius = np.radians(1)
+        while True:
+            nside = nside + 1 
+            res = nside2resol(nside, arcmin = True)
+            print("nside={} res={} arcmin".format(nside, res))
+            if res < resolution:
+                break
+            
+        self.assertEqual(nside, 3518)
+        
+        x0 = ang2vec(theta, phi)
+        
+        pixel_indices = query_disc(nside, x0, radius, inclusive=False, nest=False)
+        self.assertEqual(pixel_indices.shape[0], 11400)
+        
     def test_boundaries_floatpix_array(self):
         self.assertRaises(ValueError, boundaries, 2, np.array([5.0, 5]))
 


### PR DESCRIPTION
Hi There,

This PR changes the isnsideok() function to allow non-power-of-two nside values (when using the RING scheme). This is useful when searching for a pixelization scheme that is just high enough - which can lead to huge efficiencies in the situation where one is discretizing a small subset of the sphere at high resolution.

The test is somewhat application specific (to suit my needs) so apologies in advance for that.

Refers to Issue #583.

Tim