### PR TITLE
accept `None` cls for synalm

### DIFF
--- a/healpy/cookbook.py
+++ b/healpy/cookbook.py
@@ -18,7 +18,7 @@ def is_seq(o):
     return hasattr(o, "__len__")
 
 
-def is_seq_of_seq(o):
+def is_seq_of_seq(o, allow_none=False):
     """Check if the object is a sequence of sequences. No check is done on
     the sizes of the sequences.
 
@@ -26,6 +26,8 @@ def is_seq_of_seq(o):
     ----------
     o : any object
       The object to check
+    allow_none : bool, optional
+      Treat ``None`` entries as sequence.
 
     Returns
     -------
@@ -36,6 +38,8 @@ def is_seq_of_seq(o):
         return False
     for s in o:
         if not is_seq(s):
+            if allow_none and s is None:
+                continue
             return False
     return True
 

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -435,7 +435,7 @@ def synalm(cls, lmax=None, mmax=None, new=False, verbose=True):
     if not cb.is_seq(cls):
         raise TypeError("cls must be an array or a sequence of arrays")
 
-    if not cb.is_seq_of_seq(cls):
+    if not cb.is_seq_of_seq(cls, True):
         # Only one spectrum
         if lmax is None or lmax < 0:
             lmax = cls.size - 1
@@ -452,7 +452,7 @@ def synalm(cls, lmax=None, mmax=None, new=False, verbose=True):
 
     # From here, we interpret cls as a list of spectra
     cls_list = list(cls)
-    maxsize = max([len(c) for c in cls])
+    maxsize = max([len(c) for c in cls if c is not None])
 
     if lmax is None or lmax < 0:
         lmax = maxsize - 1


### PR DESCRIPTION
This PR makes it so that `synalm` accepts Cls that are `None` at the Python layer. Closes #700.

```py
>>> hp.synalm([[1.], None, None, None, None, None], new=True)
array([[-0.14311095+0.j],
       [ 0.        +0.j],
       [ 0.        +0.j]])
```