### PR TITLE
Change default for read_map and write_map

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
 Release in progress
 
+* `write_map` keeps dtype of input map array instead of float32 <https://github.com/healpy/healpy/pull/688>
+* `read_map` keeps dtype of FITS file instead of upcasting to float64 <https://github.com/healpy/healpy/pull/688>
 * Support transparency in plotting with the `alpha` parameter <https://github.com/healpy/healpy/pull/696>
 * Experimental `projview` function to plot maps using projections from `matplotlib` <https://github.com/healpy/healpy/pull/695>
 * `write_cl` uses dtype of input cl instead of float64 <https://github.com/healpy/healpy/pull/688>

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -765,3 +765,9 @@ def getformat(t):
             return conv[np.dtype(t[0].type)]
     except:
         pass
+
+    raise ValueError(
+        "healpy could not understand the equivalent FITS datatype of {}, please open an issue on the healpy Github repository".format(
+            str(t)
+        )
+    )

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -716,6 +716,8 @@ def getformat(t):
         np.dtype(np.complex64): "C",
         np.dtype(np.complex128): "M",
     }
+    if hasattr(t, "type"):
+        t = t.type
     try:
         if t in conv:
             return conv[t]

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -719,8 +719,6 @@ def getformat(t):
         np.dtype(np.complex64): "C",
         np.dtype(np.complex128): "M",
     }
-    if hasattr(t, "type"):
-        t = t.type
     try:
         if t in conv:
             return conv[t]
@@ -755,5 +753,15 @@ def getformat(t):
         if type(t[0]) is str:
             l = max(len(s) for s in t)
             return "A%d" % (l)
+    except:
+        pass
+    try:
+        if np.dtype(t.type) in conv:
+            return conv[np.dtype(t.type)]
+    except:
+        pass
+    try:
+        if np.dtype(t[0].type) in conv:
+            return conv[np.dtype(t[0].type)]
     except:
         pass

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -130,7 +130,8 @@ def write_map(
 ):
     """Writes a healpix map into a healpix FITS file.
 
-    WARNING: starting from healpy 1.15.0, if you do not specify `dtype`,
+    .. warning::
+    Starting from healpy 1.15.0, if you do not specify `dtype`,
     the map will be written to disk with the same precision it is stored in memory.
     Previously, by default `healpy` wrote maps in `float32`.
     To reproduce the same behaviour of `healpy` 1.14.0 and below, set `dtype=np.float32`.
@@ -173,8 +174,9 @@ def write_map(
       internally from the numpy datatype to the fits convention. If a list,
       the length must correspond to the number of map arrays.
       Default: use the data type of the input array(s)
-      (WARNING: this changed in 1.15.0, previous versions saved in float32
-      by default)
+      .. note::
+      this changed in 1.15.0, previous versions saved in float32
+      by default
     overwrite : bool, optional
       If True, existing file is silently overwritten. Otherwise trying to write
       an existing file raises an OSError (IOError for Python 2).
@@ -303,7 +305,8 @@ def read_map(
     """Read a healpix map from a fits file.  Partial-sky files,
     if properly identified, are expanded to full size and filled with UNSEEN.
 
