### PR TITLE
Add support for line integral convolution (LIC)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,14 +9,17 @@ exclude .gitignore .gitmodules .travis.yml clean.sh
 include COPYING CITATION INSTALL.rst README.rst MANIFEST.in CHANGELOG.rst ez_setup.py run_pykg_config.py
 include healpy/src/_healpy_utils.h
 include healpy/src/_healpy_hotspots_lib.h
+include healpy/src/_line_integral_convolution_lib.h
 include healpy/src/_query_disc.cpp
 include healpy/src/_sphtools.cpp
 include healpy/src/_pixelfunc.cpp
 include healpy/src/_masktools.cpp
 include healpy/src/_hotspots.cpp
+include healpy/src/_line_integral_convolution.cpp
 include healpy/src/_common.pxd
 include healpy/src/_query_disc.pyx
 include healpy/src/_sphtools.pyx
 include healpy/src/_pixelfunc.pyx
 include healpy/src/_masktools.pyx
 include healpy/src/_hotspots.pyx
+include healpy/src/_line_integral_convolution.pyx

--- a/doc/healpy_line_integral_convolution.rst
+++ b/doc/healpy_line_integral_convolution.rst
@@ -1,0 +1,10 @@
+.. currentmodule:: healpy
+
+
+Line integral convolution
+=========================
+
+.. autosummary::
+   :toctree: generated/
+
+   line_integral_convolution

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -56,6 +56,7 @@ Reference
    healpy_rotator
    healpy_projector
    healpy_zoomtool
+   healpy_line_integral_convolution
 
 Indices and tables
 ==================

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -103,3 +103,4 @@ from .zoomtool import mollzoom, set_g_clim
 from .fitsfunc import write_map, read_map, read_alm, write_alm, write_cl, read_cl
 from ._masktools import dist2holes_healpy as dist2holes
 from ._hotspots import hotspots_healpy as hotspots
+from ._line_integral_convolution import line_integral_convolution

