### PR TITLE
try to make dtype defaults more consistent

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -346,6 +346,14 @@ def read_map(
     m | (m0, m1, ...) [, header] : array or a tuple of arrays, optionally with header appended
       The map(s) read from the file, and the header if *h* is True.
     """
+    # Temporary warning for default dtype
+    if dtype == np.float64:
+        warnings.warn(
+            "If you are not specifying the input dtype and using the default "
+            "np.float64 dtype of read_map(), please consider that it will "
+            "change in a future version to None as to keep the same dtype of "
+            "the input file: please explicitly set the dtype if it is "
+            "important to you.")
 
     fits_hdu = _get_hdu(filename, hdu=hdu, memmap=memmap)
 
@@ -412,9 +420,6 @@ def read_map(
             fits_hdu.verify("fix")
             pix = fits_hdu.data.field(0).astype(int, copy=False).ravel()
 
-    #FIXME: at some point in the future, add:
-    # if dtype is None:
-    #     dtype = [fits_hdu.data.field(ff).dtype for ff in field]
     try:
         assert len(dtype) == len(
             field

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -288,7 +288,7 @@ def write_map(
 def read_map(
     filename,
     field=0,
-    dtype=None,
+    dtype=42,
     nest=False,
     partial=False,
     hdu=1,
@@ -313,7 +313,8 @@ def read_map(
     dtype : data type or list of data types, optional
       Force the conversion to some type. Passing a list allows different
       types for each field. In that case, the length of the list must
-      correspond to the length of the field parameter. Default: np.float64
+      correspond to the length of the field parameter.
+      If None, keep the dtype of the input FITS file
       Default: use np.float64
       (WARNING: in a future version this will change to
       "use the data type of the input FITS file".)
@@ -411,7 +412,10 @@ def read_map(
             fits_hdu.verify("fix")
             pix = fits_hdu.data.field(0).astype(int, copy=False).ravel()
 
-    if dtype is None:
+    # This is extremely ugly, but I couldn't think of another way to decide
+    # when to print the warning.
+    # In the future, the default value should be changed to None, of course.
+    if dtype == 42:
         warnings.warn(
             "The default dtype of read_map() will change in a future version: "
             "explicitly set the dtype if it is important to you",

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -288,7 +288,7 @@ def write_map(
 def read_map(
     filename,
     field=0,
-    dtype=42,
+    dtype=np.float64,
     nest=False,
     partial=False,
     hdu=1,
@@ -412,17 +412,9 @@ def read_map(
             fits_hdu.verify("fix")
             pix = fits_hdu.data.field(0).astype(int, copy=False).ravel()
 
-    # This is extremely ugly, but I couldn't think of another way to decide
-    # when to print the warning.
-    # In the future, the default value should be changed to None, of course.
-    if dtype == 42:
-        warnings.warn(
-            "The default dtype of read_map() will change in a future version: "
-            "explicitly set the dtype if it is important to you",
-            category=FutureWarning)
-        dtype = [np.float64 for ff in field]
-        # Change this at some point to:
-        # dtype = [fits_hdu.data.field(ff).dtype for ff in field]
+    #FIXME: at some point in the future, add:
+    # if dtype is None:
+    #     dtype = [fits_hdu.data.field(ff).dtype for ff in field]
     try:
         assert len(dtype) == len(
             field

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -79,13 +79,20 @@ def write_cl(filename, cl, dtype=None, overwrite=False):
       the cl array to write to file
     dtype : np.dtype (optional)
       The datatype in which the columns will be stored. If not supplied,
-      the type of cl will be used.
+      np.float64 will be assumed.
+      (WARNING: in some future version, the type of cl will be used instead.)
     overwrite : bool, optional
       If True, existing file is silently overwritten. Otherwise trying to write
       an existing file raises an OSError (IOError for Python 2).
     """
     if dtype is None:
-        dtype = cl.dtype if isinstance(cl, np.ndarray) else cl[0].dtype
+        warnings.warn(
+            "The default dtype of write_cl() will change in a future version: "
+            "explicitly set the dtype if it is important to you",
+            category=FutureWarning)
+        dtype = np.float64
+        # At some poin change this to:
+        # dtype = cl.dtype if isinstance(cl, np.ndarray) else cl[0].dtype
     # check the dtype and convert it
     fitsformat = getformat(dtype)
     column_names = ["TEMPERATURE", "GRADIENT", "CURL", "G-T", "C-T", "C-G"]
@@ -158,7 +165,9 @@ def write_map(
       The datatype in which the columns will be stored. Will be converted
       internally from the numpy datatype to the fits convention. If a list,
       the length must correspond to the number of map arrays.
-      Default: use the data type of the input array(s).
+      Default: use np.float32
+      (WARNING: in a future version this will change to
+      "use the data type of the input array(s)".)
     overwrite : bool, optional
       If True, existing file is silently overwritten. Otherwise trying to write
       an existing file raises an OSError (IOError for Python 2).
@@ -172,7 +181,13 @@ def write_map(
 
     # check the dtype and convert it
     if dtype is None:
-        dtype = [x.dtype for x in m]
+        warnings.warn(
+            "The default dtype of write_map() will change in a future version: "
+            "explicitly set the dtype if it is important to you",
+            category=FutureWarning)
+        dtype = [np.float32 for x in m]
+        # Change this at some point to:
+        # dtype = [x.dtype for x in m]
     try:
         fitsformat = []
         for curr_dtype in dtype:
@@ -299,7 +314,9 @@ def read_map(
       Force the conversion to some type. Passing a list allows different
       types for each field. In that case, the length of the list must
       correspond to the length of the field parameter. Default: np.float64
-      if None, keep the dtype of the input FITS file
+      Default: use np.float64
+      (WARNING: in a future version this will change to
+      "use the data type of the input FITS file".)
     nest : bool, optional
       If True return the map in NEST ordering, otherwise in RING ordering;
       use fits keyword ORDERING to decide whether conversion is needed or not
@@ -395,7 +412,13 @@ def read_map(
             pix = fits_hdu.data.field(0).astype(int, copy=False).ravel()
 
     if dtype is None:
-        dtype = [fits_hdu.data.field(ff).dtype for ff in field]
+        warnings.warn(
+            "The default dtype of read_map() will change in a future version: "
+            "explicitly set the dtype if it is important to you",
+            category=FutureWarning)
+        dtype = [np.float64 for ff in field]
+        # Change this at some point to:
+        # dtype = [fits_hdu.data.field(ff).dtype for ff in field]
     try:
         assert len(dtype) == len(
             field

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -151,6 +151,7 @@ class TestSphtFunc(unittest.TestCase):
                 "wmap_band_iqumap_r9_7yr_W_v4_udgraded32_smoothed10deg_fortran.fits",
             ),
             (0, 1, 2),
+            np.float64
         )
         np.testing.assert_array_almost_equal(smoothed, smoothed_f90, decimal=6)
 
@@ -164,6 +165,7 @@ class TestSphtFunc(unittest.TestCase):
                     "wmap_band_iqumap_r9_7yr_W_v4_udgraded32_masked_smoothed10deg_fortran.fits",
                 ),
                 (0, 1, 2),
+                np.float64
             )
         )
         # fortran does not restore the mask


### PR DESCRIPTION
related to #585 

I don't know the procedure how to make compatibility warnings (as @crosset suggested), but can add these as soon as someone has told me :).