-    WARNING: starting from healpy 1.15.0, if you do not specify `dtype`,
+    .. warning::
+    Starting from healpy 1.15.0, if you do not specify `dtype`,
     the map will be read in memory with the same precision it is stored on disk.
     Previously, by default `healpy` wrote maps in `float32` and then upcast to
     `float64` when reading to memory. To reproduce the same behaviour of `healpy`

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -328,7 +328,7 @@ def read_map(
       types for each field. In that case, the length of the list must
       correspond to the length of the field parameter.
       If None, keep the dtype of the input FITS file
-      Default: None
+      Default: Preserve the data types in the file
     nest : bool, optional
       If True return the map in NEST ordering, otherwise in RING ordering;
       use fits keyword ORDERING to decide whether conversion is needed or not

--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -128,7 +128,12 @@ def write_map(
     extra_header=(),
     overwrite=False,
 ):
-    """Writes a healpix map into a healpix file.
+    """Writes a healpix map into a healpix FITS file.
+
+    WARNING: starting from healpy 1.15.0, if you do not specify `dtype`,
+    the map will be written to disk with the same precision it is stored in memory.
+    Previously, by default `healpy` wrote maps in `float32`.
+    To reproduce the same behaviour of `healpy` 1.14.0 and below, set `dtype=np.float32`.
 
     Parameters
     ----------
@@ -167,9 +172,9 @@ def write_map(
       The datatype in which the columns will be stored. Will be converted
       internally from the numpy datatype to the fits convention. If a list,
       the length must correspond to the number of map arrays.
-      Default: use np.float32
-      (WARNING: in a future version this will change to
-      "use the data type of the input array(s)".)
+      Default: use the data type of the input array(s)
+      (WARNING: this changed in 1.15.0, previous versions saved in float32
+      by default)
     overwrite : bool, optional
       If True, existing file is silently overwritten. Otherwise trying to write
       an existing file raises an OSError (IOError for Python 2).
@@ -183,14 +188,8 @@ def write_map(
 
     # check the dtype and convert it
     if dtype is None:
-        warnings.warn(
-            "The default dtype of write_map() will change in a future version: "
-            "explicitly set the dtype if it is important to you",
-            category=FutureWarning,
-        )
-        dtype = [np.float32 for x in m]
-        # Change this at some point to:
-        # dtype = [x.dtype for x in m]
+        dtype = [x.dtype for x in m]
+        warnings.warn("setting the output map dtype to %s" % str(dtype))
     try:
         fitsformat = []
         for curr_dtype in dtype:
@@ -293,7 +292,7 @@ def write_map(
 def read_map(
     filename,
     field=0,
-    dtype=np.float64,
+    dtype=None,
     nest=False,
     partial=False,
     hdu=1,
@@ -303,6 +302,12 @@ def read_map(
 ):
     """Read a healpix map from a fits file.  Partial-sky files,
     if properly identified, are expanded to full size and filled with UNSEEN.
+
+    WARNING: starting from healpy 1.15.0, if you do not specify `dtype`,
+    the map will be read in memory with the same precision it is stored on disk.
+    Previously, by default `healpy` wrote maps in `float32` and then upcast to
+    `float64` when reading to memory. To reproduce the same behaviour of `healpy`
+    1.14.0 and below, set `dtype=np.float64` in `read_map`.
 
     Parameters
     ----------
@@ -320,9 +325,7 @@ def read_map(
       types for each field. In that case, the length of the list must
       correspond to the length of the field parameter.
       If None, keep the dtype of the input FITS file
-      Default: use np.float64
-      (WARNING: in a future version this will change to
-      "use the data type of the input FITS file".)
+      Default: None
     nest : bool, optional
       If True return the map in NEST ordering, otherwise in RING ordering;
       use fits keyword ORDERING to decide whether conversion is needed or not
@@ -352,15 +355,6 @@ def read_map(
     m | (m0, m1, ...) [, header] : array or a tuple of arrays, optionally with header appended
       The map(s) read from the file, and the header if *h* is True.
     """
-    # Temporary warning for default dtype
-    if dtype == np.float64:
-        warnings.warn(
-            "If you are not specifying the input dtype and using the default "
-            "np.float64 dtype of read_map(), please consider that it will "
-            "change in a future version to None as to keep the same dtype of "
-            "the input file: please explicitly set the dtype if it is "
-            "important to you."
-        )
 
     opened_file = False
     if isinstance(filename, allowed_paths):

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -311,5 +311,10 @@ def test_getformat():
     assert getformat(["DD", "CCC"]) == "A3"
 
 
+def test_writemap_newdefault():
+    m = np.zeros(12, dtype=">f4")
+    write_map("test_map.fits", m, overwrite=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -312,8 +312,30 @@ def test_getformat():
 
 
 def test_writemap_newdefault(tmp_path):
+    filename = tmp_path / "test_map.fits"
+    for dtype in (
+        "bool",
+        "uint8",
+        "int16",
+        "int32",
+        "int64",
+        "float32",
+        "float64",
+        "complex64",
+        "complex128",
+    ):
+        m = np.ones(12, dtype=dtype)
+        write_map(filename, m, overwrite=True)
+        with pf.open(filename) as f:
+            assert f[1].data.field(0).dtype.name == dtype
+            np.testing.assert_array_almost_equal(f[1].data.field(0), m)
+
+
+def test_writemap_typestr(tmp_path):
+    filename = tmp_path / "test_map.fits"
     m = np.zeros(12, dtype=">f4")
-    write_map(tmp_path / "test_map.fits", m, overwrite=True)
+    write_map(filename, m, overwrite=True)
+    assert pf.open(filename)[1].data.field(0).dtype.name == "float32"
 
 
 if __name__ == "__main__":

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -311,9 +311,9 @@ def test_getformat():
     assert getformat(["DD", "CCC"]) == "A3"
 
 
-def test_writemap_newdefault():
+def test_writemap_newdefault(tmp_path):
     m = np.zeros(12, dtype=">f4")
-    write_map("test_map.fits", m, overwrite=True)
+    write_map(tmp_path / "test_map.fits", m, overwrite=True)
 
 
 if __name__ == "__main__":

--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -331,11 +331,14 @@ def test_writemap_newdefault(tmp_path):
             np.testing.assert_array_almost_equal(f[1].data.field(0), m)
 
 
-def test_writemap_typestr(tmp_path):
+def test_writemap_typestr_endianness(tmp_path):
     filename = tmp_path / "test_map.fits"
-    m = np.zeros(12, dtype=">f4")
-    write_map(filename, m, overwrite=True)
-    assert pf.open(filename)[1].data.field(0).dtype.name == "float32"
+    for endiannes in [">", "<"]:
+        m = np.ones(12, dtype=">f4")
+        write_map(filename, m, overwrite=True)
+        with pf.open(filename) as f:
+            assert f[1].data.field(0).dtype.name == "float32"
+            np.testing.assert_array_almost_equal(f[1].data.field(0), m)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Until the last release (1.14.0), whatever precision a map is in memory, it is written to disk in single precision (`float32`) and when read, it is converted to double precision (`float64`). As was written in the warning, now instead `healpy` will maintain whatever precision the map is in both when reading and writing.
I am a bit worried that a user upgrading is not notified about this, it is in the docstring and the changelog but there is no other notification, any suggestions here?