### PR TITLE
fix: import from Cython last

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import errno
 import fnmatch
 import sys
 import shlex
-from Cython.Distutils import build_ext, Extension
 from distutils.sysconfig import get_config_var, get_config_vars
 import pkg_resources
 from subprocess import check_output, CalledProcessError, check_call
@@ -16,6 +15,7 @@ from distutils.errors import DistutilsExecError
 from distutils.dir_util import mkpath
 from distutils.file_util import copy_file
 from distutils import log
+from Cython.Distutils import build_ext, Extension
 
 # Apple switched default C++ standard libraries (from gcc's libstdc++ to
 # clang's libc++), but some pre-packaged Python environments such as Anaconda


### PR DESCRIPTION
See
https://stackoverflow.com/questions/21594925/error-each-element-of-ext-modules-option-must-be-an-extension-instance-or-2-t

Error trying to build the package:

```
error: each element of 'ext_modules' option must be an Extension
instance or 2-tuple
```

Noticed on:

* Linux
* Python 3.8
* Cython 0.29.22
* setuptools 51.1.2 

@hivon also noticed on Mac OS, Python 3.9.

However, it doesn't cause any error in the Github Actions build.