### PR TITLE
Report version of dependencies under test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,12 @@ before_install:
       bash miniconda.sh -b -p ~/miniconda && \
       ~/miniconda/bin/conda create --yes -n anaconda_env \
         python=$TRAVIS_PYTHON_VERSION \
-        setuptools pip numpy matplotlib astropy cython pytest scipy requests && \
+        setuptools pip numpy matplotlib astropy pytest-astropy-header cython pytest scipy requests && \
       source ~/miniconda/bin/activate anaconda_env
     else
      sudo apt-get -y install pkg-config && \
      travis_retry pip install --upgrade setuptools && \
-     travis_retry pip install numpy matplotlib astropy cython pytest scipy requests
+     travis_retry pip install numpy matplotlib astropy pytest-astropy-header cython pytest scipy requests
     fi
 
   # Install cfitsio if necessary

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -16,9 +16,9 @@ Conda forge provides a `conda
 channel <https://anaconda.org/conda-forge/healpy>`_ with a pre-compiled version of ``healpy``
 for linux 64bit and MAC OS X platforms, you can install it in Anaconda with::
 
-    conda config --add channels conda-forge 
+    conda config --add channels conda-forge
     conda install healpy
-    
+
 Source installation with Pip
 ---------------------------
 
@@ -35,7 +35,7 @@ On Linux with newer compilers many users reported compilation errors like ``conf
 the solution is to specifiy the flags for the C and CXX compiler:
 
     CC=gcc CXX=g++ CFLAGS='-fPIC' CXXFLAGS='-fPIC' pip install --user healpy
-    
+
 Compilation issues with Mac OS
 ------------------------------
 
@@ -50,7 +50,7 @@ package manager, it's even easer to install Healpy with::
 
     sudo port install py27-healpy
 
-Binary `apt-get` style packages are also available in the development versions of 
+Binary `apt-get` style packages are also available in the development versions of
 `Debian (sid) <https://packages.debian.org/sid/python-healpy>`_ and
 `Ubuntu (utopic) <http://packages.ubuntu.com/utopic/python-healpy>`_.
 
@@ -75,13 +75,13 @@ If everything goes fine, you can test it::
     python
 >>> import matplotlib.pyplot as plt
 >>> import numpy as np
->>> import healpy as hp 
+>>> import healpy as hp
 >>> hp.mollview(np.arange(12))
 >>> plt.show()
 
-or run the test suite with nose::
+or run the test suite with::
 
-    cd healpy-1.7.4 && python setup.py test
+    cd healpy-* && python setup.py test
 
 Building against external Healpix and cfitsio
 ---------------------------------------------

--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,10 @@
 def pytest_configure(config):
     config.option.astropy_header = True
+    try:
+        from pytest_astropy_header.display import PYTEST_HEADER_MODULES
+        PYTEST_HEADER_MODULES.pop('Pandas')
+        PYTEST_HEADER_MODULES.pop('h5py')
+        PYTEST_HEADER_MODULES['astropy'] = 'astropy'
+        PYTEST_HEADER_MODULES['cython'] = 'cython'
+    except ImportError:
+        pass

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,2 @@
+def pytest_configure(config):
+    config.option.astropy_header = True


### PR DESCRIPTION
Useful for Travis, uses `pytest-astropy-header`
but does not fail if that is missing.

Closes #448