### PR TITLE
Added alpha channel in visualization

### DIFF
--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -174,7 +174,7 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         coord : {'G', 'E', 'C', None}
           The coordinate system of the map ('G','E' or 'C'), rotate
           the map if different from the axes coord syst.
-        map : array-like
+        alpha : array-like
           The alpha (transparency) map.
 
         Notes

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -23,6 +23,7 @@ from . import rotator as R
 from . import pixelfunc
 import matplotlib
 import matplotlib.axes
+import matplotlib.pyplot as plt
 import numpy as np
 import copy
 
@@ -146,6 +147,7 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         norm=None,
         rot=None,
         coord=None,
+        alpha=None,
         **kwds
     ):
         """Project a map on the SphericalProjAxes.
@@ -172,6 +174,8 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         coord : {'G', 'E', 'C', None}
           The coordinate system of the map ('G','E' or 'C'), rotate
           the map if different from the axes coord syst.
+        map : array-like
+          The alpha (transparency) map.
 
         Notes
         -----
@@ -179,6 +183,12 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         """
         img = self.proj.projmap(map, vec2pix_func, rot=rot, coord=coord)
         w = ~(np.isnan(img) | np.isinf(img) | pixelfunc.mask_bad(img, badval=badval))
+        if (alpha is not None):            
+            alpha_img = self.proj.projmap(alpha, vec2pix_func, rot=rot, coord=coord)
+            alpha_img[alpha_img == -np.inf] = 0
+            alpha = plt.Normalize()(alpha_img)
+        else:
+            alpha = None        
         try:
             if vmin is None:
                 vmin = img[w].min()
@@ -207,6 +217,7 @@ class SphericalProjAxes(matplotlib.axes.Axes):
             origin="lower",
             vmin=vmin,
             vmax=vmax,
