### PR TITLE
warnings to logging and changing defaults for write_map, read_map

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
 Release in progress
 
+* Changed all warnings to using the `logging` module, removed all `verbose` keywords except `remove_dipole` (which computes and plots the amplitude) <https://github.com/healpy/healpy/pull/679>
+* `read_map` uses dtype of input map instead of float64 <https://github.com/healpy/healpy/pull/679>
 * `write_map` uses dtype of input map instead of float32 <https://github.com/healpy/healpy/pull/679>
 * `write_cl` uses dtype of input cl instead of float64 <https://github.com/healpy/healpy/pull/679>
 * Support nested maps `hp.smoothing` <https://github.com/healpy/healpy/pull/678>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Release in progress
 
 * Removed the note that we will change order of cl in `synfast` and `synalm`, we will leave `new=False` default <https://github.com/healpy/healpy/pull/679>
-* Changed all warnings to using the `logging` module, removed all `verbose` keywords except `remove_dipole` (which computes and plots the amplitude) <https://github.com/healpy/healpy/pull/679>
+* Changed all warnings to using the `logging` module, deprecated all `verbose` keywords except `remove_dipole` (which computes and plots the amplitude) <https://github.com/healpy/healpy/pull/679>
 * `read_map` uses dtype of input map instead of float64 <https://github.com/healpy/healpy/pull/679>
 * `write_map` uses dtype of input map instead of float32 <https://github.com/healpy/healpy/pull/679>
 * `write_cl` uses dtype of input cl instead of float64 <https://github.com/healpy/healpy/pull/679>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Release in progress
 
 * Support nested maps `hp.smoothing` <https://github.com/healpy/healpy/pull/678>
+* `write_cl` uses dtype of input cl instead of float64 <https://github.com/healpy/healpy/pull/679>
 * Improvements of the build system <https://github.com/healpy/healpy/pull/660> <https://github.com/healpy/healpy/pull/661>
 * Automatically build wheels for Linux/MacOS on Github actions <https://github.com/healpy/healpy/pull/656>
 * Drop support for Python 2.7-3.5 <https://github.com/healpy/healpy/pull/658>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 Release in progress
 
+* Removed the note that we will change order of cl in `synfast` and `synalm`, we will leave `new=False` default <https://github.com/healpy/healpy/pull/679>
 * Changed all warnings to using the `logging` module, removed all `verbose` keywords except `remove_dipole` (which computes and plots the amplitude) <https://github.com/healpy/healpy/pull/679>
 * `read_map` uses dtype of input map instead of float64 <https://github.com/healpy/healpy/pull/679>
 * `write_map` uses dtype of input map instead of float32 <https://github.com/healpy/healpy/pull/679>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 Release in progress
 
-* Support nested maps `hp.smoothing` <https://github.com/healpy/healpy/pull/678>
+* `write_map` uses dtype of input map instead of float32 <https://github.com/healpy/healpy/pull/679>
 * `write_cl` uses dtype of input cl instead of float64 <https://github.com/healpy/healpy/pull/679>
+* Support nested maps `hp.smoothing` <https://github.com/healpy/healpy/pull/678>
 * Improvements of the build system <https://github.com/healpy/healpy/pull/660> <https://github.com/healpy/healpy/pull/661>
 * Automatically build wheels for Linux/MacOS on Github actions <https://github.com/healpy/healpy/pull/656>
 * Drop support for Python 2.7-3.5 <https://github.com/healpy/healpy/pull/658>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,6 +23,11 @@ is very welcome to propose new features.
 * transform maps to Spherical Harmonics space and back using multi-threaded C++ routines
 * compute Auto and Cross Power Spectra from maps and create map realizations from spectra
 
+Changelog
+---------
+
+Review the changes in each release in the `CHANGELOG on Github <https://github.com/healpy/healpy/blob/main/CHANGELOG.rst>`_.
+
 Citing
 ------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,6 +23,28 @@ is very welcome to propose new features.
 * transform maps to Spherical Harmonics space and back using multi-threaded C++ routines
 * compute Auto and Cross Power Spectra from maps and create map realizations from spectra
 
+Verbosity
+---------
+
+Starting from 1.15.0, `healpy` uses the `logging` module instead of `warnings`.
+By default `healpy` will only print warnings and errors, to configure logging,
+you can use :py:func:configure_logging, which by default enables all logging as
+in `healpy` 1.14.0.
+For more advanced configuration you can access the "healpy" logger with::
+
+    import logging
+    log = logging.getLogger("healpy")
+
+For more details see the `Python documentation <https://docs.python.org/3/library/logging.html>`_.
+
+All the `verbose` keywords (except :py:func:remove_dipole) are now deprecated and
+will be removed in the future.
+You can disable deprecation warnings with::
+
+    import warnings
+    from astropy.utils.exceptions import AstropyDeprecationWarning
+    warnings.simplefilter('ignore', category=AstropyDeprecationWarning)
+
 Changelog
 ---------
 

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -104,10 +104,3 @@ from .fitsfunc import write_map, read_map, read_alm, write_alm, write_cl, read_c
 from ._masktools import dist2holes_healpy as dist2holes
 from ._hotspots import hotspots_healpy as hotspots
 from ._line_integral_convolution import line_integral_convolution
-
-# Default null handler prevents printing all log messages if the user doesn't
-# configure `logging`
-# See https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
-import logging
-
-logging.getLogger("healpy").addHandler(logging.NullHandler())

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -21,8 +21,6 @@
 compute spherical harmonics tranforms on them.
 """
 
-import warnings
-
 from .version import __version__
 
 from .pixelfunc import (
@@ -105,18 +103,10 @@ from .zoomtool import mollzoom, set_g_clim
 from .fitsfunc import write_map, read_map, read_alm, write_alm, write_cl, read_cl
 from ._masktools import dist2holes_healpy as dist2holes
 from ._hotspots import hotspots_healpy as hotspots
-from ._line_integral_convolution import line_integral_convolution
 
+# Default null handler prevents printing all log messages if the user doesn't
+# configure `logging`
+# See https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
+import logging
 
-def disable_warnings():
-    """Disable all healpy warnings messages for the current session
-
-    Warnings from individual functions can be disabled setting
-    ``verbose=False``.
-    Warnings can be re-enabled calling ``hp.enable_warnings()``.
-    """
-    warnings.filterwarnings(action="ignore", module="healpy")
-
-
-def enable_warnings():
-    warnings.simplefilter("always")
+logging.getLogger("healpy").addHandler(logging.NullHandler())

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -103,6 +103,7 @@ from .zoomtool import mollzoom, set_g_clim
 from .fitsfunc import write_map, read_map, read_alm, write_alm, write_cl, read_cl
 from ._masktools import dist2holes_healpy as dist2holes
 from ._hotspots import hotspots_healpy as hotspots
+from ._line_integral_convolution import line_integral_convolution
 
 # Default null handler prevents printing all log messages if the user doesn't
 # configure `logging`

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -21,6 +21,8 @@
 compute spherical harmonics tranforms on them.
 """
 
+import logging
+
 from .version import __version__
 
 from .pixelfunc import (
@@ -104,3 +106,55 @@ from .fitsfunc import write_map, read_map, read_alm, write_alm, write_cl, read_c
 from ._masktools import dist2holes_healpy as dist2holes
 from ._hotspots import hotspots_healpy as hotspots
 from ._line_integral_convolution import line_integral_convolution
+
+from astropy.utils.decorators import deprecated
+
+
+@deprecated("1.15.0", alternative="configure_logging")
+def disable_warnings():
+    """healpy uses logging now
+
+    See configure_logging
+    This function has no effect
+    """
+    pass
+
+
+@deprecated("1.15.0", alternative="configure_logging")
+def enable_warnings():
+    """healpy uses logging now
+
+    See configure_logging
+    This function has no effect
+    """
+    pass
+
+
+def configure_logging(
+    level=logging.DEBUG, log_format="%(name)s - %(levelname)s - %(message)s"
+):
+    """Configure logging
+
+    By default healpy only prints warning or error messages, to disable even
+    that, set the level to `logging.CRITICAL`.
+    Calling `configure_logging` with default arguments restores the same logging
+    messages of `healpy<=1.14.0`.
+
+    Parameters
+    ----------
+    level : int
+        Logging level, DEBUG, INFO, WARNING, ERROR, CRITICAL
+    log_format : str
+        Logging format string, see the logging module documentation
+    """
+    log = logging.getLogger("healpy")
+    log.setLevel(level)
+
+    # create console handler
+    handler = logging.StreamHandler()
+
+    # create formatter
+    formatter = logging.Formatter(log_format)
+    handler.setFormatter(formatter)
+
+    log.addHandler(handler)

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -702,6 +702,8 @@ def getformat(t):
         np.dtype(np.complex64): "C",
         np.dtype(np.complex128): "M",
     }