--- a/healpy/src/_line_integral_convolution.pyx
+++ b/healpy/src/_line_integral_convolution.pyx
@@ -1,0 +1,124 @@
+import numpy as np
+cimport numpy as np
+cimport cython
+from _common cimport RING, Healpix_Map, ndarray2map
+from pixelfunc import npix2nside
+from healpy.sphtfunc import alm2map, Alm
+
+cdef extern from "_line_integral_convolution_lib.cc":
+    cdef void lic_main(const Healpix_Map[double] &Q, const Healpix_Map[double] &U,
+                       const Healpix_Map[double] &th, Healpix_Map[double] &hit,
+                       Healpix_Map[double] &tex, Healpix_Map[double] &mag,
+                       int steps, int kernel_steps, double step_radian,
+                       double polmin, double polmax)
+
+
+def line_integral_convolution(
+    Q,
+    U,
+    steps=100,
+    kernel_steps=50,
+    step_radian=0.003,
+    pol_min=-1e30,
+    pol_max=1e30,
+    rand_seed=42,
+    ell=None,
+    texture=None,
+    modulate=False,
+):
+    """Computes line integral convolution of polarized map.
+
+    Parameters
+    ----------
+    Q : array-like, shape (Npix,)
+      Input Stokes Q map. Must be in RING ordering.
+    U : array-like, shape (Npix,)
+      Input Stokes U map. Must be in RING ordering.
+    steps : int
+      Number of steps to use for each line of the convolution (default: 100).
+    kernel_steps : int
+      Extent of the convolution kernel (in steps, <= steps) (default: 50).
+    step_radian : float
+      Size (in radians) of each step in the convolution (default: 0.003).
+    pol_min : float
+      Minimum value for the polarization magnitude (default: -1e30).
+    pol_max : float
+      Maximum value for the polarization magnitude (default: 1e30).
+    rand_seed : int
+      Seed for the random number generator; only used when texture is not
+      provided (default: 42).
+    ell : int or None
+      The ell value at which the generated background texture has power
+      (default: ``None``). If ``ell < 0``, it is set to ``ell=2*nside``. If
+      ``None``, the generated background texture will contain white noise.
+    texture : array-like, shape (Npix,) or None
+      Background texture map (default: ``None``). Must be in RING ordering. If
+      ``None``, a background texture will be generated based on the values of
+      ``rand_seed`` and ``ell``.
+    modulate : bool
+      Whether or not to modulate the convolved texture with the polarization
+      intensity (default: ``False``).
+
+    Returns
+    -------
+    lic_texture : Line integral convolved texture.
+
+    Example
+    -------
+    >>> import healpy as hp
+    >>> import numpy as np
+    >>> import matplotlib.cm
+    >>> import matplotlib.colors
+    >>> I, Q, U = hp.read_map('iqu_map.fits', (0, 1, 2))
+    >>> lic = hp.line_integral_convolution(Q, U)
+    >>> hp.mollview(I)
+    >>> cmap_colors = matplotlib.cm.get_cmap('binary', 256)(np.linspace(0, 1, 256))
+    >>> cmap_colors[..., 3] = 0.5  # Make colormap partially transparent
+    >>> cmap = matplotlib.colors.ListedColormap(cmap_colors)
+    >>> hp.mollview(lic, cmap=cmap, cbar=False, reuse_axes=True)
+
+    """
+
+    if Q.shape != U.shape:
+        raise ValueError("Q and U maps must be the same size!")
+    if texture is not None and texture.shape != Q.shape:
+        raise ValueError("Texture and Q / U maps must be the same size!")
+    if Q.ndim != 1:
+        raise ValueError("Maps must have only a single dimension!")
+    if kernel_steps > steps:
+        raise ValueError("Kernel steps must be fewer than steps!")
+
+    npix = Q.size
+    nside = npix2nside(npix)
+    if texture is None:
+        rng = np.random.RandomState(rand_seed)
+        if ell is not None:
+            if ell < 0:
+                ell = 2 * nside
+            alms = np.zeros(Alm.getsize(ell), dtype=np.complex)
+            for m in range(ell + 1):
+                alms[Alm.getidx(ell, ell, m)] = rng.normal() + 1j * rng.normal()
+            texture = alm2map(alms, nside)
+        else:
+            texture = rng.uniform(size=npix) - 0.5
+
+    hit = np.empty(npix)
+    tex = np.empty(npix)
+    mag = np.empty(npix)
+
+    lic_main(
+        ndarray2map(Q, RING)[0],
+        ndarray2map(U, RING)[0],
+        ndarray2map(texture, RING)[0],
+        ndarray2map(hit, RING)[0],
+        ndarray2map(tex, RING)[0],
+        ndarray2map(mag, RING)[0],
+        steps,
+        kernel_steps,
+        step_radian,
+        pol_min,
+        pol_max,
+    )
+
+    lic_texture = mag if modulate else tex
+    return lic_texture

--- a/healpy/src/_line_integral_convolution.pyx
+++ b/healpy/src/_line_integral_convolution.pyx
@@ -5,7 +5,7 @@ from _common cimport RING, Healpix_Map, ndarray2map
 from pixelfunc import npix2nside
 from healpy.sphtfunc import alm2map, Alm
 
