### PR TITLE
Replace all deprecated numpy aliases with builtins

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -627,7 +627,7 @@ def read_alm(filename, hdu=1, return_mmax=False):
 
     for unit in np.atleast_1d(hdu):
         idx, almr, almi = [_get_hdu(filename, hdu=unit).data.field(i) for i in range(3)]
-        l = np.floor(np.sqrt(idx - 1)).astype(np.long)
+        l = np.floor(np.sqrt(idx - 1)).astype(int)
         m = idx - l ** 2 - l - 1
         if (m < 0).any():
             raise ValueError("Negative m value encountered !")

--- a/healpy/pixelfunc.py
+++ b/healpy/pixelfunc.py
@@ -1260,10 +1260,10 @@ def isnsideok(nside, nest=False):
         if not isinstance(nside, np.ndarray):
             nside = np.asarray(nside)
         is_nside_ok = (
-            (nside == nside.astype(np.int)) & (nside > 0) & (nside <= max_nside)
+            (nside == nside.astype(int)) & (nside > 0) & (nside <= max_nside)
         )
         if nest:
-            is_nside_ok &= (nside.astype(np.int) & (nside.astype(np.int) - 1)) == 0
+            is_nside_ok &= (nside.astype(int) & (nside.astype(int) - 1)) == 0
     else:
         is_nside_ok = nside == int(nside) and 0 < nside <= max_nside
         if nest:

--- a/healpy/projaxes.py
+++ b/healpy/projaxes.py
@@ -1064,7 +1064,7 @@ class HistEqNorm(matplotlib.colors.Normalize):
         if bins.size == hist.size + 1:
             # new bins format, remove last point
             bins = bins[:-1]
-        hist = hist.astype(np.float64) / np.float(hist.sum())
+        hist = hist.astype(np.float64) / float(hist.sum())
         self.yval = np.concatenate([[0.0], hist.cumsum(), [1.0]])
         self.xval = np.concatenate(
             [[self.vmin], bins + 0.5 * (bins[1] - bins[0]), [self.vmax]]

--- a/healpy/projector.py
+++ b/healpy/projector.py
@@ -346,8 +346,8 @@ class GnomonicProj(SphericalProj):
             x, y = x
         dx = reso / 60.0 * dtor
         xc, yc = 0.5 * (xsize - 1), 0.5 * (ysize - 1)
-        j = np.around(xc + x / dx).astype(np.long)
-        i = np.around(yc + y / dx).astype(np.long)
+        j = np.around(xc + x / dx).astype(int)
+        i = np.around(yc + y / dx).astype(int)
         return i, j
 
     xy2ij.__doc__ = SphericalProj.xy2ij.__doc__ % (name, name)
@@ -486,8 +486,8 @@ class MollweideProj(SphericalProj):
             x, y = x
         xc, yc = (xsize - 1.0) / 2.0, (ysize - 1.0) / 2.0
         if hasattr(x, "__len__"):
-            j = np.around(x * xc / 2.0 + xc).astype(np.long)
-            i = np.around(yc + y * yc).astype(np.long)
+            j = np.around(x * xc / 2.0 + xc).astype(int)
+            i = np.around(yc + y * yc).astype(int)
             mask = x ** 2 / 4.0 + y ** 2 > 1.0
             if not mask.any():
                 mask = np.ma.nomask
@@ -497,8 +497,8 @@ class MollweideProj(SphericalProj):
             if x ** 2 / 4.0 + y ** 2 > 1.0:
                 i, j = np.nan, np.nan
             else:
-                j = np.around(x * xc / 2.0 + xc).astype(np.long)
-                i = np.around(yc + y * yc).astype(np.long)
+                j = np.around(x * xc / 2.0 + xc).astype(int)
+                i = np.around(yc + y * yc).astype(int)
         return i, j
 
     xy2ij.__doc__ = SphericalProj.xy2ij.__doc__ % (name, name)
@@ -631,12 +631,12 @@ class CartesianProj(SphericalProj):
             )
         lonra = self._flip * np.float64(lonra)[:: self._flip]
         latra = np.float64(latra)
-        xsize = np.long(xsize)
+        xsize = int(xsize)
         if ysize is None:
             ratio = (latra[1] - latra[0]) / (lonra[1] - lonra[0])
-            ysize = np.long(round(ratio * xsize))
+            ysize = int(round(ratio * xsize))
         else:
