### PR TITLE
Add requests to tests_require list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -481,7 +481,7 @@ setup(
     },
     install_requires=["matplotlib", "numpy>=1.13", "six", "astropy", "scipy"],
     setup_requires=["pytest-runner", "six"],
-    tests_require=["pytest", "pytest-cython", "pytest-doctestplus"],
+    tests_require=["pytest", "pytest-cython", "pytest-doctestplus", "requests"],
     test_suite="healpy",
     license="GPLv2",
     scripts=["bin/healpy_get_wmap_maps.sh"],


### PR DESCRIPTION
`test_pixelweights.py` imports `requests`, so it should be in `setup.py`'s list of requirements: https://github.com/healpy/healpy/blob/master/healpy/test/test_pixelweights.py#L3

Before this, I was unable to run `python setup.py test`. It works after this change.