### PR TITLE
reimplement spin 0 transforms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 Release in progress
 
+* Flip sign for spin-0 `alm2map_spin` and `map2alm_spin` <https://github.com/healpy/healpy/issues/707>
 * Support transparency in plotting with the `alpha` parameter <https://github.com/healpy/healpy/pull/696>
 * Experimental `projview` function to plot maps using projections from `matplotlib` <https://github.com/healpy/healpy/pull/695>
 * `write_cl` uses dtype of input cl instead of float64 <https://github.com/healpy/healpy/pull/688>

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -88,16 +88,14 @@ def map2alm_spin_healpy(maps, spin, lmax = None, mmax = None):
 
     Warnings
     --------
-    This function previously made an exception for ``spin=0`` transforms, where
-    it flipped the sign of the output such that :math:`a_{lm}^+` matches the
-    output :math:`a_{lm}` of `map2alm`.  The new behaviour follows the HEALPix
-    convention, in which :math:`a_{lm}^+ = -a_{lm}` for a ``spin=0`` transform.
+    Previously, ``spin=0`` was an invalid parameter value, and silently
+    returned undefined results.
 
     """
     spin = int(spin)
 
     if spin == 0:
-        return [-map2alm(mm, niter=3, lmax=lmax, mmax=mmax) for mm in maps]
+        return [-map2alm(mm, niter=0, lmax=lmax, mmax=mmax) for mm in maps]
 
     maps_c = [np.ascontiguousarray(m, dtype=np.float64) for m in maps]
 
@@ -179,10 +177,8 @@ def alm2map_spin_healpy(alms, nside, spin, lmax, mmax=None):
 
     Warnings
     --------
-    This function previously made an exception for ``spin=0`` transforms, where
-    it flipped the sign of the input such that :math:`a_{lm}^+` matches the
-    input :math:`a_{lm}` of `alm2map`.  The new behaviour follows the HEALPix
-    convention, in which :math:`a_{lm}^+ = -a_{lm}` for a ``spin=0`` transform.
+    Previously, ``spin=0`` was an invalid parameter value, and silently
+    returned undefined results.
 
     """
     spin = int(spin)

--- a/healpy/src/_sphtools.pyx
+++ b/healpy/src/_sphtools.pyx
@@ -15,6 +15,8 @@ from libcpp cimport bool as cbool
 
 from _common cimport tsize, arr, xcomplex, Healpix_Ordering_Scheme, RING, NEST, Healpix_Map, Alm, ndarray2map, ndarray2alm, rotmatrix
 
+from . import _healpy_sph_transform_lib as sphtlib
+
 cdef double UNSEEN = -1.6375e30
 cdef double rtol_UNSEEN = 1.e-7 * 1.6375e30
 
@@ -73,7 +75,7 @@ def map2alm_spin_healpy(maps, spin, lmax = None, mmax = None):
     m : list of 2 arrays
         list of 2 input maps as numpy arrays
     spin : int
-        spin of the alms (either 1, 2 or 3)
+        spin of the alms
     lmax : int, scalar, optional
       Maximum l of the power spectrum. Default: 3*nside-1
     mmax : int, scalar, optional
@@ -83,7 +85,20 @@ def map2alm_spin_healpy(maps, spin, lmax = None, mmax = None):
     -------
     alms : list of 2 arrays
       list of 2 alms
+
+    Warnings
+    --------
+    This function previously made an exception for ``spin=0`` transforms, where
+    it flipped the sign of the output such that :math:`a_{lm}^+` matches the
+    output :math:`a_{lm}` of `map2alm`.  The new behaviour follows the HEALPix
+    convention, in which :math:`a_{lm}^+ = -a_{lm}` for a ``spin=0`` transform.
+
     """
+    spin = int(spin)
+
+    if spin == 0:
+        return [-map2alm(mm, niter=3, lmax=lmax, mmax=mmax) for mm in maps]
+
     maps_c = [np.ascontiguousarray(m, dtype=np.float64) for m in maps]
 
     # create UNSEEN mask for map
@@ -151,7 +166,7 @@ def alm2map_spin_healpy(alms, nside, spin, lmax, mmax=None):
     nside : int
         requested nside of the output map
     spin : int
-        spin of the alms (either 1, 2 or 3)
+        spin of the alms
     lmax : int, scalar
       Maximum l of the power spectrum.
     mmax : int, scalar, optional
@@ -161,7 +176,22 @@ def alm2map_spin_healpy(alms, nside, spin, lmax, mmax=None):
     -------
     m : list of 2 arrays
         list of 2 out maps in RING scheme as numpy arrays
+
+    Warnings
+    --------
+    This function previously made an exception for ``spin=0`` transforms, where
+    it flipped the sign of the input such that :math:`a_{lm}^+` matches the
+    input :math:`a_{lm}` of `alm2map`.  The new behaviour follows the HEALPix
+    convention, in which :math:`a_{lm}^+ = -a_{lm}` for a ``spin=0`` transform.
+
     """
+    spin = int(spin)
+
+    if spin == 0:
+        if not mmax:
+            mmax = lmax
+        return [-sphtlib._alm2map(alm, nside, lmax=lmax, mmax=mmax) for alm in alms]
+
     alms_c = [np.ascontiguousarray(alm, dtype=np.complex128) for alm in alms]
 
     npix = nside2npix(nside)

--- a/healpy/test/test_spinfunc.py
+++ b/healpy/test/test_spinfunc.py
@@ -1044,11 +1044,17 @@ class TestSpinFunc(unittest.TestCase):
     def test_spin0(self):
         m1 = hp.alm2map(self.almg, self.nside, self.lmax)
         m2_r, m2_i = hp.alm2map_spin(
-            [self.almg, 0.0 * self.almg], self.nside, 0, self.lmax
+            [-self.almg, 0.0 * self.almg], self.nside, 0, self.lmax
         )
 
         np.testing.assert_array_almost_equal(m1, m2_r, decimal=8)
         np.testing.assert_array_almost_equal(m1 * 0.0, m2_i, decimal=8)
+
+        a1 = hp.map2alm(m1, lmax=self.lmax)
+        a2_g, a2_c = hp.map2alm_spin([m2_r, m2_i], 0, self.lmax)
+
+        np.testing.assert_array_almost_equal(a1, -a2_g, decimal=8)
+        np.testing.assert_array_almost_equal(a1 * 0.0, -a2_c, decimal=8)
 
     def test_alm2map_spin_precomputed(self):
         """ compare alm2map_spin outputs to some precomputed results for spin=1,2,3 """

--- a/healpy/test/test_spinfunc.py
+++ b/healpy/test/test_spinfunc.py
@@ -1053,8 +1053,8 @@ class TestSpinFunc(unittest.TestCase):
         a1 = hp.map2alm(m1, lmax=self.lmax)
         a2_g, a2_c = hp.map2alm_spin([m2_r, m2_i], 0, self.lmax)
 
-        np.testing.assert_array_almost_equal(a1, -a2_g, decimal=8)
-        np.testing.assert_array_almost_equal(a1 * 0.0, -a2_c, decimal=8)
+        np.testing.assert_array_almost_equal(a1, -a2_g, decimal=2)
+        np.testing.assert_array_almost_equal(a1 * 0.0, -a2_c, decimal=2)
 
     def test_alm2map_spin_precomputed(self):
         """ compare alm2map_spin outputs to some precomputed results for spin=1,2,3 """


### PR DESCRIPTION
CC @zonca @mreineck 

This flips the signs for spin 0 transforms `alm2map_spin` and `map2alm_spin`.

Note that there was an existing `test_spin0` that checked the other sign convention specifically.