### PR TITLE
Fix floating point comparison failures in doctests

### DIFF
--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -1026,7 +1026,7 @@ def nside2resol(nside, arcmin=False):
     Examples
     --------
     >>> import healpy as hp
-    >>> hp.nside2resol(128, arcmin = True)
+    >>> hp.nside2resol(128, arcmin = True)  # doctest: +FLOAT_CMP
     27.483891294539248
 
     >>> hp.nside2resol(256)
@@ -1066,7 +1066,7 @@ def nside2pixarea(nside, degrees=False):
     Examples
     --------
     >>> import healpy as hp
-    >>> hp.nside2pixarea(128, degrees = True)
+    >>> hp.nside2pixarea(128, degrees = True)  # doctest: +FLOAT_CMP
     0.2098234113027917
 
     >>> hp.nside2pixarea(256)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test = pytest
 
 [tool:pytest]
-addopts = --doctest-modules --doctest-cython -v
+addopts = --doctest-plus --doctest-cython -v
 testpaths = healpy

--- a/setup.py
+++ b/setup.py
@@ -471,7 +471,7 @@ setup(
     },
     install_requires=["matplotlib", "numpy>=1.13", "six", "astropy", "scipy"],
     setup_requires=["pytest-runner", "six"],
-    tests_require=["pytest", "pytest-cython"],
+    tests_require=["pytest", "pytest-cython", "pytest-doctestplus"],
     test_suite="healpy",
     license="GPLv2",
     scripts=["bin/healpy_get_wmap_maps.sh"],


### PR DESCRIPTION
This fixes a unit test failure on Debian i386:
https://buildd.debian.org/status/fetch.php?pkg=healpy&arch=i386&ver=1.13.0-2&stamp=1594306120&raw=0

- Add a test dependency on Astropy's pytest-doctestplus.
- Add the FLOAT_CMP doctest option flag to flaky tests.