### PR TITLE
Do not assume that OBJECT is a string

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -399,7 +399,7 @@ def read_map(
     ret = []
 
     # partial sky: check OBJECT, then INDXSCHM
-    obj = fits_hdu.header.get("OBJECT", "UNDEF").strip()
+    obj = str(fits_hdu.header.get("OBJECT", "UNDEF")).strip()
     if obj != "UNDEF":
         if obj == "PARTIAL":
             partial = True


### PR DESCRIPTION
LIGO/Virgo probability maps sometimes set OBJECT to an integer to indicate an event ID:

https://git.ligo.org/lscsoft/ligo.skymap/-/blob/v0.5.0/CHANGES.rst#L11-13