### PR TITLE
add spin functions to sphtfunc module and doc

### DIFF
--- a/doc/healpy_spht.rst
+++ b/doc/healpy_spht.rst
@@ -13,6 +13,7 @@ From map to spherical harmonics
 
    anafast
    map2alm
+   map2alm_spin
 
 From spherical harmonics to map
 -------------------------------
@@ -22,6 +23,7 @@ From spherical harmonics to map
    synfast
    alm2map
    alm2map_der1
+   alm2map_spin
 
 Spherical harmonic transform tools
 ----------------------------------

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -81,14 +81,14 @@ from .sphtfunc import (
     bl2beam,
     beam2bl,
     check_max_nside,
+    map2alm_spin,
+    alm2map_spin,
 )
 
 from ._query_disc import query_disc, query_strip, query_polygon, boundaries
 from ._pixelfunc import ringinfo, pix2ring
 
 from ._sphtools import rotate_alm
-from ._sphtools import alm2map_spin_healpy as alm2map_spin
-from ._sphtools import map2alm_spin_healpy as map2alm_spin
 from .rotator import Rotator, vec2dir, dir2vec
 from ._healpy_pixel_lib import UNSEEN
 from .visufunc import (

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -36,6 +36,9 @@ from . import pixelfunc
 
 from .pixelfunc import maptype, UNSEEN, ma_to_array, accept_ma
 
+from ._sphtools import alm2map_spin_healpy as alm2map_spin
+from ._sphtools import map2alm_spin_healpy as map2alm_spin
+
 
 class FutureChangeWarning(UserWarning):
     pass


### PR DESCRIPTION
This PR imports the `map2alm_spin` and `spin2alm_map` functions into the `sphtfunc` module, and also adds them to the documentation. Closes #701.