### PR TITLE
Remove note that we will change order in synalm and synfast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 Release in progress
 
+* Removed the note that we will change order of cl in `synfast` and `synalm`, we will leave `new=False` default <https://github.com/healpy/healpy/pull/687>
 * Support nested maps `hp.smoothing` <https://github.com/healpy/healpy/pull/678>
 * Improvements of the build system <https://github.com/healpy/healpy/pull/660> <https://github.com/healpy/healpy/pull/661>
 * Automatically build wheels for Linux/MacOS on Github actions <https://github.com/healpy/healpy/pull/656>

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -423,24 +423,9 @@ def synalm(cls, lmax=None, mmax=None, new=False, verbose=True):
 
     Notes
     -----
-    The order of the spectra will change in a future release. The new= parameter
-    help to make the transition smoother. You can start using the new order
-    by setting new=True.
-    In the next version of healpy, the default will be new=True.
-    This change is done for consistency between the different tools
-    (alm2cl, synfast, anafast).
-    In the new order, the spectra are ordered by diagonal of the correlation
-    matrix. Eg, if fields are T, E, B, the spectra are TT, EE, BB, TE, EB, TB
-    with new=True, and TT, TE, TB, EE, EB, BB if new=False.
+    We don't plan to change the default order anymore, that would break old
+    code in a way difficult to debug.
     """
-    if (not new) and verbose:
-        warnings.warn(
-            "The order of the input cl's will change in a future "
-            "release.\n"
-            "Use new=True keyword to start using the new order.\n"
-            "See documentation of healpy.synalm.",
-            category=FutureChangeWarning,
-        )
     if not cb.is_seq(cls):
         raise TypeError("cls must be an array or a sequence of arrays")
 
@@ -545,6 +530,11 @@ def synfast(
     sigma : float, scalar, optional
       The sigma of the Gaussian used to smooth the map (applied on alm)
       [in radians]
+    new : bool, optional
+      If True, use the new ordering of cl's, ie by diagonal
+      (e.g. TT, EE, BB, TE, EB, TB or TT, EE, BB, TE if 4 cl as input).
+      If False, use the old ordering, ie by row
+      (e.g. TT, TE, TB, EE, EB, BB or TT, TE, EE, BB if 4 cl as input).
 
     Returns
     -------
@@ -555,15 +545,8 @@ def synfast(
 
     Notes
     -----
-    The order of the spectra will change in a future release. The new= parameter
-    help to make the transition smoother. You can start using the new order
-    by setting new=True.
-    In the next version of healpy, the default will be new=True.
-    This change is done for consistency between the different tools
-    (alm2cl, synfast, anafast).
-    In the new order, the spectra are ordered by diagonal of the correlation
-    matrix. Eg, if fields are T, E, B, the spectra are TT, EE, BB, TE, EB, TB
-    with new=True, and TT, TE, TB, EE, EB, BB if new=False.
+    We don't plan to change the default order anymore, that would break old
+    code in a way difficult to debug.
     """
     if not pixelfunc.isnsideok(nside):
         raise ValueError("Wrong nside value (must be a power of two).")


### PR DESCRIPTION
I think we shouldn't change this, better keep supporting both ways keeping the same default we have now.