### PR TITLE
Replace np.bool with np.bool_ and np.float with np.float64

### DIFF
--- a/doc/create_images.py
+++ b/doc/create_images.py
@@ -29,7 +29,7 @@ hp.graticule()
 plt.savefig("static/wmap_histeq_ecl.png", dpi=DPI)
 mask = hp.read_map(
     "../healpy/test/data/wmap_temperature_analysis_mask_r9_7yr_v4.fits"
-).astype(np.bool)
+).astype(np.bool_)
 wmap_map_I_masked = hp.ma(wmap_map_I)
 wmap_map_I_masked.mask = np.logical_not(mask)
 LMAX = 1024

--- a/doc/healpy_tutorial.ipynb
+++ b/doc/healpy_tutorial.ipynb
@@ -319,7 +319,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask = hp.read_map(\"wmap_temperature_analysis_mask_r9_7yr_v4.fits\").astype(np.bool)\n",
+    "mask = hp.read_map(\"wmap_temperature_analysis_mask_r9_7yr_v4.fits\").astype(np.bool_)\n",
     "wmap_map_I_masked = hp.ma(wmap_map_I)\n",
     "wmap_map_I_masked.mask = np.logical_not(mask)"
    ]

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -209,7 +209,7 @@ the mask.
 
 .. code-block:: python
 
