### PR TITLE
Support for alpha channel in visualization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 Release in progress
 
+* Support transparency in plotting with the `alpha` parameter <https://github.com/healpy/healpy/pull/696>
 * Experimental `projview` function to plot maps using projections from `matplotlib` <https://github.com/healpy/healpy/pull/695>
 * `write_cl` uses dtype of input cl instead of float64 <https://github.com/healpy/healpy/pull/688>
 * Removed the note that we will change order of cl in `synfast` and `synalm`, we will leave `new=False` default <https://github.com/healpy/healpy/pull/687>

--- a/doc/alpha_channel_example.ipynb
+++ b/doc/alpha_channel_example.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "accab10f-f89e-48bd-8cf2-515974b1c6d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import healpy as hp\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da178e4f-c00f-4294-9c6e-5aad4f402136",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nside = 128\n",
+    "npix = hp.nside2npix(nside)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "290641fc-c237-4061-a3ae-56970adf9222",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(12)\n",
+    "signal = np.random.normal(size=npix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d255d249-9f70-436b-9b06-682c0f376238",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp.mollview(signal, title=\"Signal\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2807c4da-7e9b-47f7-93e8-e340a553cf16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gal_cut = np.radians(10)\n",
+    "mask = np.zeros(npix, dtype=np.float32)\n",
+    "mask[hp.query_strip(nside, np.pi/2-gal_cut, np.pi/2+gal_cut)] = 1\n",
+    "mask[hp.query_disc(nside, hp.ang2vec(np.pi/2, 0), np.radians(20))] = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc85d2ce-3e76-4727-9a6a-c53af482ea29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp.mollview(mask, title=\"Binary mask\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "836e516b-886d-4f55-973d-61087a94c343",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "apodized_mask = np.clip(hp.smoothing(mask, fwhm=np.radians(10)), 0, None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca635292-dda3-4284-9c4d-26451a5e5ca0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp.mollview(apodized_mask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f8a9c07-a7e6-4c5a-a0f2-5b78f9bece07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp.mollview(signal, alpha=(1-mask), title=\"Signal with binary mask\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19b73958-33eb-420f-8740-ba98dddd5069",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp.mollview(signal, alpha=(1-apodized_mask), title=\"Signal with apodized mask\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8fece3d-75c6-4059-9001-7f35ea78f439",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/alpha_channel_example.ipynb
+++ b/doc/alpha_channel_example.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "352f4cd9-6331-459f-ae1c-70928d6c20ea",
+   "metadata": {},
+   "source": [
+    "# Example of using the alpha argument for transparency"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "accab10f-f89e-48bd-8cf2-515974b1c6d8",

--- a/doc/other_tutorials.rst
+++ b/doc/other_tutorials.rst
@@ -3,6 +3,14 @@ Other tutorials
 
 Links to other tutorials about `healpy`
 
+Alpha channel in visualization for transparency
+-----------------------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   alpha_channel_example
+
 New experimental visualization function
 ---------------------------------------
 

--- a/healpy/newvisufunc.py
+++ b/healpy/newvisufunc.py
@@ -473,8 +473,8 @@ def newprojplot(theta, phi, fmt=None, **kwargs):
 
     You can call this function as::
 
-       projplot(theta, phi)        # plot a line going through points at coord (theta, phi)
-       projplot(theta, phi, 'bo')  # plot 'o' in blue at coord (theta, phi)
+       newprojplot(theta, phi)        # plot a line going through points at coord (theta, phi)
+       newprojplot(theta, phi, 'bo')  # plot 'o' in blue at coord (theta, phi)
 
     Parameters
     ----------

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -179,12 +179,10 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         """
         img = self.proj.projmap(map, vec2pix_func, rot=rot, coord=coord)
         w = ~(np.isnan(img) | np.isinf(img) | pixelfunc.mask_bad(img, badval=badval))
-        if (alpha is not None):            
+        if (alpha is not None):
             alpha_img = self.proj.projmap(alpha, vec2pix_func, rot=rot, coord=coord)
             alpha_img[alpha_img == -np.inf] = 0
             alpha = plt.Normalize()(alpha_img)
-        else:
-            alpha = None        
         try:
             if vmin is None:
                 vmin = img[w].min()

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -179,7 +179,7 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         """
         img = self.proj.projmap(map, vec2pix_func, rot=rot, coord=coord)
         w = ~(np.isnan(img) | np.isinf(img) | pixelfunc.mask_bad(img, badval=badval))
-        if (alpha is not None):
+        if alpha is not None:
             alpha_img = self.proj.projmap(alpha, vec2pix_func, rot=rot, coord=coord)
             alpha_img[alpha_img == -np.inf] = 0
             alpha = plt.Normalize()(alpha_img)

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -170,7 +170,7 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         coord : {'G', 'E', 'C', None}
           The coordinate system of the map ('G','E' or 'C'), rotate
           the map if different from the axes coord syst.
-        map : array-like
+        alpha : array-like
           The alpha (transparency) map.
 
         Notes

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -23,6 +23,7 @@ from . import rotator as R
 from . import pixelfunc
 import matplotlib
 import matplotlib.axes
+import matplotlib.pyplot as plt
 import numpy as np
 import copy
 
@@ -142,6 +143,7 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         norm=None,
         rot=None,
         coord=None,
+        alpha=None,
         **kwds
     ):
         """Project a map on the SphericalProjAxes.
@@ -168,6 +170,8 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         coord : {'G', 'E', 'C', None}
           The coordinate system of the map ('G','E' or 'C'), rotate
           the map if different from the axes coord syst.
+        map : array-like
+          The alpha (transparency) map.
 
         Notes
         -----
@@ -175,6 +179,12 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         """
         img = self.proj.projmap(map, vec2pix_func, rot=rot, coord=coord)
         w = ~(np.isnan(img) | np.isinf(img) | pixelfunc.mask_bad(img, badval=badval))
+        if (alpha is not None):            
+            alpha_img = self.proj.projmap(alpha, vec2pix_func, rot=rot, coord=coord)
+            alpha_img[alpha_img == -np.inf] = 0
+            alpha = plt.Normalize()(alpha_img)
+        else:
+            alpha = None        
         try:
             if vmin is None:
                 vmin = img[w].min()
@@ -202,6 +212,7 @@ class SphericalProjAxes(matplotlib.axes.Axes):
             norm=nn,
             interpolation="nearest",
             origin="lower",
+            alpha=alpha,
             **kwds
         )
         xmin, xmax, ymin, ymax = self.proj.get_extent()

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -64,6 +64,7 @@ __all__ = [
 from . import projaxes as PA
 import numpy as np
 import matplotlib
+import matplotlib.pyplot as plt
 from . import pixelfunc
 
 pi = np.pi
@@ -99,6 +100,7 @@ def mollview(
     sub=None,
     nlocs=2,
     return_projected_map=False,
+    alpha=None,
 ):
     """Plot a healpix map (given as an array) in Mollweide projection.
 
@@ -175,6 +177,9 @@ def mollview(
       Default: None
     return_projected_map : bool
       if True returns the projected map in a 2d numpy array
+    alpha : float, array-like or None
+      An array containing the alpha channel, supports masked maps, see the `ma` function.
+      If None, no transparency will be applied.
 
     See Also
     --------
@@ -232,6 +237,8 @@ def mollview(
     pylab.ioff()
     try:
         map = pixelfunc.ma_to_array(map)
+        if (alpha is not None):
+            alpha = pixelfunc.ma_to_array(alpha)
         if reuse_axes:
             ax = f.gca()
         else:
@@ -258,14 +265,16 @@ def mollview(
             badcolor=badcolor,
             bgcolor=bgcolor,
             norm=norm,
+            alpha=alpha,
         )
         if cbar:
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
+            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     ax=ax,
                     orientation="horizontal",
                     shrink=0.5,
@@ -280,7 +289,7 @@ def mollview(
             else:
                 # for older matplotlib versions, no ax kwarg
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     orientation="horizontal",
                     shrink=0.5,
                     aspect=25,
@@ -352,6 +361,7 @@ def gnomview(
     notext=False,
     return_projected_map=False,
     no_plot=False,
+    alpha=None,
 ):
     """Plot a healpix map (given as an array) in Gnomonic projection.
 
@@ -428,6 +438,9 @@ def gnomview(
       if True returns the projected map in a 2d numpy array
     no_plot : bool, optional
       if True no figure will be created
+    alpha : float, array-like or None
+      An array containing the alpha channel, supports masked maps, see the `ma` function.
+      If None, no transparency will be applied.
 
     See Also
     --------
@@ -511,14 +524,16 @@ def gnomview(
             norm=norm,
             badcolor=badcolor,
             bgcolor=bgcolor,
+            alpha=alpha,
         )
         if cbar:
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
+            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     ax=ax,
                     orientation="horizontal",
                     shrink=0.5,
@@ -532,7 +547,7 @@ def gnomview(
                 )
             else:
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     orientation="horizontal",
                     shrink=0.5,
                     aspect=25,
@@ -635,6 +650,7 @@ def cartview(
     margins=None,
     notext=False,
     return_projected_map=False,
+    alpha=None,
 ):
     """Plot a healpix map (given as an array) in Cartesian projection.
 
@@ -714,6 +730,9 @@ def cartview(
       Default: None
     return_projected_map : bool
       if True returns the projected map in a 2d numpy array
+    alpha : float, array-like or None
+      An array containing the alpha channel, supports masked maps, see the `ma` function.
+      If None, no transparency will be applied.
 
     See Also
     --------
@@ -805,14 +824,16 @@ def cartview(
             bgcolor=bgcolor,
             norm=norm,
             aspect=aspect,
+            alpha=alpha,
         )
         if cbar:
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
+            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     ax=ax,
                     orientation="horizontal",
                     shrink=0.5,
@@ -826,7 +847,7 @@ def cartview(
                 )
             else:
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     orientation="horizontal",
                     shrink=0.5,
                     aspect=25,
@@ -899,6 +920,7 @@ def orthview(
     sub=None,
     reuse_axes=False,
     return_projected_map=False,
+    alpha=None,
 ):
     """Plot a healpix map (given as an array) in Orthographic projection.
 
@@ -977,7 +999,10 @@ def orthview(
       Default: None
     return_projected_map : bool
       if True returns the projected map in a 2d numpy array
-
+    alpha : float, array-like or None
+      An array containing the alpha channel, supports masked maps, see the `ma` function.
+      If None, no transparency will be applied.
+    
     See Also
     --------
     mollview, gnomview, cartview, azeqview
@@ -1060,14 +1085,16 @@ def orthview(
             badcolor=badcolor,
             bgcolor=bgcolor,
             norm=norm,
+            alpha=alpha,
         )
         if cbar:
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
+            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     ax=ax,
                     orientation="horizontal",
                     shrink=0.5,
@@ -1082,7 +1109,7 @@ def orthview(
             else:
                 # for older matplotlib versions, no ax kwarg
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     orientation="horizontal",
                     shrink=0.5,
                     aspect=25,
@@ -1157,6 +1184,7 @@ def azeqview(
     margins=None,
     notext=False,
     return_projected_map=False,
+    alpha=None,
 ):
     """Plot a healpix map (given as an array) in Azimuthal equidistant projection
     or Lambert azimuthal equal-area projection.
@@ -1243,6 +1271,9 @@ def azeqview(
       Default: None
     return_projected_map : bool
       if True returns the projected map in a 2d numpy array
+    alpha : float, array-like or None
+      An array containing the alpha channel, supports masked maps, see the `ma` function.
+      If None, no transparency will be applied.
 
     See Also
     --------
@@ -1329,14 +1360,16 @@ def azeqview(
             badcolor=badcolor,
             bgcolor=bgcolor,
             norm=norm,
+            alpha=alpha,
         )
         if cbar:
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
+            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     ax=ax,
                     orientation="horizontal",
                     shrink=0.5,
@@ -1351,7 +1384,7 @@ def azeqview(
             else:
                 # for older matplotlib versions, no ax kwarg
                 cb = f.colorbar(
-                    im,
+                    mappable,
                     orientation="horizontal",
                     shrink=0.5,
                     aspect=25,

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -444,6 +444,8 @@ def gnomview(
     alpha : float, array-like or None
       An array containing the alpha channel, supports masked maps, see the `ma` function.
       If None, no transparency will be applied.
+      See an example usage of the alpha channel transparency in the documentation under
+      "Other tutorials"
 
     See Also
     --------

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -237,7 +237,7 @@ def mollview(
     pylab.ioff()
     try:
         map = pixelfunc.ma_to_array(map)
-        if (alpha is not None):
+        if alpha is not None:
             alpha = pixelfunc.ma_to_array(alpha)
         if reuse_axes:
             ax = f.gca()
@@ -271,7 +271,10 @@ def mollview(
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
-            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
+            mappable = plt.cm.ScalarMappable(
+                norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax),
+                cmap=cmap,
+            )
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
                     mappable,
@@ -530,7 +533,10 @@ def gnomview(
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
-            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
+            mappable = plt.cm.ScalarMappable(
+                norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax),
+                cmap=cmap,
+            )
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
                     mappable,
@@ -830,7 +836,10 @@ def cartview(
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
-            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
+            mappable = plt.cm.ScalarMappable(
+                norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax),
+                cmap=cmap,
+            )
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
                     mappable,
@@ -1002,7 +1011,7 @@ def orthview(
     alpha : float, array-like or None
       An array containing the alpha channel, supports masked maps, see the `ma` function.
       If None, no transparency will be applied.
-    
+
     See Also
     --------
     mollview, gnomview, cartview, azeqview
@@ -1091,7 +1100,10 @@ def orthview(
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
-            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
+            mappable = plt.cm.ScalarMappable(
+                norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax),
+                cmap=cmap,
+            )
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
                     mappable,
@@ -1366,7 +1378,10 @@ def azeqview(
             im = ax.get_images()[0]
             b = im.norm.inverse(np.linspace(0, 1, im.cmap.N + 1))
             v = np.linspace(im.norm.vmin, im.norm.vmax, im.cmap.N)
-            mappable = plt.cm.ScalarMappable(norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax), cmap=cmap)
+            mappable = plt.cm.ScalarMappable(
+                norm=matplotlib.colors.Normalize(vmin=im.norm.vmin, vmax=im.norm.vmax),
+                cmap=cmap,
+            )
             if matplotlib.__version__ >= "0.91.0":
                 cb = f.colorbar(
                     mappable,


### PR DESCRIPTION
Following from #684

- Added alpha channel in visualization
- Updated docstring with the alpha channel
- fix: alpha is already None
- format with black