-cdef extern from "_line_integral_convolution_lib.cc":
+cdef extern from "_line_integral_convolution_lib.h":
     cdef void lic_main(const Healpix_Map[double] &Q, const Healpix_Map[double] &U,
                        const Healpix_Map[double] &th, Healpix_Map[double] &hit,
                        Healpix_Map[double] &tex, Healpix_Map[double] &mag,

--- a/healpy/src/_line_integral_convolution.pyx
+++ b/healpy/src/_line_integral_convolution.pyx
@@ -28,6 +28,15 @@ def line_integral_convolution(
 ):
     """Computes line integral convolution of polarized map.
 
+    This visualizes the vector field via convolution of streamlines with a
+    random background texture. It thus serves as a technique for visualizing
+    polarization orientation. Polarization intensity can additionally be
+    visualized by modulating it with the convolved texture by setting the
+    *modulate* argument. By default, the random texture is white noise, but it
+    can also be generated with power at a given angular scale if *ell* is
+    specified, or a custom texture can be passed to this function with the
+    *texture* argument.
+
     Parameters
     ----------
     Q : array-like, shape (Npix,)

--- a/healpy/src/_line_integral_convolution_lib.cc
+++ b/healpy/src/_line_integral_convolution_lib.cc
@@ -1,0 +1,213 @@
+// Copied from Healpix 3.60, then modified for use as library
+/*
+ *  This file was part of Healpix_cxx.
+ *
+ *  Healpix_cxx is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Healpix_cxx is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Healpix_cxx; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *  For more information about HEALPix, see http://healpix.sourceforge.net
+ */
+
+/*
+ *  Healpix_cxx is being developed at the Max-Planck-Institut fuer Astrophysik
+ *  and financially supported by the Deutsches Zentrum fuer Luft- und Raumfahrt
+ *  (DLR).
+ */
+
+/*! \file alice3.cc
+ *  Copyright (C) 2005-2015 David Larson, Max-Planck-Society
+ *  \author David Larson \author Martin Reinecke
+ */
+
+#include "lsconstants.h"
+#include "arr.h"
+#include "vec3.h"
+#include "healpix_map.h"
+
+using namespace std;
+
+class PolarizationHolder
+  {
+  public:
+    Healpix_Map<double> Q, U;
+
+    void getQU(const pointing &p, double &q, double &u) const
+      {
+      fix_arr<int,4> pix;
+      fix_arr<double,4> wgt;
+      Q.get_interpol(p,pix,wgt);
+      q=u=0.f;
+      for (tsize i=0;i<4;++i) {q+=Q[pix[i]]*wgt[i];u+=U[pix[i]]*wgt[i]; }
+      }
+
+    vec3 getQUDir(const vec3 &loc) const
+      {
+      double q,u;
+      getQU(loc,q,u);
+      vec3 east(1,0,0);
+      if (abs(loc.x)+abs(loc.y) > 0.0)
+        east = vec3(-loc.y,loc.x,0).Norm();
+      vec3 north = crossprod(loc, east);
+      double angle = 0.5*safe_atan2(u,q);
+      return north*(-cos(angle)) + east*sin(angle);
+      }
+
+    // Return the magnitude of the polarization at some pointing.
+    double getQUMagnitude(const pointing& p) const
+      {
+      double q,u;
+      getQU(p,q,u);
+      return sqrt(q*q + u*u);
+      }
+  };
+
+/*! Steps from loc in direction dir for an angle theta and updates loc and dir. */
+void get_step(const PolarizationHolder &ph, vec3 &loc, vec3 &dir, double theta)
+  {
+  loc=(loc+dir*theta).Norm();
+  vec3 tdir=ph.getQUDir(loc);
+  dir = (dotprod(dir,tdir)<0) ? -tdir : tdir;
+  }
+
+/*! Performs one Runge-Kutta second order step. Updates loc and dir. */
+void runge_kutta_step(vec3 &loc, vec3 &dir, const PolarizationHolder &ph,
+  double theta)
+  {
+  // Take a half-theta step
+  vec3 tloc=loc;
+  get_step(ph, tloc, dir, theta/2.0);
+
+  // Then take a full step with the new direction
+  get_step(ph, loc, dir, theta);
+  }
+
+/*! Second order Runge-Kutta integration on the sphere.  Given a
+  starting location, a qu map of the sky, and a step size theta, this
+  subroutine returns an array of vectors extending in both
+  directions from the starting location.  */
+void runge_kutta_2(const vec3 &location, const PolarizationHolder &ph,
+  double theta, arr<vec3> &locs)
+  {
+  vec3 first_dir=ph.getQUDir(location);
+  vec3 dir = first_dir;
+  vec3 loc = location;
+
+  locs[locs.size()/2] = loc;
+
+  for(int i = 1 + locs.size()/2; i<int(locs.size()); i++)
+    {
+    runge_kutta_step(loc, dir, ph, theta);
+    locs[i] = loc;
+    }
+
+  dir = -first_dir;
+  loc = location;
+  for(int i = -1 + locs.size()/2; i>=0; i--)
+    {
+    runge_kutta_step(loc, dir, ph, theta);
+    locs[i] = loc;
+    }
+  }
+
+/*! Create a sinusoidal kernel. */
+void make_kernel(arr<double> &kernel)
+  {
+  for(tsize i=0; i<kernel.size(); i++)
+    {
+    double sinx = sin(pi*(i+1) / (kernel.size()+1));
+    kernel[i] = sinx*sinx;
+    }
+  }
+
+/*! Convolve an array with a kernel. */
+void convolve(const arr<double> &kernel, const arr<double> &raw, arr<double> &convolution)
+  {
+  convolution.alloc(raw.size()-kernel.size()+1);
+  for(tsize i=0; i<convolution.size(); i++)
+    {
+    double total=0;
+    for (tsize j=0; j<kernel.size(); j++)
+      total += kernel[j] * raw[i+j];
+    convolution[i] = total;
+    }
+  }
+
+// Perform line integral convolution on sphere
+int lic_function(Healpix_Map<double> &hitcount, Healpix_Map<double> &texture,
+  const PolarizationHolder &ph, const Healpix_Map<double> &th, int steps,
+  int kernel_steps, double step_radian)
+  {
+  arr<double> kernel(kernel_steps), convolution, rawtexture;
+  make_kernel(kernel);
+  arr<vec3> curve(steps);
+
+  texture.fill(0.);
+  int num_curves=0;
+
+  for(int i=0; i<texture.Npix(); i++)
+    {
+    if (hitcount[i]<1.0)
+      {
+      num_curves++;
+      runge_kutta_2(texture.pix2vec(i), ph, step_radian, curve);
+      rawtexture.alloc(curve.size());
+      for (tsize i2=0; i2<curve.size(); i2++)
+        rawtexture[i2] = th.interpolated_value(curve[i2]);
+      convolve(kernel, rawtexture, convolution);
+      for (tsize j=0; j<convolution.size(); j++)
+        {
+        int k = texture.vec2pix(curve[j+kernel.size()/2]);
+        texture[k] += convolution[j];
+        hitcount[k] += 1.;
+        }
+      }
+    }
+  return num_curves;
+  }
+
+// Expose line integral convolution for external use
+void lic_main(const Healpix_Map<double> &Q, const Healpix_Map<double> &U, const Healpix_Map<double> &th,
+  Healpix_Map<double> &hit, Healpix_Map<double> &tex, Healpix_Map<double> &mag,
+  int steps, int kernel_steps, double step_radian, double polmin, double polmax)
+  {
+  PolarizationHolder ph;
+  ph.Q = Q;
+  ph.U = U;
+
+  hit.fill(0.);
+
+  for (int i=0; i<mag.Npix(); i++)
+    {
+    pointing p = mag.pix2ang(i);
+
+    mag[i] = min(polmax,max(polmin,ph.getQUMagnitude(p)));
+    tex[i] = th.interpolated_value(p);
+    }
+
+  lic_function(hit, tex, ph, th, steps, kernel_steps, step_radian);
+
+  for (int i=0; i<tex.Npix(); ++i)
+    tex[i]/=hit[i];
+  double tmin,tmax,mmin,mmax;
+  tex.minmax(tmin,tmax);
+  mag.minmax(mmin,mmax);
+  for (int i=0; i<tex.Npix(); ++i)
+    {
+    mag[i]*=(tex[i]-tmin);
+    tex[i]=1.0-(tex[i]-tmin)/(tmax-tmin);
+    }
+  mag.minmax(mmin,mmax);
+  for (int i=0; i<mag.Npix(); ++i)
+    mag[i]=1.0-(mag[i]-mmin)/(mmax-mmin);
+  }

--- a/healpy/src/_line_integral_convolution_lib.h
+++ b/healpy/src/_line_integral_convolution_lib.h
@@ -1,0 +1,10 @@
+#ifndef HEALPY_LINE_INTEGRAL_CONVOLUTION_H
+#define HEALPY_LINE_INTEGRAL_CONVOLUTION_H
+
+#include "healpix_map.h"
+
+void lic_main(const Healpix_Map<double> &Q, const Healpix_Map<double> &U, const Healpix_Map<double> &th,
+  Healpix_Map<double> &hit, Healpix_Map<double> &tex, Healpix_Map<double> &mag,
+  int steps, int kernel_steps, double step_radian, double polmin, double polmax);
+
+#endif

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -574,6 +574,7 @@ def rotate_alm(alm not None, double psi=0, double theta=0, double phi=0, matrix=
         del AI, AG, AC
 
 
+@cython.cdivision(True)
 cdef int alm_getn(int l, int m):
     if not m <= l:
         raise ValueError("mmax must be <= lmax")

--- a/healpy/test/test_line_integral_convolution.py
+++ b/healpy/test/test_line_integral_convolution.py
@@ -1,0 +1,52 @@
+import os.path
+import unittest
+import numpy as np
+
+from .. import line_integral_convolution as lic
+from .. import read_map
+
+
+class TestLIC(unittest.TestCase):
+    def test_qu_shape_equal(self):
+        self.assertRaises(ValueError, lic, np.empty(12), np.empty(48))
+
+    def test_texture_shape_equal(self):
+        self.assertRaises(
+            ValueError, lic, np.empty(12), np.empty(12), texture=np.empty(48)
+        )
+
+    def test_qu_shape_dims(self):
+        self.assertRaises(ValueError, lic, np.empty((12, 2)), np.empty((12, 2)))
+
+    def test_kernel_steps_fewer_than_steps(self):
+        self.assertRaises(
+            ValueError, lic, np.empty(12), np.empty(12), kernel_steps=51, steps=50
+        )
+
+    def test_lic_no_crash(self):
+        lic(np.empty(12), np.empty(12))
+        lic(np.empty(12), np.empty(12), ell=-1)
+        lic(np.empty(12), np.empty(12), ell=10)
+        lic(np.empty(12), np.empty(12), texture=np.empty(12))
+        lic(np.empty(12), np.empty(12), modulate=True)
+
+    def test_lic_regression(self):
+        path = os.path.dirname(os.path.realpath(__file__))
+        Q, U = read_map(
+            os.path.join(path, "data", "wmap_band_iqumap_r9_7yr_W_v4_udgraded32.fits"),
+            (1, 2),
+        )
+        lic_result = lic(Q, U, step_radian=0.01)
+        np.testing.assert_almost_equal(
+            np.mean(np.abs(lic_result)), 0.54281382, decimal=8
+        )
+        np.testing.assert_almost_equal(
+            np.std(np.abs(lic_result)), 0.13154804, decimal=8
+        )
+        lic_result = lic(Q, U, step_radian=0.01, ell=-1)
+        np.testing.assert_almost_equal(
+            np.mean(np.abs(lic_result)), 0.51307069, decimal=8
+        )
+        np.testing.assert_almost_equal(
+            np.std(np.abs(lic_result)), 0.11628964, decimal=8
+        )

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -94,6 +94,7 @@ def mollview(
     notext=False,
     norm=None,
     hold=False,
+    reuse_axes=False,
     margins=None,
     sub=None,
     nlocs=2,
@@ -163,6 +164,10 @@ def mollview(
     sub : int, scalar or sequence, optional
       Use only a zone of the current figure (same syntax as subplot).
       Default: None
+    reuse_axes : bool, optional
+      If True, reuse the current Axes (should be a MollweideAxes). This is
+      useful if you want to overplot with a partially transparent colormap,
+      such as for plotting a line integral convolution. Default: False
     margins : None or sequence, optional
       Either None, or a sequence (left,bottom,right,top)
       giving the margins on left,bottom,right and top
@@ -186,7 +191,7 @@ def mollview(
     nside = pixelfunc.get_nside(map)
     pixelfunc.check_nside(nside, nest=nest)
 
-    if not (hold or sub):
+    if not (hold or sub or reuse_axes):
         f = pylab.figure(fig, figsize=(8.5, 5.4))
         extent = (0.02, 0.05, 0.96, 0.9)
     elif hold:
@@ -194,6 +199,8 @@ def mollview(
         left, bottom, right, top = np.array(f.gca().get_position()).ravel()
         extent = (left, bottom, right - left, top - bottom)
         f.delaxes(f.gca())
+    elif reuse_axes:
+        f = pylab.gcf()
     else:  # using subplot syntax
         f = pylab.gcf()
         if hasattr(sub, "__len__"):
@@ -225,10 +232,13 @@ def mollview(
     pylab.ioff()
     try:
         map = pixelfunc.ma_to_array(map)
-        ax = PA.HpxMollweideAxes(
-            f, extent, coord=coord, rot=rot, format=format2, flipconv=flip
-        )
-        f.add_axes(ax)
+        if reuse_axes:
+            ax = f.gca()
+        else:
+            ax = PA.HpxMollweideAxes(
+                f, extent, coord=coord, rot=rot, format=format2, flipconv=flip
+            )
+            f.add_axes(ax)
         if remove_dip:
             map = pixelfunc.remove_dipole(
                 map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True
@@ -337,6 +347,7 @@ def gnomview(
     norm=None,
     hold=False,
     sub=None,
+    reuse_axes=False,
     margins=None,
     notext=False,
     return_projected_map=False,
@@ -396,12 +407,16 @@ def gnomview(
     bgcolor : str
       Color to use for background
     hold : bool, optional
-      If True, replace the current Axes by a MollweideAxes.
+      If True, replace the current Axes by a GnomonicAxes.
       use this if you want to have multiple maps on the same
       figure. Default: False
     sub : int or sequence, optional
       Use only a zone of the current figure (same syntax as subplot).
       Default: None
+    reuse_axes : bool, optional
+      If True, reuse the current Axes (should be a GnomonicAxes). This is
+      useful if you want to overplot with a partially transparent colormap,
+      such as for plotting a line integral convolution. Default: False
     margins : None or sequence, optional
       Either None, or a sequence (left,bottom,right,top)
       giving the margins on left,bottom,right and top
@@ -428,7 +443,7 @@ def gnomview(
     nside = pixelfunc.get_nside(map)
     pixelfunc.check_nside(nside, nest=nest)
 
-    if not (hold or sub):
+    if not (hold or sub or reuse_axes):
         f = pylab.figure(fig, figsize=(5.8, 6.4))
         if not margins:
             margins = (0.075, 0.05, 0.075, 0.05)
@@ -440,6 +455,8 @@ def gnomview(
             margins = (0.0, 0.0, 0.0, 0.0)
         extent = (left, bottom, right - left, top - bottom)
         f.delaxes(pylab.gca())
+    elif reuse_axes:
+        f = pylab.gcf()
     else:  # using subplot syntax
         f = pylab.gcf()
         if hasattr(sub, "__len__"):
@@ -470,10 +487,13 @@ def gnomview(
     pylab.ioff()
     try:
         map = pixelfunc.ma_to_array(map)
-        ax = PA.HpxGnomonicAxes(
-            f, extent, coord=coord, rot=rot, format=format, flipconv=flip
-        )
-        f.add_axes(ax)
+        if reuse_axes:
+            ax = f.gca()
+        else:
+            ax = PA.HpxGnomonicAxes(
+                f, extent, coord=coord, rot=rot, format=format, flipconv=flip
+            )
+            f.add_axes(ax)
         if remove_dip:
             map = pixelfunc.remove_dipole(map, gal_cut=gal_cut, nest=nest, copy=True)
         elif remove_mono:
@@ -611,6 +631,7 @@ def cartview(
     aspect=None,
     hold=False,
     sub=None,
+    reuse_axes=False,
     margins=None,
     notext=False,
     return_projected_map=False,
@@ -682,6 +703,10 @@ def cartview(
     sub : int, scalar or sequence, optional
       Use only a zone of the current figure (same syntax as subplot).
       Default: None
+    reuse_axes : bool, optional
+      If True, reuse the current Axes (should be a CartesianAxes). This is
+      useful if you want to overplot with a partially transparent colormap,
+      such as for plotting a line integral convolution. Default: False
     margins : None or sequence, optional
       Either None, or a sequence (left,bottom,right,top)
       giving the margins on left,bottom,right and top
@@ -704,7 +729,7 @@ def cartview(
     nside = pixelfunc.get_nside(map)
     pixelfunc.check_nside(nside, nest=nest)
 
-    if not (hold or sub):
+    if not (hold or sub or reuse_axes):
         f = pylab.figure(fig, figsize=(8.5, 5.4))
         if not margins:
             margins = (0.075, 0.05, 0.075, 0.05)
@@ -716,6 +741,8 @@ def cartview(
             margins = (0.0, 0.0, 0.0, 0.0)
         extent = (left, bottom, right - left, top - bottom)
         f.delaxes(pylab.gca())
+    elif reuse_axes:
+        f = pylab.gcf()
     else:  # using subplot syntax
         f = pylab.gcf()
         if hasattr(sub, "__len__"):
@@ -752,10 +779,13 @@ def cartview(
             rot = np.array(zat, dtype=np.float64)
             rot.resize(3)
             rot[1] -= 90
-        ax = PA.HpxCartesianAxes(
-            f, extent, coord=coord, rot=rot, format=format, flipconv=flip
-        )
-        f.add_axes(ax)
+        if reuse_axes:
+            ax = f.gca()
+        else:
+            ax = PA.HpxCartesianAxes(
+                f, extent, coord=coord, rot=rot, format=format, flipconv=flip
+            )
+            f.add_axes(ax)
         if remove_dip:
             map = pixelfunc.remove_dipole(map, gal_cut=gal_cut, nest=nest, copy=True)
         elif remove_mono:
@@ -867,6 +897,7 @@ def orthview(
     hold=False,
     margins=None,
     sub=None,
+    reuse_axes=False,
     return_projected_map=False,
 ):
     """Plot a healpix map (given as an array) in Orthographic projection.
@@ -935,6 +966,10 @@ def orthview(
     sub : int, scalar or sequence, optional
       Use only a zone of the current figure (same syntax as subplot).
       Default: None
+    reuse_axes : bool, optional
+      If True, reuse the current Axes (should be a OrthographicAxes). This is
+      useful if you want to overplot with a partially transparent colormap,
+      such as for plotting a line integral convolution. Default: False
     margins : None or sequence, optional
       Either None, or a sequence (left,bottom,right,top)
       giving the margins on left,bottom,right and top
@@ -958,7 +993,7 @@ def orthview(
     nside = pixelfunc.get_nside(map)
     pixelfunc.check_nside(nside, nest=nest)
 
-    if not (hold or sub):
+    if not (hold or sub or reuse_axes):
         f = pylab.figure(fig, figsize=(8.5, 5.4))
         extent = (0.02, 0.05, 0.96, 0.9)
     elif hold:
@@ -966,6 +1001,8 @@ def orthview(
         left, bottom, right, top = np.array(f.gca().get_position()).ravel()
         extent = (left, bottom, right - left, top - bottom)
         f.delaxes(f.gca())
+    elif reuse_axes:
+        f = pylab.gcf()
     else:  # using subplot syntax
         f = pylab.gcf()
         if hasattr(sub, "__len__"):
@@ -996,10 +1033,13 @@ def orthview(
     wasinteractive = pylab.isinteractive()
     pylab.ioff()
     try:
-        ax = PA.HpxOrthographicAxes(
-            f, extent, coord=coord, rot=rot, format=format2, flipconv=flip
-        )
-        f.add_axes(ax)
+        if reuse_axes:
+            ax = f.gca()
+        else:
+            ax = PA.HpxOrthographicAxes(
+                f, extent, coord=coord, rot=rot, format=format2, flipconv=flip
+            )
+            f.add_axes(ax)
         if remove_dip:
             map = pixelfunc.remove_dipole(
                 map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True
@@ -1113,6 +1153,7 @@ def azeqview(
     aspect=None,
     hold=False,
     sub=None,
+    reuse_axes=False,
     margins=None,
     notext=False,
     return_projected_map=False,
@@ -1191,6 +1232,10 @@ def azeqview(
     sub : int, scalar or sequence, optional
       Use only a zone of the current figure (same syntax as subplot).
       Default: None
+    reuse_axes : bool, optional
+      If True, reuse the current Axes (should be a AzimuthalAxes). This is
+      useful if you want to overplot with a partially transparent colormap,
+      such as for plotting a line integral convolution. Default: False
     margins : None or sequence, optional
       Either None, or a sequence (left,bottom,right,top)
       giving the margins on left,bottom,right and top
@@ -1214,7 +1259,7 @@ def azeqview(
     nside = pixelfunc.get_nside(map)
     pixelfunc.check_nside(nside, nest=nest)
 
-    if not (hold or sub):
+    if not (hold or sub or reuse_axes):
         f = pylab.figure(fig, figsize=(8.5, 5.4))
         extent = (0.02, 0.05, 0.96, 0.9)
     elif hold:
@@ -1222,6 +1267,8 @@ def azeqview(
         left, bottom, right, top = np.array(f.gca().get_position()).ravel()
         extent = (left, bottom, right - left, top - bottom)
         f.delaxes(f.gca())
+    elif reuse_axes:
+        f = pylab.gcf()
     else:  # using subplot syntax
         f = pylab.gcf()
         if hasattr(sub, "__len__"):
@@ -1252,10 +1299,13 @@ def azeqview(
     wasinteractive = pylab.isinteractive()
     pylab.ioff()
     try:
-        ax = PA.HpxAzimuthalAxes(
-            f, extent, coord=coord, rot=rot, format=format, flipconv=flip
-        )
-        f.add_axes(ax)
+        if reuse_axes:
+            ax = f.gca()
+        else:
+            ax = PA.HpxAzimuthalAxes(
+                f, extent, coord=coord, rot=rot, format=format, flipconv=flip
+            )
+            f.add_axes(ax)
         if remove_dip:
             map = pixelfunc.remove_dipole(
                 map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True

--- a/setup.py
+++ b/setup.py
@@ -460,11 +460,13 @@ setup(
         ),
         Extension(
             "healpy._line_integral_convolution",
-            ["healpy/src/_line_integral_convolution.pyx"],
+            [
+                "healpy/src/_line_integral_convolution.pyx",
+                "healpy/src/_line_integral_convolution_lib.cc",
+            ],
             language="c++",
             extra_compile_args=["-std=c++11"],
             cython_directives=dict(embedsignature=True),
-            include_dirs=["healpixsubmodule/src/cxx/cxxsupport"],
         ),
     ],
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -458,6 +458,14 @@ setup(
             extra_compile_args=["-std=c++11"],
             cython_directives=dict(embedsignature=True),
         ),
+        Extension(
+            "healpy._line_integral_convolution",
+            ["healpy/src/_line_integral_convolution.pyx"],
+            language="c++",
+            extra_compile_args=["-std=c++11"],
+            cython_directives=dict(embedsignature=True),
+            include_dirs=["healpixsubmodule/src/cxx/cxxsupport"],
+        ),
     ],
     package_data={
         "healpy": [


### PR DESCRIPTION
This pull request adds line integral convolution support based on the `alice3` executable from Healpix 3.60.

Since `alice3` is structured as a standalone executable, I copied the C++ code and modified it such that it could be called as a function from Cython, although refactoring the code upstream to support both uses would have been another possibility.

The other main change made is to add an option to the visualization functions to allow the current axes to be reused. When combined with a partially transparent colormap, this allows the LIC output to be plotted over another map.

I also fixed a compilation bug I came across in `_sphtools.pyx`, which I believe is related to the default language level change in Cython 3.0.

Here's an example of the new functionality:
```python3
import numpy as np
import matplotlib.pyplot as plt
from matplotlib.cm import get_cmap
from matplotlib.colors import ListedColormap
import healpy as hp

cmap_colors = get_cmap('binary', 256)(np.linspace(0, 1, 256))
cmap_colors[..., 3] = 0.4  # Make colormap partially transparent
cmap = ListedColormap(cmap_colors)

m = hp.read_map('wmap_band_iqumap_r9_9yr_K_v5.fits', (0, 1, 2), verbose=False)
I, Q, U = hp.smoothing(m, np.deg2rad(5))
lic = hp.line_integral_convolution(Q, U)

lic = hp.smoothing(lic, np.deg2rad(0.5))

hp.mollview(np.log(1 + np.sqrt(Q**2 + U**2) * 100), cmap='inferno', cbar=False)
hp.mollview(lic, cmap=cmap, cbar=False, reuse_axes=True, title='WMAP K')

plt.savefig('wmapk.png', dpi=150)
```

![wmapk](https://user-images.githubusercontent.com/1450212/84576410-911a6000-ad82-11ea-9c80-b32ea9e130a5.png)