-    mask = hp.read_map("wmap_temperature_analysis_mask_r9_7yr_v4.fits").astype(np.bool)
+    mask = hp.read_map("wmap_temperature_analysis_mask_r9_7yr_v4.fits").astype(np.bool_)
     wmap_map_I_masked = hp.ma(wmap_map_I)
     wmap_map_I_masked.mask = np.logical_not(mask)
 

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -721,7 +721,7 @@ def getformat(t):
       The FITS string code describing the data type, or None if unknown type.
     """
     conv = {
-        np.dtype(np.bool): "L",
+        np.dtype(np.bool_): "L",
         np.dtype(np.uint8): "B",
         np.dtype(np.int16): "I",
         np.dtype(np.int32): "J",

--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -251,7 +251,7 @@ def ma_to_array(m):
     --------
     >>> import healpy as hp
     >>> m = hp.ma(np.array([2., 2., 3, 4, 5, 0, 0, 0, 0, 0, 0, 0]))
-    >>> m.mask = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.bool)
+    >>> m.mask = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.bool_)
     >>> print(m.data[1]) # data is not affected by mask
     2.0
     >>> print(m[1]) # shows that the value is masked

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -978,10 +978,10 @@ class HistEqNorm(matplotlib.colors.Normalize):
 
         if np.iterable(value):
             vtype = "array"
-            val = np.ma.asarray(value).astype(np.float)
+            val = np.ma.asarray(value).astype(np.float64)
         else:
             vtype = "scalar"
-            val = np.ma.array([value]).astype(np.float)
+            val = np.ma.array([value]).astype(np.float64)
 
         self.autoscale_None(val)
 
@@ -1043,8 +1043,8 @@ class HistEqNorm(matplotlib.colors.Normalize):
             w = w | data.mask
         data2 = data.data[~w]
         if data2.size < 3:
-            self.yval = np.array([0, 1], dtype=np.float)
-            self.xval = np.array([self.vmin, self.vmax], dtype=np.float)
+            self.yval = np.array([0, 1], dtype=np.float64)
+            self.xval = np.array([self.vmin, self.vmax], dtype=np.float64)
             return
         bins = min(data2.size // 20, 5000)
         if bins < 3:
@@ -1060,7 +1060,7 @@ class HistEqNorm(matplotlib.colors.Normalize):
         if bins.size == hist.size + 1:
             # new bins format, remove last point
             bins = bins[:-1]
-        hist = hist.astype(np.float) / np.float(hist.sum())
+        hist = hist.astype(np.float64) / np.float(hist.sum())
         self.yval = np.concatenate([[0.0], hist.cumsum(), [1.0]])
         self.xval = np.concatenate(
             [[self.vmin], bins + 0.5 * (bins[1] - bins[0]), [self.vmax]]
@@ -1069,10 +1069,10 @@ class HistEqNorm(matplotlib.colors.Normalize):
     def _lininterp(self, x, X, Y):
         if hasattr(x, "__len__"):
             xtype = "array"
-            xx = np.asarray(x).astype(np.float)
+            xx = np.asarray(x).astype(np.float64)
         else:
             xtype = "scalar"
-            xx = np.asarray([x]).astype(np.float)
+            xx = np.asarray([x]).astype(np.float64)
         idx = X.searchsorted(xx)
         yy = xx * 0
         yy[idx > len(X) - 1] = Y[-1]  # over
@@ -1111,10 +1111,10 @@ class LogNorm2(matplotlib.colors.Normalize):
 
         if np.iterable(value):
             vtype = "array"
-            val = np.ma.asarray(value).astype(np.float)
+            val = np.ma.asarray(value).astype(np.float64)
         else:
             vtype = "scalar"
-            val = np.ma.array([value]).astype(np.float)
+            val = np.ma.array([value]).astype(np.float64)
 
         val = np.ma.masked_where(np.isinf(val.data), val)
 
@@ -1175,10 +1175,10 @@ class LinNorm2(matplotlib.colors.Normalize):
 
         if np.iterable(value):
             vtype = "array"
-            val = np.ma.asarray(value).astype(np.float)
+            val = np.ma.asarray(value).astype(np.float64)
         else:
             vtype = "scalar"
-            val = np.ma.array([value]).astype(np.float)
+            val = np.ma.array([value]).astype(np.float64)
 
         winf = np.isinf(val.data)
         val = np.ma.masked_where(winf, val)

--- a/healpy/src/_pixelfunc.pyx
+++ b/healpy/src/_pixelfunc.pyx
@@ -54,9 +54,9 @@ def ringinfo(nside, np.ndarray[int64, ndim=1] ring not None):
     num = ring.shape[0]
     cdef np.ndarray[int64, ndim=1] startpix = np.empty(num, dtype=np.int64)
     cdef np.ndarray[int64, ndim=1] ringpix = np.empty(num, dtype=np.int64)
-    cdef np.ndarray[double, ndim=1] costheta = np.empty(num, dtype=np.float)
-    cdef np.ndarray[double, ndim=1] sintheta = np.empty(num, dtype=np.float)
-    cdef np.ndarray[bool, ndim=1, cast=True] shifted = np.empty(num, dtype=np.bool)
+    cdef np.ndarray[double, ndim=1] costheta = np.empty(num, dtype=np.float64)
+    cdef np.ndarray[double, ndim=1] sintheta = np.empty(num, dtype=np.float64)
+    cdef np.ndarray[bool, ndim=1, cast=True] shifted = np.empty(num, dtype=np.bool_)
     for i in range(num):
         hb.get_ring_info(ring[i], startpix[i], ringpix[i], costheta[i], sintheta[i], shifted[i])
     return startpix, ringpix, costheta, sintheta, shifted

--- a/healpy/src/_query_disc.pyx
+++ b/healpy/src/_query_disc.pyx
@@ -203,7 +203,7 @@ def _boundaries_single(nside, pix, step=1, nest=False):
         raise ValueError('Pixel identifier is too large')
     hb.boundaries(pix, step, bounds)
     cdef size_t n = bounds.size()
-    cdef np.ndarray[double, ndim = 2] out = np.empty((3, n), dtype=np.float)
+    cdef np.ndarray[double, ndim = 2] out = np.empty((3, n), dtype=np.float64)
     for i in range(n):
         out[0,i] = bounds[i].x
         out[1,i] = bounds[i].y
@@ -220,7 +220,7 @@ def _boundaries_multiple(nside, pix, step=1, nest=False):
     cdef size_t npix = len(pix)
     cdef size_t n = step * 4
     cdef size_t maxnpix = 12*nside*nside
-    cdef np.ndarray[double, ndim = 3] out = np.empty((npix, 3, n), dtype=np.float)
+    cdef np.ndarray[double, ndim = 3] out = np.empty((npix, 3, n), dtype=np.float64)
     cdef vector[vec3] bounds
  
     for j in range(npix):

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -42,7 +42,7 @@ class TestSphtFunc(unittest.TestCase):
                 "data",
                 "wmap_temperature_analysis_mask_r9_7yr_v4_udgraded32.fits",
             )
-        ).astype(np.bool)
+        ).astype(np.bool_)
         for m in chain(self.map1, self.map2):
             m.mask = np.logical_not(self.mask)
         self.cla = hp.read_cl(


### PR DESCRIPTION
The np.bool and np.float types have been deprecated in numpy 1.20 and
the correct versions have been available for a very long time.