### PR TITLE
Suggestion of a new nest parameter in healpy.smoothing() 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 Release in progress
 
-* Added a nest argument in healpy.sphtfunc.smoothing() <https://github.com/healpy/healpy/pull/678>
+* Support nested maps `hp.smoothing` <https://github.com/healpy/healpy/pull/678>
 * Improvements of the build system <https://github.com/healpy/healpy/pull/660> <https://github.com/healpy/healpy/pull/661>
 * Automatically build wheels for Linux/MacOS on Github actions <https://github.com/healpy/healpy/pull/656>
 * Drop support for Python 2.7-3.5 <https://github.com/healpy/healpy/pull/658>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 Release in progress
 
+* Added a nest argument in healpy.sphtfunc.smoothing() <https://github.com/healpy/healpy/pull/678>
 * Improvements of the build system <https://github.com/healpy/healpy/pull/660> <https://github.com/healpy/healpy/pull/661>
 * Automatically build wheels for Linux/MacOS on Github actions <https://github.com/healpy/healpy/pull/656>
 * Drop support for Python 2.7-3.5 <https://github.com/healpy/healpy/pull/658>

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -945,10 +945,10 @@ def smoothing(
     verbose : bool, optional
       If True prints diagnostic information. Default: True
     nest : bool, optional
-      If True, ordering scheme is NESTED. Default: False (RING)
-      The map ordering is modified by this function, the input map array should
-      be in RING ordering, if not this function will convert it to RING ordering 
-      and order the output back to NESTED. 
+      If True, the input map ordering is assumed to be NESTED. Default: False (RING)
+      This function will temporary reorder the NESTED map into RING to perform the
+      smoothing and order the output back to NESTED. If the map is in RING ordering 
+      no internal reordering will be performed. 
 
     Returns
     -------
@@ -1029,10 +1029,7 @@ def smoothing(
     output_map[masks] = UNSEEN
     
     if nest:
-        ordering = "NESTED"
         output_map = pixelfunc.reorder(output_map, inp=None, out=None, r2n=True, n2r=False)
-    else:
-        ordering = "RING" 
 
     return output_map
 

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -972,10 +972,7 @@ def smoothing(
     check_max_nside(nside)
     
     if nest:
-        ordering = "NESTED"
-        map_in = pixelfunc.reorder(map_in, inp=None, out=None, r2n=None, n2r=True)
-    else:
-        ordering = "RING"    
+        map_in = pixelfunc.reorder(map_in, inp=None, out=None, r2n=None, n2r=True) 
 
     if pol or n_maps in (0, 1):
         # Treat the maps together (1 or 3 maps)


### PR DESCRIPTION
I suggest implementing a new "nest" parameter in healpy.sphtfunc.smoothing() so that when the input map is in NESTED ordering, the function takes care of reordering it to RING for the smoothing and back to NESTED before the output. I have tried to follow the way "nest" argument where used in other Healpy functions, but maybe the description in the docstring can be improved and maybe the ordering back to NESTED can be removed and you could just specify that healpy.sphtfunc.smoothing() will return a RING ordered map no matter the input. 

I hope this helps a bit or at least serves as a base to improve the clarity of the smoothing function. 