### PR TITLE
Add hotspot support in healpy

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ include healpy/src/_query_disc.cpp
 include healpy/src/_sphtools.cpp
 include healpy/src/_pixelfunc.cpp
 include healpy/src/_masktools.cpp
+include healpy/src/_hotspots.cpp
 include healpy/src/_common.pxd
 include healpy/src/_query_disc.pyx
 include healpy/src/_sphtools.pyx

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ exclude *.a
 exclude .gitignore .gitmodules .travis.yml clean.sh
 include COPYING CITATION INSTALL.rst README.rst MANIFEST.in CHANGELOG.rst ez_setup.py run_pykg_config.py
 include healpy/src/_healpy_utils.h
+include healpy/src/_healpy_hotspots_lib.h
 include healpy/src/_query_disc.cpp
 include healpy/src/_sphtools.cpp
 include healpy/src/_pixelfunc.cpp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,4 +17,4 @@ include healpy/src/_query_disc.pyx
 include healpy/src/_sphtools.pyx
 include healpy/src/_pixelfunc.pyx
 include healpy/src/_masktools.pyx
-
+include healpy/src/_hotspots.pyx

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -102,3 +102,4 @@ from .visufunc import (
 from .zoomtool import mollzoom, set_g_clim
 from .fitsfunc import write_map, read_map, read_alm, write_alm, write_cl, read_cl
 from ._masktools import dist2holes_healpy as dist2holes
+from ._hotspots import hotspots_healpy as hotspots

--- a/healpy/src/_healpy_hotspots_lib.cc
+++ b/healpy/src/_healpy_hotspots_lib.cc
@@ -1,0 +1,32 @@
+#include "_healpy_hotspots_lib.h"
+
+void hotspots(const Healpix_Map<double> & inmap,
+              Healpix_Map<double> & outmap,
+              std::vector<int> & min_pixels,
+              std::vector<int> & max_pixels)
+{
+  outmap.Set(inmap.Order(),inmap.Scheme());
+
+  const int npix = inmap.Npix();
+  min_pixels.reserve(npix);
+  max_pixels.reserve(npix);
+// #pragma omp parallel for schedule(dynamic,10000)
+  for (int m=0; m<npix; ++m) {
+    const double value = inmap[m];
+    if (approx<double>(value, Healpix_undef)) continue;
+    fix_arr<int,8> nb;
+    inmap.neighbors(m,nb);
+    bool is_max = true, is_min = true;
+    for (tsize n=0; n<nb.size(); ++n) {
+      if (nb[n] == -1) continue;
+      const float nbval = inmap[nb[n]];
+      if (approx<double>(nbval, Healpix_undef)) continue;
+      if (nbval>=value) is_max = false;
+      if (nbval<=value) is_min = false;
+    }
+    outmap[m] = (is_max || is_min) ? value : Healpix_undef;
+    if (is_min) min_pixels.push_back(m);
+    if (is_max) max_pixels.push_back(m);
+  }
+
+}

--- a/healpy/src/_healpy_hotspots_lib.h
+++ b/healpy/src/_healpy_hotspots_lib.h
@@ -1,0 +1,12 @@
+#ifndef HEALPIX_HOTSPOTS_H
+#define HEALPIX_HOTSPOTS_H
+
+#include <vector>
+#include "healpix_map.h"
+
+void hotspots(const Healpix_Map<double> & inmap,
+              Healpix_Map<double> & outmap,
+              std::vector<int> & min_pixels,
+              std::vector<int> & max_pixels);
+
+#endif

--- a/healpy/src/_hotspots.pyx
+++ b/healpy/src/_hotspots.pyx
@@ -3,12 +3,11 @@ cimport numpy as np
 from libcpp.vector cimport vector
 
 import cython
-from healpy import npix2nside, nside2npix
 from healpy.pixelfunc import maptype
 
 from _common cimport Healpix_Map, RING, ndarray2map
 
-cdef extern from "hotspots.h":
+cdef extern from "_healpy_hotspots_lib.h":
     cdef void hotspots(const Healpix_Map[double] &inmap,
                        Healpix_Map[double] &outmap,
                        vector[int] &maskmin,

--- a/healpy/src/_hotspots.pyx
+++ b/healpy/src/_hotspots.pyx
@@ -16,6 +16,11 @@ cdef extern from "_healpy_hotspots_lib.h":
 def hotspots_healpy(m):
     """Find extrema in the 2-D field on the sphere.
 
+    This routine finds the local extrema in (for example) the CMB temperature field to compute a
+    projection of the angular correlation function of the CMB. Applications of this function can be
+    found in WMAP paper (https://arxiv.org/pdf/1001.4538.pdf) as well as recent work done by Planck
+    (https://arxiv.org/pdf/1303.5062.pdf, https://arxiv.org/abs/1506.07135).
+
     Parameters
     ----------
     m : array-like, shape (Npix,)

--- a/healpy/src/_hotspots.pyx
+++ b/healpy/src/_hotspots.pyx
@@ -16,10 +16,11 @@ cdef extern from "_healpy_hotspots_lib.h":
 def hotspots_healpy(m):
     """Find extrema in the 2-D field on the sphere.
 
-    This routine finds the local extrema in a healpix map. This can be used (for example) to compute
-    a projection of the angular correlation function of the CMB. Applications of this function can
-    be found in WMAP paper (https://arxiv.org/pdf/1001.4538.pdf) as well as recent work done by
-    Planck (https://arxiv.org/pdf/1303.5062.pdf, https://arxiv.org/abs/1506.07135).
+    This routine finds the local extrema by comparing each pixel to its 8 (or 7) immediate
+    neighbours. This can be used (for example) to compute a projection of the angular correlation
+    function of the CMB. Applications of this function can be found in WMAP paper
+    (https://arxiv.org/pdf/1001.4538.pdf) as well as recent work done by Planck
+    (https://arxiv.org/pdf/1303.5062.pdf, https://arxiv.org/abs/1506.07135).
 
     Parameters
     ----------

--- a/healpy/src/_hotspots.pyx
+++ b/healpy/src/_hotspots.pyx
@@ -1,0 +1,66 @@
+import numpy as np
+cimport numpy as np
+from libcpp.vector cimport vector
+
+import cython
+from healpy import npix2nside, nside2npix
+from healpy.pixelfunc import maptype
+
+from _common cimport Healpix_Map, RING, ndarray2map
+
+cdef extern from "hotspots.h":
+    cdef void hotspots(const Healpix_Map[double] &inmap,
+                       Healpix_Map[double] &outmap,
+                       vector[int] &maskmin,
+                       vector[int] &maskmax);
+
+def hotspots_healpy(m):
+    """Find extrema in the 2-D field on the sphere.
+
+    Parameters
+    ----------
+    m : array-like, shape (Npix,)
+      The input map.
+
+    Returns
+    -------
+    outmap : array-like, shape (Npix,)
+      Out map of extrema (other pixels are set to UNSEEN)
+
+    min_pixels : array_like
+      Pixel number for minima
+
+    max_pixels : array_like
+      Pixel number for maxima
+
+    Example
+    -------
+    >>> import healpy as hp
+    >>> import numpy as np
+    >>> nside = 16
+    >>> outmap, min_pixels, max_pixels = hp.hotspots(np.random.randn(12*nside**2))
+
+    """
+
+    info = maptype(m)
+    if info == 0:
+        mi = m.astype(np.float64, order='C', copy=True)
+    elif info == 1:
+        mi = m[0].astype(np.float64, order='C', copy=True)
+    else:
+        raise ValueError("Wrong input map (must be a valid healpix map)")
+
+    # View the ndarray as a Healpix_Map
+    M = ndarray2map(mi, RING)
+
+    # Declare output arrays
+    npix = mi.size
+    mhs = np.empty(npix, dtype=np.float64)
+    MHS = ndarray2map(mhs, RING)
+    cdef vector[int] vmin;
+    cdef vector[int] vmax;
+
+    hotspots(M[0], MHS[0], vmin, vmax)
+
+    del M, MHS
+    return mhs, np.array(vmin), np.array(vmax)

--- a/healpy/src/_hotspots.pyx
+++ b/healpy/src/_hotspots.pyx
@@ -16,10 +16,10 @@ cdef extern from "_healpy_hotspots_lib.h":
 def hotspots_healpy(m):
     """Find extrema in the 2-D field on the sphere.
 
-    This routine finds the local extrema in (for example) the CMB temperature field to compute a
-    projection of the angular correlation function of the CMB. Applications of this function can be
-    found in WMAP paper (https://arxiv.org/pdf/1001.4538.pdf) as well as recent work done by Planck
-    (https://arxiv.org/pdf/1303.5062.pdf, https://arxiv.org/abs/1506.07135).
+    This routine finds the local extrema in an healpix map. This can be used (for example) to
+    compute a projection of the angular correlation function of the CMB. Applications of this
+    function can be found in WMAP paper (https://arxiv.org/pdf/1001.4538.pdf) as well as recent work
+    done by Planck (https://arxiv.org/pdf/1303.5062.pdf, https://arxiv.org/abs/1506.07135).
 
     Parameters
     ----------

--- a/healpy/src/_hotspots.pyx
+++ b/healpy/src/_hotspots.pyx
@@ -16,10 +16,10 @@ cdef extern from "_healpy_hotspots_lib.h":
 def hotspots_healpy(m):
     """Find extrema in the 2-D field on the sphere.
 
-    This routine finds the local extrema in an healpix map. This can be used (for example) to
-    compute a projection of the angular correlation function of the CMB. Applications of this
-    function can be found in WMAP paper (https://arxiv.org/pdf/1001.4538.pdf) as well as recent work
-    done by Planck (https://arxiv.org/pdf/1303.5062.pdf, https://arxiv.org/abs/1506.07135).
+    This routine finds the local extrema in a healpix map. This can be used (for example) to compute
+    a projection of the angular correlation function of the CMB. Applications of this function can
+    be found in WMAP paper (https://arxiv.org/pdf/1001.4538.pdf) as well as recent work done by
+    Planck (https://arxiv.org/pdf/1303.5062.pdf, https://arxiv.org/abs/1506.07135).
 
     Parameters
     ----------

--- a/setup.py
+++ b/setup.py
@@ -524,7 +524,8 @@ setup(
         ),
         Extension(
             "healpy._hotspots",
-            ["healpy/src/_hotspots.pyx"],
+            ["healpy/src/_hotspots.pyx",
+             "healpy/src/_healpy_hotspots_lib.cc"],
             language="c++", extra_compile_args=["-std=c++11"],
             cython_directives=dict(embedsignature=True),
         ),

--- a/setup.py
+++ b/setup.py
@@ -522,6 +522,12 @@ setup(
             language="c++", extra_compile_args=["-std=c++11"],
             cython_directives=dict(embedsignature=True),
         ),
+        Extension(
+            "healpy._hotspots",
+            ["healpy/src/_hotspots.pyx"],
+            language="c++", extra_compile_args=["-std=c++11"],
+            cython_directives=dict(embedsignature=True),
+        ),
     ],
     package_data={
         "healpy": [


### PR DESCRIPTION
This PR adds support for hotspot computation within healpy. This was something already in Healpix/F90 code since years as well as in Healpix/C++ (see [hotspots_cxx_module.cc](https://github.com/healpy/healpixmirror/blob/29d2a54dde968a4e71bdb06c193f607f0b98168a/src/cxx/Healpix_cxx/hotspots_cxx_module.cc)) but only as an executable for the latter. 

The PR wraps the C++ code in a `cython` file given its implementation as an "independant" library. I also post the corresponding C++ code which is just a copy-paste of the original code from `hotspots_cxx_module.cc` (see the following [gist](https://gist.github.com/xgarrido/7333c6686ca913f5365d92fd79ef4151)). It will need to be added to Healpix/C++ code, so @mreineck or any one else, feel free to amend it.

Btw, this PR will fix the #493 issue. 