### PR TITLE
fixes #709: get nside from length of array

### DIFF
--- a/healpy/fitsfunc.py
+++ b/healpy/fitsfunc.py
@@ -375,6 +375,8 @@ def read_map(
     nside = fits_hdu.header.get("NSIDE")
     if nside is None:
         log.info("No NSIDE in the header file : will use length of array")
+        pix = fits_hdu.data.field(0)
+        nside = pixelfunc.npix2nside(pix.size)
     else:
         nside = int(nside)
     log.info("NSIDE = %d", nside)


### PR DESCRIPTION
Closes #709.

(Note that the map used in the issue is not in healpix format and `npix2nside` rises an error. I tried in another maps and works)
