### PR TITLE
Fix propagation of mmax in smoothing

### DIFF
--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -968,10 +968,20 @@ def smoothing(
             fwhm=fwhm,
             sigma=sigma,
             beam_window=beam_window,
-            inplace=True,
+            pol=pol,
+            mmax=mmax,
             verbose=verbose,
+            inplace=True,
         )
-        output_map = alm2map(alms, nside, pixwin=False, verbose=verbose)
+        output_map = alm2map(
+            alms,
+            nside,
+            lmax=lmax,
+            mmax=mmax,
+            pixwin=False,
+            verbose=verbose,
+            pol=pol,
+        )
     else:
         # Treat each map independently (any number)
         output_map = []


### PR DESCRIPTION
In current `master`, smoothing with `mmax !=lmax` fails:
```
In [1]: import healpy as hp                                                                                                                                                           

In [2]: hp.smoothing(np.arange(12*8**2),lmax=8,mmax=3)                                                                                                                                
Sigma is 0.000000 arcmin (0.000000 rad) 
-> fwhm is 0.000000 arcmin
Sigma is 0.000000 arcmin (0.000000 rad) 
-> fwhm is 0.000000 arcmin
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-e0ab22460e8a> in <module>
----> 1 hp.smoothing(np.arange(12*8**2),lmax=8,mmax=3)

/global/common/software/sobs/cori/gnu_20200303/cmbenv_aux/lib/python3.6/site-packages/healpy-1.12.10-py3.6-linux-x86_64.egg/healpy/pixelfunc.py in wrapper(map_in, *args, **kwds)
    301         return_ma = is_ma(map_in)
    302         m = ma_to_array(map_in)
--> 303         out = f(m, *args, **kwds)
    304         return ma(out) if return_ma else out
    305 

/global/common/software/sobs/cori/gnu_20200303/cmbenv_aux/lib/python3.6/site-packages/healpy-1.12.10-py3.6-linux-x86_64.egg/healpy/sphtfunc.py in smoothing(map_in, fwhm, sigma, beam_window, pol, iter, lmax, mmax, use_weights, use_pixel_weights, datapath, verbose)
    931             verbose=verbose,
    932         )
--> 933         output_map = alm2map(alms, nside, pixwin=False, verbose=verbose)
    934     else:
    935         # Treat each map independently (any number)

/global/common/software/sobs/cori/gnu_20200303/cmbenv_aux/lib/python3.6/site-packages/healpy-1.12.10-py3.6-linux-x86_64.egg/healpy/sphtfunc.py in alm2map(alms, nside, lmax, mmax, pixwin, fwhm, sigma, pol, inplace, verbose)
    337     if pol:
    338         output = sphtlib._alm2map(
--> 339             alms_new[0] if lonely else tuple(alms_new), nside, lmax=lmax, mmax=mmax
    340         )
    341         if lonely:

TypeError: Wrong alm size (or give lmax and mmax)
```

This PR propagates the `mmax` from `smoothing()` to the relevant subroutines.