+    if hasattr(t, "type"):
+        t = t.type
     try:
         if t in conv:
             return conv[t]

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -23,6 +23,7 @@ from __future__ import division
 
 import sys
 import logging
+log = logging.getLogger("healpy")
 
 import pathlib
 import astropy.io.fits as pf
@@ -185,7 +186,7 @@ def write_map(
     # check the dtype and convert it
     if dtype is None:
         dtype = [x.dtype for x in m]
-        logging.info("setting the output map dtype to %s", str(dtype))
+        log.info("setting the output map dtype to %s", str(dtype))
     try:
         fitsformat = []
         for curr_dtype in dtype:
@@ -359,20 +360,20 @@ def read_map(
 
     nside = fits_hdu.header.get("NSIDE")
     if nside is None:
-        logging.info(
+        log.info(
             "No NSIDE in the header file : will use length of array"
         )
     else:
         nside = int(nside)
-    logging.info("NSIDE = %d", nside)
+    log.info("NSIDE = %d", nside)
 
     if not pixelfunc.isnsideok(nside):
         raise ValueError("Wrong nside parameter.")
     ordering = fits_hdu.header.get("ORDERING", "UNDEF").strip()
     if ordering == "UNDEF":
         ordering = nest and "NESTED" or "RING"
-        logging.info("No ORDERING keyword in header file : assume %s", ordering)
-    logging.info("ORDERING = %s in fits file", ordering)
+        log.info("No ORDERING keyword in header file : assume %s", ordering)
+    log.info("ORDERING = %s in fits file", ordering)
 
     sz = pixelfunc.nside2npix(nside)
     ret = []
@@ -398,8 +399,8 @@ def read_map(
 
     if schm == "UNDEF":
         schm = partial and "EXPLICIT" or "IMPLICIT"
-        logging.info("No INDXSCHM keyword in header file: assume %s", schm)
-    logging.info("INDXSCHM = %s", schm)
+        log.info("No INDXSCHM keyword in header file: assume %s", schm)
+    log.info("INDXSCHM = %s", schm)
 
     if field is None:
         field = range(len(fits_hdu.data.columns) - 1 * partial)
@@ -412,8 +413,8 @@ def read_map(
         try:
             pix = fits_hdu.data.field(0).astype(int, copy=False).ravel()
         except pf.VerifyError as e:
-            logging.warning(e)
-            logging.warning("Trying to fix a badly formatted header")
+            log.warning(e)
+            log.warning("Trying to fix a badly formatted header")
             fits_hdu.verify("fix")
             pix = fits_hdu.data.field(0).astype(int, copy=False).ravel()
 
@@ -431,8 +432,8 @@ def read_map(
             else:
                 m = fits_hdu.data.field(ff).astype(curr_dtype, copy=False).ravel()
         except pf.VerifyError as e:
-            logging.warning(e)
-            logging.warning("Trying to fix a badly formatted header")
+            log.warning(e)
+            log.warning("Trying to fix a badly formatted header")
             m = fits_hdu.verify("fix")
             if curr_dtype is None:
                 m = fits_hdu.data.field(ff).ravel()
@@ -450,11 +451,11 @@ def read_map(
             if nest and ordering == "RING":
                 idx = pixelfunc.nest2ring(nside, np.arange(m.size, dtype=np.int32))
                 m = m[idx]
-                logging.info("Ordering converted to NEST")
+                log.info("Ordering converted to NEST")
             elif (not nest) and ordering == "NESTED":
                 idx = pixelfunc.ring2nest(nside, np.arange(m.size, dtype=np.int32))
                 m = m[idx]
-                logging.info("Ordering converted to RING")
+                log.info("Ordering converted to RING")
         try:
             m[pixelfunc.mask_bad(m)] = UNSEEN
         except OverflowError:

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -23,11 +23,13 @@ from __future__ import division
 
 import sys
 import logging
+
 log = logging.getLogger("healpy")
 
 import pathlib
 import astropy.io.fits as pf
 import numpy as np
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from . import pixelfunc
 from .sphtfunc import Alm
@@ -287,6 +289,7 @@ def write_map(
     tbhdu.writeto(str(filename), overwrite=overwrite)
 
 
+@deprecated_renamed_argument("verbose", None, "1.15.0")
 def read_map(
     filename,
     field=0,
@@ -295,6 +298,7 @@ def read_map(
     partial=False,
     hdu=1,
     h=False,
+    verbose=True,
     memmap=False,
 ):
     """Read a healpix map from a fits file.  Partial-sky files,
@@ -340,8 +344,8 @@ def read_map(
       the header number to look at (start at 0)
     h : bool, optional
       If True, return also the header. Default: False.
-    verbose : bool, not supported anymore
-      Configure the Python logging module instead
+    verbose : bool, deprecated
+      It has no effect, see `hp.configure_logging`
     memmap : bool, optional
       Argument passed to astropy.io.fits.open, if True, the map is not read into memory,
       but only the required pixels are read when needed. Default: False.

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -124,7 +124,12 @@ def write_map(
     extra_header=(),
     overwrite=False,
 ):
-    """Writes a healpix map into a healpix file.
+    """Writes a healpix map into a healpix FITS file.
+
+    WARNING: starting from healpy 1.15.0, if you do not specify `dtype`,
+    the map will be written to disk with the same precision it is stored in memory.
+    Previously, by default `healpy` wrote maps in `float32`.
+    To reproduce the same behaviour of `healpy` 1.14.0 and below, set `dtype=np.float32`.
 
     Parameters
     ----------
@@ -283,7 +288,7 @@ def write_map(
 def read_map(
     filename,
     field=0,
-    dtype=np.float64,
+    dtype=None,
     nest=False,
     partial=False,
     hdu=1,
@@ -292,6 +297,12 @@ def read_map(
 ):
     """Read a healpix map from a fits file.  Partial-sky files,
     if properly identified, are expanded to full size and filled with UNSEEN.
+
+    WARNING: starting from healpy 1.15.0, if you do not specify `dtype`,
+    the map will be read in memory with the same precision it is stored on disk.
+    Previously, by default `healpy` wrote maps in `float32` and then upcast to
+    `float64` when reading to memory. To reproduce the same behaviour of `healpy`
+    1.14.0 and below, set `dtype=np.float64` in `read_map`.
 
     Parameters
     ----------
@@ -309,9 +320,7 @@ def read_map(
       types for each field. In that case, the length of the list must
       correspond to the length of the field parameter.
       If None, keep the dtype of the input FITS file
-      Default: use np.float64
-      (WARNING: in a future version this will change to
-      "use the data type of the input FITS file".)
+      Default: None
     nest : bool, optional
       If True return the map in NEST ordering, otherwise in RING ordering;
       use fits keyword ORDERING to decide whether conversion is needed or not
@@ -340,15 +349,6 @@ def read_map(
     m | (m0, m1, ...) [, header] : array or a tuple of arrays, optionally with header appended
       The map(s) read from the file, and the header if *h* is True.
     """
-    # Temporary warning for default dtype
-    if dtype == np.float64:
-        logging.warning(
-            "If you are not specifying the input dtype and using the default "
-            "np.float64 dtype of read_map(), please consider that it will "
-            "change in a future version to None as to keep the same dtype of "
-            "the input file: please explicitly set the dtype if it is "
-            "important to you."
-        )
 
     opened_file = False
     if isinstance(filename, allowed_paths):

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -127,10 +127,10 @@ def write_map(
 ):
     """Writes a healpix map into a healpix FITS file.
 
-    WARNING: starting from healpy 1.15.0, if you do not specify `dtype`,
-    the map will be written to disk with the same precision it is stored in memory.
-    Previously, by default `healpy` wrote maps in `float32`.
-    To reproduce the same behaviour of `healpy` 1.14.0 and below, set `dtype=np.float32`.
+    .. warning:: Starting from healpy 1.15.0, if you do not specify `dtype`,
+       the map will be written to disk with the same precision it is stored in memory.
+       Previously, by default `healpy` wrote maps in `float32`.
+       To reproduce the same behaviour of `healpy` 1.14.0 and below, set `dtype=np.float32`.
 
     Parameters
     ----------
@@ -170,8 +170,9 @@ def write_map(
       internally from the numpy datatype to the fits convention. If a list,
       the length must correspond to the number of map arrays.
       Default: use the data type of the input array(s)
-      (WARNING: this changed in 1.15.0, previous versions saved in float32
-      by default)
+      WARNING: this changed in 1.15.0, previous versions saved in float32
+      by default
+
     overwrite : bool, optional
       If True, existing file is silently overwritten. Otherwise trying to write
       an existing file raises an OSError (IOError for Python 2).
@@ -299,11 +300,11 @@ def read_map(
     """Read a healpix map from a fits file.  Partial-sky files,
     if properly identified, are expanded to full size and filled with UNSEEN.
 
-    WARNING: starting from healpy 1.15.0, if you do not specify `dtype`,
-    the map will be read in memory with the same precision it is stored on disk.
-    Previously, by default `healpy` wrote maps in `float32` and then upcast to
-    `float64` when reading to memory. To reproduce the same behaviour of `healpy`
-    1.14.0 and below, set `dtype=np.float64` in `read_map`.
+    .. warning:: Starting from healpy 1.15.0, if you do not specify `dtype`,
+       the map will be read in memory with the same precision it is stored on disk.
+       Previously, by default `healpy` wrote maps in `float32` and then upcast to
+       `float64` when reading to memory. To reproduce the same behaviour of `healpy`
+       1.14.0 and below, set `dtype=np.float64` in `read_map`.
 
     Parameters
     ----------

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -85,21 +85,14 @@ def write_cl(filename, cl, dtype=None, overwrite=False):
       the cl array to write to file
     dtype : np.dtype (optional)
       The datatype in which the columns will be stored. If not supplied,
-      np.float64 will be assumed.
-      (WARNING: in some future version, the type of cl will be used instead.)
+      the dtype of the input cl will be used. This changed in `healpy` 1.15.0,
+      in previous versions, cl by default were saved in `float64`.
     overwrite : bool, optional
       If True, existing file is silently overwritten. Otherwise trying to write
-      an existing file raises an OSError (IOError for Python 2).
+      an existing file raises an OSError.
     """
     if dtype is None:
-        warnings.warn(
-            "The default dtype of write_cl() will change in a future version: "
-            "explicitly set the dtype if it is important to you",
-            category=FutureWarning,
-        )
-        dtype = np.float64
-        # At some poin change this to:
-        # dtype = cl.dtype if isinstance(cl, np.ndarray) else cl[0].dtype
+        dtype = cl.dtype if isinstance(cl, np.ndarray) else cl[0].dtype
     # check the dtype and convert it
     fitsformat = getformat(dtype)
     column_names = ["TEMPERATURE", "GRADIENT", "CURL", "G-T", "C-T", "C-G"]

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -167,9 +167,9 @@ def write_map(
       The datatype in which the columns will be stored. Will be converted
       internally from the numpy datatype to the fits convention. If a list,
       the length must correspond to the number of map arrays.
-      Default: use np.float32
-      (WARNING: in a future version this will change to
-      "use the data type of the input array(s)".)
+      Default: use the data type of the input array(s)
+      (WARNING: this changed in 1.15.0, previous versions saved in float32
+      by default)
     overwrite : bool, optional
       If True, existing file is silently overwritten. Otherwise trying to write
       an existing file raises an OSError (IOError for Python 2).
@@ -183,14 +183,8 @@ def write_map(
 
     # check the dtype and convert it
     if dtype is None:
-        warnings.warn(
-            "The default dtype of write_map() will change in a future version: "
-            "explicitly set the dtype if it is important to you",
-            category=FutureWarning,
-        )
-        dtype = [np.float32 for x in m]
-        # Change this at some point to:
-        # dtype = [x.dtype for x in m]
+        dtype = [x.dtype for x in m]
+        logging.info("setting the output map dtype to %s", str(dtype))
     try:
         fitsformat = []
         for curr_dtype in dtype:

--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -89,6 +89,7 @@ Map data manipulation
 import numpy as np
 from functools import wraps
 import logging
+log = logging.getLogger("healpy")
 
 UNSEEN = None
 
@@ -98,7 +99,7 @@ try:
     #: Special value used for masked pixels
     UNSEEN = pixlib.UNSEEN
 except:
-    logging.warning("Warning: cannot import _healpy_pixel_lib module")
+    log.warning("Warning: cannot import _healpy_pixel_lib module")
 
 # We are using 64-bit integer types.
 # nside > 2**29 requires extended integer types.
@@ -1684,7 +1685,7 @@ def remove_monopole(
         ipix = ipix[(m.flat[ipix] != bad) & (np.isfinite(m.flat[ipix]))]
         x, y, z = pix2vec(nside, ipix, nest)
         m.flat[ipix] -= mono
-    logging.info("monopole: %.3g", mono)
+    log.info("monopole: %.3g", mono)
     if input_ma:
         m = ma(m)
     if fitval:

--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -89,7 +89,9 @@ Map data manipulation
 import numpy as np
 from functools import wraps
 import logging
+
 log = logging.getLogger("healpy")
+from astropy.utils.decorators import deprecated_renamed_argument
 
 UNSEEN = None
 
@@ -1634,8 +1636,9 @@ def fit_monopole(m, nest=False, bad=UNSEEN, gal_cut=0):
     return mono
 
 
+@deprecated_renamed_argument("verbose", None, "1.15.0")
 def remove_monopole(
-    m, nest=False, bad=UNSEEN, gal_cut=0, fitval=False, copy=True
+    m, nest=False, bad=UNSEEN, gal_cut=0, fitval=False, copy=True, verbose=True
 ):
     """Fit and subtract the monopole from the given map m.
 

--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -843,9 +843,8 @@ def reorder(map_in, inp=None, out=None, r2n=None, n2r=None):
       the reordered map, as masked array if the input was a
       masked array
 
-    Notes
-    -----
-    if ``r2n`` or ``n2r`` is defined, override ``inp`` and ``out``.
+    .. note::
+       if ``r2n`` or ``n2r`` is defined, override ``inp`` and ``out``.
 
     See Also
     --------
@@ -973,9 +972,8 @@ def nside2order(nside):
     order : int
       corresponding order where nside = 2**(order)
 
-    Notes
-    -----
-    Raise a ValueError exception if nside is not valid.
+    .. note::
+       Raises a ValueError exception if nside is not valid.
 
     Examples
     --------
@@ -1014,9 +1012,8 @@ def nside2resol(nside, arcmin=False):
     resol : float
       approximate pixel size in radians or arcmin
 
-    Notes
-    -----
-    Raise a ValueError exception if nside is not valid.
+    .. note::
+       Raise a ValueError exception if nside is not valid.
 
     Examples
     --------
@@ -1054,9 +1051,8 @@ def nside2pixarea(nside, degrees=False):
     pixarea : float
       pixel area in square radian or square degree
 
-    Notes
-    -----
-    Raise a ValueError exception if nside is not valid.
+    .. note::
+       Raise a ValueError exception if nside is not valid.
 
     Examples
     --------
@@ -1092,10 +1088,9 @@ def npix2nside(npix):
     nside : int
       the nside parameter corresponding to npix
 
-    Notes
-    -----
-    Raise a ValueError exception if number of pixel does not correspond to
-    the number of pixel of a healpix map.
+    .. note::
+       Raises a ValueError exception if number of pixel does not correspond to
+       the number of pixel of a healpix map.
 
     Examples
     --------
@@ -1129,9 +1124,8 @@ def order2nside(order):
     nside : int
       the nside parameter corresponding to order
 
-    Notes
-    -----
-    Raise a ValueError exception if order produces an nside out of range.
+    .. note::
+       Raises a ValueError exception if order produces an nside out of range.
 
     Examples
     --------
@@ -1711,10 +1705,9 @@ def get_map_size(m):
      npix : int
        a valid number of pixel
 
-     Notes
-     -----
-     In implicit pixellization, raise a ValueError exception if the size of the input
-     is not a valid pixel number.
+     .. note::
+        In implicit pixellization, raise a ValueError exception if the size of the
+        input is not a valid pixel number.
 
      Examples
      --------
@@ -1783,11 +1776,10 @@ def get_nside(m):
     nside : int
       the healpix nside parameter of the map (or sequence of maps)
 
-    Notes
-    -----
-    If the input is a sequence of maps, all of them must have same size.
-    If the input is not a valid map (not a sequence, unvalid number of pixels),
-    a TypeError exception is raised.
+    .. note::
+       If the input is a sequence of maps, all of them must have same size.
+       If the input is not a valid map (not a sequence, unvalid number of pixels),
+       a TypeError exception is raised.
     """
     typ = maptype(m)
     if typ == 0:

--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -88,7 +88,7 @@ Map data manipulation
 
 import numpy as np
 from functools import wraps
-import warnings
+import logging
 
 UNSEEN = None
 
@@ -98,7 +98,7 @@ try:
     #: Special value used for masked pixels
     UNSEEN = pixlib.UNSEEN
 except:
-    warnings.warn("Warning: cannot import _healpy_pixel_lib module")
+    logging.warning("Warning: cannot import _healpy_pixel_lib module")
 
 # We are using 64-bit integer types.
 # nside > 2**29 requires extended integer types.
@@ -1541,8 +1541,7 @@ def remove_dipole(
     copy : bool
       whether to modify input map or not (by default, make a copy)
     verbose : bool
-      print values of monopole and dipole
-      call hp.disable_warnings() to disable warnings for all functions.
+      compute and print values of monopole and dipole
 
     Returns
     -------
@@ -1578,7 +1577,7 @@ def remove_dipole(
 
         lon, lat = R.vec2dir(dipole, lonlat=True)
         amp = np.sqrt((dipole * dipole).sum())
-        warnings.warn(
+        print(
             "monopole: {0:g}  dipole: lon: {1:g}, lat: {2:g}, amp: {3:g}".format(
                 mono, lon, lat, amp
             )
@@ -1641,7 +1640,7 @@ def fit_monopole(m, nest=False, bad=UNSEEN, gal_cut=0):
 
 
 def remove_monopole(
-    m, nest=False, bad=UNSEEN, gal_cut=0, fitval=False, copy=True, verbose=True
+    m, nest=False, bad=UNSEEN, gal_cut=0, fitval=False, copy=True
 ):
     """Fit and subtract the monopole from the given map m.
 
@@ -1659,8 +1658,6 @@ def remove_monopole(
       whether to return or not the fitted value of monopole
     copy : bool
       whether to modify input map or not (by default, make a copy)
-    verbose: bool
-      whether to print values of monopole
 
     Returns
     -------
@@ -1687,8 +1684,7 @@ def remove_monopole(
         ipix = ipix[(m.flat[ipix] != bad) & (np.isfinite(m.flat[ipix]))]
         x, y, z = pix2vec(nside, ipix, nest)
         m.flat[ipix] -= mono
-    if verbose:
-        warnings.warn("monopole: {0:g}".format(mono))
+    logging.info("monopole: %.3g", mono)
     if input_ma:
         m = ma(m)
     if fitval:

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -18,6 +18,7 @@
 #  For more information about Healpy, see http://code.google.com/p/healpy
 #
 import logging
+log = logging.getLogger("healpy")
 from . import projector as P
 from . import rotator as R
 from . import pixelfunc
@@ -607,7 +608,7 @@ class SphericalProjAxes(matplotlib.axes.Axes):
                         if l in self.lines:
                             self.lines.remove(l)
                         else:
-                            logging.warning("line not in lines")
+                            log.warning("line not in lines")
             del self._graticules
 
     def _get_interv_graticule(self, pmin, pmax, dpar, mmin, mmax, dmer):
@@ -637,10 +638,10 @@ class SphericalProjAxes(matplotlib.axes.Axes):
             dmer = dpar = max(dmer, dpar)
         vdeg = int(np.floor(np.around(dpar / dtor, 10)))
         varcmin = (dpar / dtor - vdeg) * 60.0
-        logging.info("The interval between parallels is %d deg %.2f'.", vdeg, varcmin)
+        log.info("The interval between parallels is %d deg %.2f'.", vdeg, varcmin)
         vdeg = int(np.floor(np.around(dmer / dtor, 10)))
         varcmin = (dmer / dtor - vdeg) * 60.0
-        logging.info("The interval between meridians is %d deg %.2f'.", vdeg, varcmin)
+        log.info("The interval between meridians is %d deg %.2f'.", vdeg, varcmin)
         return dpar, dmer
 
 

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -17,7 +17,7 @@
 #
 #  For more information about Healpy, see http://code.google.com/p/healpy
 #
-import warnings
+import logging
 from . import projector as P
 from . import rotator as R
 from . import pixelfunc
@@ -80,14 +80,12 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         self._gratdef["dpar"] = 30.0
 
     def set_format(self, f):
-        """Set the format string for value display
-        """
+        """Set the format string for value display"""
         self._format = f
         return f
 
     def set_coordprec(self, n):
-        """Set the number of digits after floating point for coord display.
-        """
+        """Set the number of digits after floating point for coord display."""
         self._coordprec = n
 
     def format_coord(self, x, y):
@@ -113,14 +111,12 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         return res
 
     def get_lonlat(self, x, y):
-        """Get the coordinate in the coord system of the image, in lon/lat in deg.
-        """
+        """Get the coordinate in the coord system of the image, in lon/lat in deg."""
         lon, lat = self.proj.xy2ang(x, y, lonlat=True)
         return lon, lat
 
     def get_value(self, x, y):
-        """Get the value of the map at position x,y
-        """
+        """Get the value of the map at position x,y"""
         if len(self.get_images()) < 1:
             return None
         im = self.get_images()[-1]
@@ -194,8 +190,9 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         if vmin == vmax:
             vmin -= 1.0
             vmax += 1.0
-        cm, nn = get_color_table(vmin, vmax, img[w], cmap=cmap, norm=norm,
-                                 badcolor=badcolor, bgcolor=bgcolor)
+        cm, nn = get_color_table(
+            vmin, vmax, img[w], cmap=cmap, norm=norm, badcolor=badcolor, bgcolor=bgcolor
+        )
         ext = self.proj.get_extent()
         img = np.ma.masked_values(img, badval)
         aximg = self.imshow(
@@ -293,9 +290,11 @@ class SphericalProjAxes(matplotlib.axes.Axes):
                 try:  # works in matplotlib 1.3 and earlier
                     linestyle, marker, color = matplotlib.axes._process_plot_format(fmt)
                 except:  # matplotlib 1.4 and later
-                    linestyle, marker, color = matplotlib.axes._axes._process_plot_format(
-                        fmt
-                    )
+                    (
+                        linestyle,
+                        marker,
+                        color,
+                    ) = matplotlib.axes._axes._process_plot_format(fmt)
                 kwds.setdefault("linestyle", linestyle)
                 kwds.setdefault("marker", marker)
                 if color is not None:
@@ -489,9 +488,7 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         phi0 = np.arctan2(vy, vx)
         return phi0 - fov / sth / 2.0, phi0 + fov / sth / 2.0
 
-    def graticule(
-        self, dpar=None, dmer=None, coord=None, local=None, verbose=True, **kwds
-    ):
+    def graticule(self, dpar=None, dmer=None, coord=None, local=None, **kwds):
         """Draw a graticule.
 
         Input:
@@ -536,16 +533,8 @@ class SphericalProjAxes(matplotlib.axes.Axes):
             mmin = u_mmin
         if u_mmax:
             mmax = u_pmax
-        if verbose:
-            warnings.warn(
-                "{0} {1} {2} {3}".format(
-                    pmin / dtor, pmax / dtor, mmin / dtor, mmax / dtor
-                )
-            )
         if not kwds.pop("force", False):
-            dpar, dmer = self._get_interv_graticule(
-                pmin, pmax, dpar, mmin, mmax, dmer, verbose=verbose
-            )
+            dpar, dmer = self._get_interv_graticule(pmin, pmax, dpar, mmin, mmax, dmer)
         theta_list = np.around(np.arange(pmin, pmax + 0.5 * dpar, dpar) / dpar) * dpar
         phi_list = np.around(np.arange(mmin, mmax + 0.5 * dmer, dmer) / dmer) * dmer
         theta = np.arange(
@@ -612,8 +601,7 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         return dpar, dmer
 
     def delgraticules(self):
-        """Delete all graticules previously created on the Axes.
-        """
+        """Delete all graticules previously created on the Axes."""
         if hasattr(self, "_graticules"):
             for dum1, dum2, g in self._graticules:
                 for gl in g:
@@ -621,10 +609,10 @@ class SphericalProjAxes(matplotlib.axes.Axes):
                         if l in self.lines:
                             self.lines.remove(l)
                         else:
-                            warnings.warn("line not in lines")
+                            logging.warning("line not in lines")
             del self._graticules
 
-    def _get_interv_graticule(self, pmin, pmax, dpar, mmin, mmax, dmer, verbose=True):
+    def _get_interv_graticule(self, pmin, pmax, dpar, mmin, mmax, dmer):
         def set_prec(d, n, nn=2):
             arcmin = False
             if d / n < 1.0:
@@ -651,20 +639,10 @@ class SphericalProjAxes(matplotlib.axes.Axes):
             dmer = dpar = max(dmer, dpar)
         vdeg = int(np.floor(np.around(dpar / dtor, 10)))
         varcmin = (dpar / dtor - vdeg) * 60.0
-        if verbose:
-            warnings.warn(
-                "The interval between parallels is {0:d} deg {1:.2f}'.".format(
-                    vdeg, varcmin
-                )
-            )
+        logging.info("The interval between parallels is %d deg %.2f'.", vdeg, varcmin)
         vdeg = int(np.floor(np.around(dmer / dtor, 10)))
         varcmin = (dmer / dtor - vdeg) * 60.0
-        if verbose:
-            warnings.warn(
-                "The interval between meridians is {0:d} deg {1:.2f}'.".format(
-                    vdeg, varcmin
-                )
-            )
+        logging.info("The interval between meridians is %d deg %.2f'.", vdeg, varcmin)
         return dpar, dmer
 
 
@@ -736,8 +714,7 @@ class HpxMollweideAxes(MollweideAxes):
 
 
 class CartesianAxes(SphericalProjAxes):
-    """Define a cylindrical Axes to handle cylindrical projection.
-    """
+    """Define a cylindrical Axes to handle cylindrical projection."""
 
     def __init__(self, *args, **kwds):
         kwds.setdefault("coordprec", 2)
@@ -868,8 +845,9 @@ class HpxAzimuthalAxes(AzimuthalAxes):
 #   http://matplotlib.org/examples/pylab_examples/custom_cmap.html
 
 
-def get_color_table(vmin, vmax, val, cmap=None, norm=None,
-                    badcolor="gray", bgcolor="white"):
+def get_color_table(
+    vmin, vmax, val, cmap=None, norm=None, badcolor="gray", bgcolor="white"
+):
     # Create color table
     newcmap = create_colormap(cmap, badcolor=badcolor, bgcolor=bgcolor)
     if type(norm) is str:

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -202,8 +202,6 @@ class SphericalProjAxes(matplotlib.axes.Axes):
             norm=nn,
             interpolation="nearest",
             origin="lower",
-            vmin=vmin,
-            vmax=vmax,
             **kwds
         )
         xmin, xmax, ymin, ymax = self.proj.get_extent()

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -47,9 +47,8 @@ class SphericalProjAxes(matplotlib.axes.Axes):
     coordprec : number of digit after floating point for coordinates display.
     format : format string for value display.
 
-    Notes
-    -----
-    Other keywords from Axes (see Axes).
+    .. note::
+       Other keywords from Axes (see Axes).
     """
 
     def __init__(self, ProjClass, *args, **kwds):
@@ -170,9 +169,8 @@ class SphericalProjAxes(matplotlib.axes.Axes):
           The coordinate system of the map ('G','E' or 'C'), rotate
           the map if different from the axes coord syst.
 
-        Notes
-        -----
-        Other keywords are transmitted to :func:`matplotlib.Axes.imshow`
+        .. note::
+           Other keywords are transmitted to :func:`matplotlib.Axes.imshow`
         """
         img = self.proj.projmap(map, vec2pix_func, rot=rot, coord=coord)
         w = ~(np.isnan(img) | np.isinf(img) | pixelfunc.mask_bad(img, badval=badval))
@@ -243,9 +241,8 @@ class SphericalProjAxes(matplotlib.axes.Axes):
           if True, the rotation to center the projection is not
           taken into account
 
-        Notes
-        -----
-        Other keywords are passed to :func:`matplotlib.Axes.plot`.
+        .. note::
+           Other keywords are passed to :func:`matplotlib.Axes.plot`.
 
         See Also
         --------
@@ -332,9 +329,8 @@ class SphericalProjAxes(matplotlib.axes.Axes):
           if True, the rotation to center the projection is not
           taken into account
 
-        Notes
-        -----
-        Other keywords are passed to :func:`matplotlib.Axes.plot`.
+        .. note::
+           Other keywords are passed to :func:`matplotlib.Axes.plot`.
 
         See Also
         --------
@@ -390,9 +386,8 @@ class SphericalProjAxes(matplotlib.axes.Axes):
           if True, the rotation to center the projection is not
           taken into account
 
-        Notes
-        -----
-        Other keywords are passed to :func:`matplotlib.Axes.text`.
+        .. note::
+           Other keywords are passed to :func:`matplotlib.Axes.text`.
 
         See Also
         --------

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -19,8 +19,10 @@
 #
 import numpy as np
 import logging
+
 log = logging.getLogger("healpy")
 from astropy.coordinates import SkyCoord
+from astropy.utils.decorators import deprecated_renamed_argument
 from . import pixelfunc
 from . import sphtfunc
 from ._sphtools import rotate_alm
@@ -411,6 +413,7 @@ class Rotator(object):
         if not inplace:
             return rotated_alm
 
+    @deprecated_renamed_argument("verbose", None, "1.15.0")
     def rotate_map_alms(
         self,
         m,
@@ -418,6 +421,7 @@ class Rotator(object):
         lmax=None,
         mmax=None,
         datapath=None,
+        verbose=None,
     ):
         """Rotate a HEALPix map to a new reference frame in spherical harmonics space
 

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -415,7 +415,6 @@ class Rotator(object):
         lmax=None,
         mmax=None,
         datapath=None,
-        verbose=None,
     ):
         """Rotate a HEALPix map to a new reference frame in spherical harmonics space
 
@@ -442,7 +441,6 @@ class Rotator(object):
             lmax=lmax,
             mmax=mmax,
             datapath=datapath,
-            verbose=verbose,
         )
         rotated_alm = self.rotate_alm(alm, lmax=lmax, mmax=mmax)
         return sphtfunc.alm2map(
@@ -450,7 +448,6 @@ class Rotator(object):
             lmax=lmax,
             mmax=mmax,
             nside=pixelfunc.get_nside(m),
-            verbose=verbose,
         )
 
     def rotate_map_pixel(self, m):

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -19,6 +19,7 @@
 #
 import numpy as np
 import logging
+log = logging.getLogger("healpy")
 from astropy.coordinates import SkyCoord
 from . import pixelfunc
 from . import sphtfunc
@@ -162,7 +163,7 @@ class Rotator(object):
             self._coords.append(cn)  # append(cn) or insert(0, cn) ?
             self._invs.append(bool(i))
         if not self.consistent:
-            logging.warning(
+            log.warning(
                 "The chain of coord system rotations is not consistent",
             )
         self._update_matrix()

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -120,7 +120,9 @@ class Rotator(object):
         - inv: whether to use inverse rotation or not
         - deg: if True, angles in rot are assumed in degree (default: True)
         - eulertype: the convention for Euler angles in rot.
-        Note: the coord system conversion is applied first, then the rotation.
+
+        .. note::
+           the coord system conversion is applied first, then the rotation.
         """
         rot_is_seq = hasattr(rot, "__len__") and hasattr(rot[0], "__len__")
         coord_is_seq = (

--- a/healpy/rotator.py
+++ b/healpy/rotator.py
@@ -18,7 +18,7 @@
 #  For more information about Healpy, see http://code.google.com/p/healpy
 #
 import numpy as np
-import warnings
+import logging
 from astropy.coordinates import SkyCoord
 from . import pixelfunc
 from . import sphtfunc
@@ -54,18 +54,6 @@ e2q = (
     .get_xyz()
     .value
 )
-
-
-class ConsistencyWarning(Warning):
-    """Warns for a problem in the consistency of data
-    """
-
-    pass
-
-
-if __name__ != "__main__":
-    warnings.filterwarnings("always", category=ConsistencyWarning, module=__name__)
-
 
 class Rotator(object):
     """Rotation operator, including astronomical coordinate systems.
@@ -174,9 +162,8 @@ class Rotator(object):
             self._coords.append(cn)  # append(cn) or insert(0, cn) ?
             self._invs.append(bool(i))
         if not self.consistent:
-            warnings.warn(
+            logging.warning(
                 "The chain of coord system rotations is not consistent",
-                category=ConsistencyWarning,
             )
         self._update_matrix()
 

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -412,23 +412,9 @@ def synalm(cls, lmax=None, mmax=None, new=False):
 
     Notes
     -----
-    The order of the spectra will change in a future release. The new= parameter
-    help to make the transition smoother. You can start using the new order
-    by setting new=True.
-    In the next version of healpy, the default will be new=True.
-    This change is done for consistency between the different tools
-    (alm2cl, synfast, anafast).
-    In the new order, the spectra are ordered by diagonal of the correlation
-    matrix. Eg, if fields are T, E, B, the spectra are TT, EE, BB, TE, EB, TB
-    with new=True, and TT, TE, TB, EE, EB, BB if new=False.
+    We don't plan to change the default order anymore, that would break old
+    code in a way difficult to debug.
     """
-    if not new:
-        logging.warning(
-            "The order of the input cl's will change in a future "
-            "release.\n"
-            "Use new=True keyword to start using the new order.\n"
-            "See documentation of healpy.synalm.",
-        )
     if not cb.is_seq(cls):
         raise TypeError("cls must be an array or a sequence of arrays")
 
@@ -532,6 +518,11 @@ def synfast(
     sigma : float, scalar, optional
       The sigma of the Gaussian used to smooth the map (applied on alm)
       [in radians]
+    new : bool, optional
+      If True, use the new ordering of cl's, ie by diagonal
+      (e.g. TT, EE, BB, TE, EB, TB or TT, EE, BB, TE if 4 cl as input).
+      If False, use the old ordering, ie by row
+      (e.g. TT, TE, TB, EE, EB, BB or TT, TE, EE, BB if 4 cl as input).
 
     Returns
     -------
@@ -542,15 +533,8 @@ def synfast(
 
     Notes
     -----
-    The order of the spectra will change in a future release. The new= parameter
-    help to make the transition smoother. You can start using the new order
-    by setting new=True.
-    In the next version of healpy, the default will be new=True.
-    This change is done for consistency between the different tools
-    (alm2cl, synfast, anafast).
-    In the new order, the spectra are ordered by diagonal of the correlation
-    matrix. Eg, if fields are T, E, B, the spectra are TT, EE, BB, TE, EB, TB
-    with new=True, and TT, TE, TB, EE, EB, BB if new=False.
+    We don't plan to change the default order anymore, that would break old
+    code in a way difficult to debug.
     """
     if not pixelfunc.isnsideok(nside):
         raise ValueError("Wrong nside value (must be a power of two).")

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -607,7 +607,7 @@ class Alm(object):
 
     @staticmethod
     def getidx(lmax, l, m):
-        """Returns index corresponding to (l,m) in an array describing alm up to lmax.
+        r"""Returns index corresponding to (l,m) in an array describing alm up to lmax.
 
         In HEALPix C++ and healpy, :math:`a_{lm}` coefficients are stored ordered by
         :math:`m`. I.e. if :math:`\ell_{max}` is 16, the first 16 elements are

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -187,6 +187,12 @@ def map2alm(
     and add the NSIDE 8192 weight from https://github.com/healpy/healpy-data/releases
     and set datapath to the root of the repository.
 
+    .. note::
+       The pixels which have the special `UNSEEN` value are replaced by zeros
+       before spherical harmonic transform. They are converted back to `UNSEEN`
+       value, so that the input maps are not modified. Each map have its own,
+       independent mask.
+
     Parameters
     ----------
     maps : array-like, shape (Npix,) or (n, Npix)
@@ -216,13 +222,6 @@ def map2alm(
     -------
     alms : array or tuple of array
       alm or a tuple of 3 alm (almT, almE, almB) if polarized input.
-
-    Notes
-    -----
-    The pixels which have the special `UNSEEN` value are replaced by zeros
-    before spherical harmonic transform. They are converted back to `UNSEEN`
-    value, so that the input maps are not modified. Each map have its own,
-    independent mask.
     """
     maps = ma_to_array(maps)
     info = maptype(maps)
@@ -297,6 +296,16 @@ def alm2map(
     and mmax, or they will be computed from array size (assuming
     lmax==mmax).
 
+    .. note::
+       Running map2alm then alm2map will not return exactly the same map if
+       the discretized field you construct on the sphere is not band-limited
+       (for example, if you have a map containing pixel-based noise rather
+       than beam-smoothed noise). If you need a band-limited map, you have to
+       start with random numbers in lm space and transform these via alm2map.
+       With such an input, the accuracy of map2alm->alm2map should be quite good,
+       depending on your choices of lmax, mmax and nside (for some typical
+       values, see e.g., section 5.1 of https://arxiv.org/pdf/1010.2084).
+
     Parameters
     ----------
     alms : complex, array or sequence of arrays
@@ -334,9 +343,6 @@ def alm2map(
       A Healpix map in RING scheme at nside or a list of T,Q,U maps (if
       polarized input)
 
-    Notes
-    -----
-    Running map2alm then alm2map will not return exactly the same map if the discretized field you construct on the sphere is not band-limited (for example, if you have a map containing pixel-based noise rather than beam-smoothed noise). If you need a band-limited map, you have to start with random numbers in lm space and transform these via alm2map. With such an input, the accuracy of map2alm->alm2map should be quite good, depending on your choices of lmax, mmax and nside (for some typical values, see e.g., section 5.1 of https://arxiv.org/pdf/1010.2084).
     """
     if not cb.is_seq(alms):
         raise TypeError("alms must be a sequence")
@@ -409,10 +415,9 @@ def synalm(cls, lmax=None, mmax=None, new=False):
       the generated alm if one spectrum is given, or a list of n alms
       (with n(n+1)/2 the number of input cl, or n=3 if there are 4 input cl).
 
-    Notes
-    -----
-    We don't plan to change the default order anymore, that would break old
-    code in a way difficult to debug.
+    .. note::
+       We don't plan to change the default order anymore, that would break old
+       code in a way difficult to debug.
     """
     if not cb.is_seq(cls):
         raise TypeError("cls must be an array or a sequence of arrays")
@@ -530,10 +535,9 @@ def synfast(
       or, if alm is True, a tuple of (map,alm)
       (alm possibly a list of alm if polarized input)
 
-    Notes
-    -----
-    We don't plan to change the default order anymore, that would break old
-    code in a way difficult to debug.
+    .. note::
+       We don't plan to change the default order anymore, that would break old
+       code in a way difficult to debug.
     """
     if not pixelfunc.isnsideok(nside):
         raise ValueError("Wrong nside value (must be a power of two).")

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -792,7 +792,7 @@ def smoothalm(
     if beam_window is None:
         log.info("Sigma is %f arcmin (%f rad) ", sigma * 60 * 180 / np.pi, sigma)
         log.info(
-            "-> fwhm is {0:f} arcmin",
+            "-> fwhm is %f arcmin",
             sigma * 60 * 180 / np.pi * (2.0 * np.sqrt(2.0 * np.log(2.0))),
         )
 

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -22,6 +22,7 @@ log = logging.getLogger("healpy")
 import numpy as np
 
 import astropy.io.fits as pf
+from astropy.utils.decorators import deprecated_renamed_argument
 from scipy.integrate import trapz
 from astropy.utils import data
 
@@ -152,6 +153,7 @@ def anafast(
         return cls
 
 
+@deprecated_renamed_argument("verbose", None, "1.15.0")
 def map2alm(
     maps,
     lmax=None,
@@ -162,6 +164,7 @@ def map2alm(
     datapath=None,
     gal_cut=0,
     use_pixel_weights=False,
+    verbose=True,
 ):
     """Computes the alm of a Healpix map. The input maps must all be
     in ring ordering.
@@ -279,6 +282,7 @@ def map2alm(
     return np.array(alms)
 
 
+@deprecated_renamed_argument("verbose", None, "1.15.0")
 def alm2map(
     alms,
     nside,
@@ -289,6 +293,7 @@ def alm2map(
     sigma=None,
     pol=True,
     inplace=False,
+    verbose=True,
 ):
     """Computes a Healpix map given the alm.
 
@@ -386,7 +391,8 @@ def alm2map(
         return np.array(output)
 
 
-def synalm(cls, lmax=None, mmax=None, new=False):
+@deprecated_renamed_argument("verbose", None, "1.15.0")
+def synalm(cls, lmax=None, mmax=None, new=False, verbose=True):
     """Generate a set of alm given cl.
     The cl are given as a float array. Corresponding alm are generated.
     If lmax is None, it is assumed lmax=cl.size-1
@@ -479,6 +485,7 @@ def synalm(cls, lmax=None, mmax=None, new=False):
     return np.array(alms_list)
 
 
+@deprecated_renamed_argument("verbose", None, "1.15.0")
 def synfast(
     cls,
     nside,
@@ -490,6 +497,7 @@ def synfast(
     fwhm=0.0,
     sigma=None,
     new=False,
+    verbose=True,
 ):
     """Create a map(s) from cl(s).
 
@@ -747,6 +755,7 @@ def almxfl(alm, fl, mmax=None, inplace=False):
     return almout
 
 
+@deprecated_renamed_argument("verbose", None, "1.15.0")
 def smoothalm(
     alms,
     fwhm=0.0,
@@ -755,6 +764,7 @@ def smoothalm(
     pol=True,
     mmax=None,
     inplace=True,
+    verbose=True,
 ):
     """Smooth alm with a Gaussian symmetric beam function.
 
@@ -852,6 +862,7 @@ def smoothalm(
     return alms
 
 
+@deprecated_renamed_argument("verbose", None, "1.15.0")
 @accept_ma
 def smoothing(
     map_in,
@@ -866,6 +877,7 @@ def smoothing(
     use_pixel_weights=False,
     datapath=None,
     nest=False,
+    verbose=True,
 ):
     """Smooth a map with a Gaussian symmetric beam.
 

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -18,6 +18,7 @@
 #  For more information about Healpy, see http://code.google.com/p/healpy
 #
 import logging
+log = logging.getLogger("healpy")
 import numpy as np
 
 import astropy.io.fits as pf
@@ -236,7 +237,7 @@ def map2alm(
         if datapath is not None:
             pixel_weights_filename = os.path.join(datapath, filename)
             if os.path.exists(pixel_weights_filename):
-                logging.info("Accessing pixel weights from %s", pixel_weights_filename)
+                log.info("Accessing pixel weights from %s", pixel_weights_filename)
             else:
                 raise RuntimeError(
                     "You specified datapath but pixel weights file"
@@ -789,8 +790,8 @@ def smoothalm(
         sigma = fwhm / (2.0 * np.sqrt(2.0 * np.log(2.0)))
 
     if beam_window is None:
-        logging.info("Sigma is %f arcmin (%f rad) ", sigma * 60 * 180 / np.pi, sigma)
-        logging.info(
+        log.info("Sigma is %f arcmin (%f rad) ", sigma * 60 * 180 / np.pi, sigma)
+        log.info(
             "-> fwhm is {0:f} arcmin",
             sigma * 60 * 180 / np.pi * (2.0 * np.sqrt(2.0 * np.log(2.0))),
         )

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -920,7 +920,6 @@ def smoothing(
       This function will temporary reorder the NESTED map into RING to perform the
       smoothing and order the output back to NESTED. If the map is in RING ordering
       no internal reordering will be performed.
->>>>>>> feat: sphtfunc module converted to logging
 
     Returns
     -------

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -1201,7 +1201,8 @@ def beam2bl(beam, theta, lmax):
 
     nx = len(theta)
     nb = len(beam)
-    assert nb == nx, "beam and theta must have same size!"
+    if nb != nx:
+        raise ValueError("Beam and theta must have same size!")
 
     x = np.cos(theta)
     st = np.sin(theta)

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -342,9 +342,7 @@ def alm2map(
 
     check_max_nside(nside)
 
-    alms = smoothalm(
-        alms, fwhm=fwhm, sigma=sigma, pol=pol, inplace=inplace
-    )
+    alms = smoothalm(alms, fwhm=fwhm, sigma=sigma, pol=pol, inplace=inplace)
 
     if not cb.is_seq_of_seq(alms):
         alms = [alms]
@@ -925,9 +923,9 @@ def smoothing(
         n_maps = 0
 
     check_max_nside(nside)
-    
+
     if nest:
-        map_in = pixelfunc.reorder(map_in, inp=None, out=None, r2n=None, n2r=True) 
+        map_in = pixelfunc.reorder(map_in, inp=None, out=None, r2n=None, n2r=True)
 
     if pol or n_maps in (0, 1):
         # Treat the maps together (1 or 3 maps)
@@ -982,9 +980,11 @@ def smoothing(
             output_map.append(alm2map(alm, nside, pixwin=False))
         output_map = np.array(output_map)
     output_map[masks] = UNSEEN
-    
+
     if nest:
-        output_map = pixelfunc.reorder(output_map, inp=None, out=None, r2n=True, n2r=False)
+        output_map = pixelfunc.reorder(
+            output_map, inp=None, out=None, r2n=True, n2r=False
+        )
 
     return output_map
 

--- a/healpy/test/test_line_integral_convolution.py
+++ b/healpy/test/test_line_integral_convolution.py
@@ -34,7 +34,7 @@ class TestLIC(unittest.TestCase):
         path = os.path.dirname(os.path.realpath(__file__))
         Q, U = read_map(
             os.path.join(path, "data", "wmap_band_iqumap_r9_7yr_W_v4_udgraded32.fits"),
-            (1, 2),
+            (1, 2), dtype=np.float64
         )
         lic_result = lic(Q, U, step_radian=0.01)
         np.testing.assert_almost_equal(

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -241,11 +241,11 @@ def mollview(
             f.add_axes(ax)
         if remove_dip:
             map = pixelfunc.remove_dipole(
-                map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True
+                map, gal_cut=gal_cut, nest=nest, copy=True
             )
         elif remove_mono:
             map = pixelfunc.remove_monopole(
-                map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True
+                map, gal_cut=gal_cut, nest=nest, copy=True
             )
         img = ax.projmap(
             map,
@@ -1042,11 +1042,11 @@ def orthview(
             f.add_axes(ax)
         if remove_dip:
             map = pixelfunc.remove_dipole(
-                map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True
+                map, gal_cut=gal_cut, nest=nest, copy=True
             )
         elif remove_mono:
             map = pixelfunc.remove_monopole(
-                map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True
+                map, gal_cut=gal_cut, nest=nest, copy=True
             )
         img = ax.projmap(
             map,
@@ -1308,11 +1308,11 @@ def azeqview(
             f.add_axes(ax)
         if remove_dip:
             map = pixelfunc.remove_dipole(
-                map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True
+                map, gal_cut=gal_cut, nest=nest, copy=True
             )
         elif remove_mono:
             map = pixelfunc.remove_monopole(
-                map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True
+                map, gal_cut=gal_cut, nest=nest, copy=True
             )
         img = ax.projmap(
             map,

--- a/healpy/zoomtool.py
+++ b/healpy/zoomtool.py
@@ -119,11 +119,11 @@ def mollzoom(
         f.add_axes(ax)
         if remove_dip:
             map = pixelfunc.remove_dipole(
-                map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True
+                map, gal_cut=gal_cut, nest=nest, copy=True
             )
         elif remove_mono:
             map = pixelfunc.remove_monopole(
-                map, gal_cut=gal_cut, nest=nest, copy=True, verbose=True
+                map, gal_cut=gal_cut, nest=nest, copy=True
             )
         ax.projmap(
             map,
@@ -447,9 +447,9 @@ class ZoomTool(object):
                 self._graton = False
             else:
                 (self._g_dpar, self._g_dmer) = self._gnom_ax.graticule(
-                    local=False, verbose=False
+                    local=False
                 )
-                (self._m_dpar, self._m_dmer) = self._moll_ax.graticule(verbose=False)
+                (self._m_dpar, self._m_dmer) = self._moll_ax.graticule()
                 self._graton = True
             self.draw_gnom()
 
@@ -567,7 +567,7 @@ class ZoomTool(object):
             if self._graton:
                 self._gnom_ax.delgraticules()
                 (self._g_dpar, self._g_dmer) = self._gnom_ax.graticule(
-                    local=False, verbose=False
+                    local=False
                 )
             self._gnom_cb_ax.cla()
             im = self._gnom_ax.images[0]

--- a/healpy/zoomtool.py
+++ b/healpy/zoomtool.py
@@ -18,7 +18,7 @@
 #  For more information about Healpy, see http://code.google.com/p/healpy
 #
 
-import warnings
+import logging
 from . import projaxes as PA
 from . import rotator as R
 import numpy as np
@@ -53,15 +53,15 @@ def mollzoom(
     sub=None,
 ):
     """Interactive mollweide plot with zoomed gnomview.
-    
+
     Parameters:
     -----------
     map : float, array-like shape (Npix,)
-      An array containing the map, 
+      An array containing the map,
       supports masked maps, see the `ma` function.
       if None, use map with inf value (white map), useful for
       overplotting
-    fig : a figure number. 
+    fig : a figure number.
       Default: create a new figure
     rot : scalar or sequence, optional
       Describe the rotation to apply.
@@ -306,8 +306,7 @@ def mollzoom(
 
 
 def set_g_clim(vmin, vmax):
-    """Set min/max value of the gnomview part of a mollzoom.
-    """
+    """Set min/max value of the gnomview part of a mollzoom."""
     import pylab
 
     f = pylab.gcf()
@@ -388,8 +387,10 @@ class ZoomTool(object):
             self._reso_idx = self.reso_list.index(self._gnom_ax.proj._arrayinfo["reso"])
         except ValueError as e:
             raise ValueError("Resolution not in %s" % self.reso_list)
-        self.zoomcenter, = self._moll_ax.plot([0], [0], "ok", mew=1, ms=15, alpha=0.1)
-        self.zoomcenter2, = self._moll_ax.plot([0], [0], "xr", ms=15, alpha=0.5, mew=3)
+        (self.zoomcenter,) = self._moll_ax.plot([0], [0], "ok", mew=1, ms=15, alpha=0.1)
+        (self.zoomcenter2,) = self._moll_ax.plot(
+            [0], [0], "xr", ms=15, alpha=0.5, mew=3
+        )
         self._text_range = self._gnom_ax.text(
             -0.4,
             -0.2,
@@ -426,12 +427,12 @@ class ZoomTool(object):
         elif ev.key == "t":
             self._increase_reso()
         elif ev.key == "p":
-            warnings.warn("lon,lat = %.17g,%.17g" % (self.lon, self.lat))
+            logging.info("lon,lat = %.17g,%.17g", self.lon, self.lat)
         elif ev.key == "c":
             self._move_zoom_center(0, 0)
             self.draw_gnom(0, 0)
         elif ev.key == "v":
-            warnings.warn("val = %.17g" % (self.lastval))
+            logging.info("val = %.17g", self.lastval)
         elif ev.key == "f":
             self._range_status += 1
             self._range_status %= 3

--- a/healpy/zoomtool.py
+++ b/healpy/zoomtool.py
@@ -19,6 +19,7 @@
 #
 
 import logging
+log = logging.getLogger("healpy")
 from . import projaxes as PA
 from . import rotator as R
 import numpy as np
@@ -427,12 +428,12 @@ class ZoomTool(object):
         elif ev.key == "t":
             self._increase_reso()
         elif ev.key == "p":
-            logging.info("lon,lat = %.17g,%.17g", self.lon, self.lat)
+            log.info("lon,lat = %.17g,%.17g", self.lon, self.lat)
         elif ev.key == "c":
             self._move_zoom_center(0, 0)
             self.draw_gnom(0, 0)
         elif ev.key == "v":
-            logging.info("val = %.17g", self.lastval)
+            log.info("val = %.17g", self.lastval)
         elif ev.key == "f":
             self._range_status += 1
             self._range_status %= 3

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import errno
 import fnmatch
 import sys
 import shlex
-from Cython.Distutils import build_ext, Extension
 from distutils.sysconfig import get_config_var, get_config_vars
 import pkg_resources
 from subprocess import check_output, CalledProcessError, check_call
@@ -16,6 +15,7 @@ from distutils.errors import DistutilsExecError
 from distutils.dir_util import mkpath
 from distutils.file_util import copy_file
 from distutils import log
+from Cython.Distutils import build_ext, Extension
 
 # Apple switched default C++ standard libraries (from gcc's libstdc++ to
 # clang's libc++), but some pre-packaged Python environments such as Anaconda


### PR DESCRIPTION
Following #675 and previous issues, I switched the library to using `logging`, most of the previous warnings became debug or info messages which are not shown by default, just a minor important ones became `logging.warning`.

The most important objective of warnings was to warn users of the future change of the default setting for `hp.write_map` and `hp.read_map`.
Until the last release (1.14.0), whatever precision a map is in memory, it is written to disk in single precision (`float32`) and when read, it is converted to double precision (`float64`). As was written in the warning, now instead `healpy` will maintain whatever precision the map is in both when reading and writing.
I am a bit worried that a user upgrading is not notified about this, it is in the docstring and the changelog but there is no other notification, any suggestions here?

The other warning that was present was in `synalm` and `synfast` about the order of  `C_ell`, going for `new=False` to `new=True`, basically changing from TT TE EE.... to TT EE BB. This seems too dangerous for old code. I prefer to remove this notice and leave the default as it is.