+            alpha=alpha,
             **kwds
         )
         xmin, xmax, ymin, ymax = self.proj.get_extent()

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -64,6 +64,7 @@ __all__ = [
 from . import projaxes as PA
 import numpy as np
 import matplotlib
+import matplotlib.pyplot as plt
 from . import pixelfunc
 
 pi = np.pi
@@ -99,6 +100,7 @@ def mollview(
     sub=None,
     nlocs=2,
     return_projected_map=False,
+    alpha=None,
 ):
     """Plot a healpix map (given as an array) in Mollweide projection.
     
@@ -175,6 +177,9 @@ def mollview(
       Default: None
     return_projected_map : bool
       if True returns the projected map in a 2d numpy array
+    alpha : float, array-like or None
+      An array containing the alpha channel, supports masked maps, see the `ma` function.
+      If None, no transparency will be applied.
 
     See Also
     --------
@@ -232,6 +237,8 @@ def mollview(
     pylab.ioff()
     try:
         map = pixelfunc.ma_to_array(map)
+        if (alpha is not None):
+            alpha = pixelfunc.ma_to_array(alpha)
         if reuse_axes:
             ax = f.gca()
         else:
@@ -258,14 +265,16 @@ def mollview(
             badcolor=badcolor,
             bgcolor=bgcolor,
             norm=norm,
+            alpha=alpha,
         )
         if cbar:
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
+            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     ax=ax,
                     orientation="horizontal",
                     shrink=0.5,
@@ -280,7 +289,7 @@ def mollview(
             else:
                 # for older matplotlib versions, no ax kwarg
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     orientation="horizontal",
                     shrink=0.5,
                     aspect=25,
@@ -352,6 +361,7 @@ def gnomview(
     notext=False,
     return_projected_map=False,
     no_plot=False,
+    alpha=None,
 ):
     """Plot a healpix map (given as an array) in Gnomonic projection.
 
@@ -428,6 +438,9 @@ def gnomview(
       if True returns the projected map in a 2d numpy array
     no_plot : bool, optional
       if True no figure will be created      
+    alpha : float, array-like or None
+      An array containing the alpha channel, supports masked maps, see the `ma` function.
+      If None, no transparency will be applied.
 
     See Also
     --------
@@ -511,14 +524,16 @@ def gnomview(
             norm=norm,
             badcolor=badcolor,
             bgcolor=bgcolor,
+            alpha=alpha,
         )
         if cbar:
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
+            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     ax=ax,
                     orientation="horizontal",
                     shrink=0.5,
@@ -532,7 +547,7 @@ def gnomview(
                 )
             else:
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     orientation="horizontal",
                     shrink=0.5,
                     aspect=25,
@@ -635,6 +650,7 @@ def cartview(
     margins=None,
     notext=False,
     return_projected_map=False,
+    alpha=None,
 ):
     """Plot a healpix map (given as an array) in Cartesian projection.
 
@@ -714,6 +730,9 @@ def cartview(
       Default: None
     return_projected_map : bool
       if True returns the projected map in a 2d numpy array
+    alpha : float, array-like or None
+      An array containing the alpha channel, supports masked maps, see the `ma` function.
+      If None, no transparency will be applied.
 
     See Also
     --------
@@ -805,14 +824,16 @@ def cartview(
             bgcolor=bgcolor,
             norm=norm,
             aspect=aspect,
+            alpha=alpha,
         )
         if cbar:
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
+            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     ax=ax,
                     orientation="horizontal",
                     shrink=0.5,
@@ -826,7 +847,7 @@ def cartview(
                 )
             else:
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     orientation="horizontal",
                     shrink=0.5,
                     aspect=25,
@@ -899,6 +920,7 @@ def orthview(
     sub=None,
     reuse_axes=False,
     return_projected_map=False,
+    alpha=None,
 ):
     """Plot a healpix map (given as an array) in Orthographic projection.
     
@@ -977,6 +999,9 @@ def orthview(
       Default: None
     return_projected_map : bool
       if True returns the projected map in a 2d numpy array
+    alpha : float, array-like or None
+      An array containing the alpha channel, supports masked maps, see the `ma` function.
+      If None, no transparency will be applied.
     
     See Also
     --------
@@ -1060,14 +1085,16 @@ def orthview(
             badcolor=badcolor,
             bgcolor=bgcolor,
             norm=norm,
+            alpha=alpha,
         )
         if cbar:
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
+            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     ax=ax,
                     orientation="horizontal",
                     shrink=0.5,
@@ -1082,7 +1109,7 @@ def orthview(
             else:
                 # for older matplotlib versions, no ax kwarg
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     orientation="horizontal",
                     shrink=0.5,
                     aspect=25,
@@ -1157,6 +1184,7 @@ def azeqview(
     margins=None,
     notext=False,
     return_projected_map=False,
+    alpha=None,
 ):
     """Plot a healpix map (given as an array) in Azimuthal equidistant projection
     or Lambert azimuthal equal-area projection.
@@ -1243,6 +1271,9 @@ def azeqview(
       Default: None
     return_projected_map : bool
       if True returns the projected map in a 2d numpy array
+    alpha : float, array-like or None
+      An array containing the alpha channel, supports masked maps, see the `ma` function.
+      If None, no transparency will be applied.
 
     See Also
     --------
@@ -1329,14 +1360,16 @@ def azeqview(
             badcolor=badcolor,
             bgcolor=bgcolor,
             norm=norm,
+            alpha=alpha,
         )
         if cbar:
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
+            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     ax=ax,
                     orientation="horizontal",
                     shrink=0.5,
@@ -1351,7 +1384,7 @@ def azeqview(
             else:
                 # for older matplotlib versions, no ax kwarg
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     orientation="horizontal",
                     shrink=0.5,
                     aspect=25,


### PR DESCRIPTION
Transparency is still now allowed in Healpy. I've added a new `alpha` keyword to all map visualization routines to allow for this. To avoid returning errors when using colorbars with transparency (the error is produced by Matplotlib `imshow`), the colorbar is extracted from the original map without transparency.