### PR TITLE
chore: cibuildwheel has joined the pypa

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: true
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.9.0
+        uses: pypa/cibuildwheel@v1.12.0
         env:
           CIBW_BEFORE_ALL_LINUX: yum install -y openssl-devel
           CIBW_BEFORE_ALL_MACOS: brew install automake


### PR DESCRIPTION
Be sure to checkout cibuildwheel 2.0 when it comes out, as the new config mode will let you move most of the config into pyproject.toml!