### PR TITLE
check is_seq by calling len()

### DIFF
--- a/healpy/cookbook.py
+++ b/healpy/cookbook.py
@@ -15,7 +15,13 @@ def is_seq(o):
     is_seq : bool, scalar
       True if *o* is a sequence, False otherwise
     """
-    return hasattr(o, "__len__")
+    try:
+        len(o)
+    except:
+        is_seq = False
+    else:
+        is_seq = True
+    return is_seq
 
 
 def is_seq_of_seq(o, allow_none=False):
@@ -37,9 +43,7 @@ def is_seq_of_seq(o, allow_none=False):
     if not is_seq(o):
         return False
     for s in o:
-        if not is_seq(s):
-            if allow_none and s is None:
-                continue
+        if not (allow_none and s is None) and not is_seq(s):
             return False
     return True
 

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -438,7 +438,7 @@ def synalm(cls, lmax=None, mmax=None, new=False, verbose=True):
     if not cb.is_seq_of_seq(cls, True):
         # Only one spectrum
         if lmax is None or lmax < 0:
-            lmax = cls.size - 1
+            lmax = len(cls) - 1
         if mmax is None or mmax < 0:
             mmax = lmax
         cls_list = [np.asarray(cls, dtype=np.float64)]

--- a/healpy/test/test_cookbook.py
+++ b/healpy/test/test_cookbook.py
@@ -1,0 +1,39 @@
+def test_is_seq():
+    import numpy as np
+    from healpy.cookbook import is_seq
+
+    assert not is_seq(None)
+    assert not is_seq(1)
+    assert not is_seq(1.)
+    assert not is_seq(np.array(1))
+    assert is_seq((1, 2, 3))
+    assert is_seq([1, 2, 3])
+    assert is_seq(np.array([1, 2, 3]))
+    assert is_seq(np.array([[1], [2], [3]]))
+    assert is_seq(())
+    assert is_seq([])
+    assert is_seq(np.array([]))
+
+
+def test_is_seq_of_seq():
+    import numpy as np
+    from healpy.cookbook import is_seq_of_seq
+
+    assert not is_seq_of_seq(None)
+    assert not is_seq_of_seq(1)
+    assert not is_seq_of_seq(1.)
+    assert not is_seq_of_seq(np.array(1))
+    assert not is_seq_of_seq((1, 2, 3))
+    assert not is_seq_of_seq([1, 2, 3])
+    assert not is_seq_of_seq(np.array([1, 2, 3]))
+    assert is_seq_of_seq(((1, 2, 3), (4, 5), (6,)))
+    assert is_seq_of_seq([[1], [2, 3], [4, 5, 6]])
+    assert is_seq_of_seq(np.array([[1], [2], [3]]))
+    assert is_seq_of_seq(((1,), [2], np.array([3])))
+    assert is_seq_of_seq(())
+    assert is_seq_of_seq([])
+    assert is_seq_of_seq(np.array([]))
+
+    # allow None
+    assert not is_seq_of_seq([[1], [2], None], False)
+    assert is_seq_of_seq([[1], [2], None], True)


### PR DESCRIPTION
There are situations in which `synalm()` breaks when called with a single cl with entries that are not plain numbers, but objects that have a `__len__` function. This happens naturally when e.g. the cl is generated in a framework such as JAX, and can be simulated using 0-dimensional numpy arrays:

```py
>>> cl = [np.zeros(shape=())]*4
>>> cl
[array(0.), array(0.), array(0.), array(0.)]
```

The reason for the failure is that the `is_seq_of_seq` check tests for the `__len__` function, which the entries of the cl now have:

```py
>>> hp.cookbook.is_seq_of_seq(cl)
True
```

In `synalm()`, the single cl passes through to the code which deals with lists of cls, and when `len(c) for c in cl` is called, the `len()` of the 0-dimensional arrays raises an error (same as e.g. within JAX):

```py
>>> len(cl[0])
Traceback (most recent call last):
  ...
TypeError: len() of unsized object
>>>
>>> hp.synalm(cl)
Traceback (most recent call last):
  ...
TypeError: len() of unsized object
```

This PR replaces the `is_seq()` check that looks for the `__len__()` method by an actual call to `len()`. Failure to call `len()` are caught with a bare `except`, which indicates the object is not a sequence:

```py
    try:
        len(o)
    except:
        is_seq = False
    else:
        is_seq = True
    return is_seq
```

This is not a great way to test for sequences, but it works around the "`__len__` but not really an array" issue.

A different solution would be to check against the `collections.abc.Sequence` abstract base class, but I wonder how many codes use homemade array classes that do not register themselves with the ABC.

(The PR also fixes an unrelated issue with calling `cls.size` on the input, which may not be a numpy array.)