-            ysize = np.long(ysize)
+            ysize = int(ysize)
             ratio = float(ysize) / float(xsize)
         super(CartesianProj, self).set_proj_plane_info(
             xsize=xsize, lonra=lonra, latra=latra, ysize=ysize, ratio=ratio
@@ -938,8 +938,8 @@ class OrthographicProj(SphericalProj):
                 mask = (np.mod(x + 2.0, 2.0) - 1.0) ** 2 + y ** 2 > 1.0
             if not mask.any():
                 mask = np.ma.nomask
-            j = np.ma.array(np.around(x * xc / ratio + xc).astype(np.long), mask=mask)
-            i = np.ma.array(np.around(yc + y * yc).astype(np.long), mask=mask)
+            j = np.ma.array(np.around(x * xc / ratio + xc).astype(int), mask=mask)
+            i = np.ma.array(np.around(yc + y * yc).astype(int), mask=mask)
         else:
             if (half_sky and x ** 2 + y ** 2 > 1.0) or (
                 not half_sky and (np.mod(x + 2.0, 2.0) - 1.0) ** 2 + y ** 2 > 1.0
@@ -949,8 +949,8 @@ class OrthographicProj(SphericalProj):
                     np.nan,
                 )
             else:
-                j = np.around(x * xc / ratio + xc).astype(np.long)
-                i = np.around(yc + y * yc).astype(np.long)
+                j = np.around(x * xc / ratio + xc).astype(int)
+                i = np.around(yc + y * yc).astype(int)
         return i, j
 
     xy2ij.__doc__ = SphericalProj.xy2ij.__doc__ % (name, name)
@@ -1206,8 +1206,8 @@ class AzimuthalProj(SphericalProj):
             mask = x ** 2 + y ** 2 > r2max
             if not mask.any():
                 mask = np.ma.nomask
-            j = np.ma.array(np.around(xc + x / dx).astype(np.long), mask=mask)
-            i = np.ma.array(np.around(yc + y / dx).astype(np.long), mask=mask)
+            j = np.ma.array(np.around(xc + x / dx).astype(int), mask=mask)
+            i = np.ma.array(np.around(yc + y / dx).astype(int), mask=mask)
         else:
             if x ** 2 + y ** 2 > r2max:
                 i, j, = (
@@ -1215,8 +1215,8 @@ class AzimuthalProj(SphericalProj):
                     np.nan,
                 )
             else:
-                j = np.around(xc + x / dx).astype(np.long)
-                i = np.around(yc + y / dx).astype(np.long)
+                j = np.around(xc + x / dx).astype(int)
+                i = np.around(yc + y / dx).astype(int)
         return i, j
 
     xy2ij.__doc__ = SphericalProj.xy2ij.__doc__ % (name, name)

--- a/healpy/src/_line_integral_convolution.pyx
+++ b/healpy/src/_line_integral_convolution.pyx
@@ -106,7 +106,7 @@ def line_integral_convolution(
         if ell is not None:
             if ell < 0:
                 ell = 2 * nside
-            alms = np.zeros(Alm.getsize(ell), dtype=np.complex)
+            alms = np.zeros(Alm.getsize(ell), dtype=complex)
             for m in range(ell + 1):
                 alms[Alm.getidx(ell, ell, m)] = rng.normal() + 1j * rng.normal()
             texture = alm2map(alms, nside)

--- a/healpy/src/_query_disc.pyx
+++ b/healpy/src/_query_disc.pyx
@@ -279,15 +279,15 @@ def boundaries(nside, pix, step=1, nest=False):
     if not isnsideok(nside, nest):
         raise ValueError('Wrong nside value, must be a power of 2, less than 2**30')
     if np.isscalar(pix):
-        if not np.can_cast(type(pix), np.int):
+        if not np.can_cast(type(pix), int):
             raise ValueError('Array of pixels has to be integers')
         return _boundaries_single(nside, pix, step=step, nest=nest)
     else:
         pix = np.asarray(pix)
-        if np.can_cast(pix.dtype, np.int):
+        if np.can_cast(pix.dtype, int):
             if pix.ndim!=1:
                 raise ValueError('Array has to be one dimensional')
-            return _boundaries_multiple(nside, pix.astype(np.int), step=step, nest=nest)
+            return _boundaries_multiple(nside, pix.astype(int), step=step, nest=nest)
         else:
             raise ValueError('Array of pixels has to be integers')
 

--- a/healpy/test/test_pixelweights.py
+++ b/healpy/test/test_pixelweights.py
@@ -14,7 +14,7 @@ def create_reference_alm():
     lmax = 96
     alm_size = 4753
     np.random.seed(123)
-    input_alm = np.ones(alm_size, dtype=np.complex)
+    input_alm = np.ones(alm_size, dtype=complex)
     m = hp.alm2map(input_alm, nside=nside, lmax=lmax)
     return lmax, input_alm, m
 

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -276,7 +276,7 @@ class TestSphtFunc(unittest.TestCase):
         """rotate_alm also support rotation matrix instead of angles"""
         lmax = 32
         nalm = hp.Alm.getsize(lmax)
-        alm = np.zeros([3, nalm], dtype=np.complex)
+        alm = np.zeros([3, nalm], dtype=complex)
         alm[0, 1] = 1
         alm[1, 2] = 1
         alm_rotated_angles = alm.copy()
@@ -290,7 +290,7 @@ class TestSphtFunc(unittest.TestCase):
         # Test rotate_alm against the Fortran library
         lmax = 64
         nalm = hp.Alm.getsize(lmax)
-        alm = np.zeros([3, nalm], dtype=np.complex)
+        alm = np.zeros([3, nalm], dtype=complex)
         for i in range(3):
             for ell in range(lmax + 1):
                 for m in range(ell):


### PR DESCRIPTION
This PR replaces all instances of the [deprecated numpy aliases](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) with the appropriate (identical) builtin. This should have absolutely zero functional impact, but will remove a bunch of `DeprecationWarning`s for users of `numpy >=1.20.0`.