### PR TITLE
docs: improve docs on datapath for pixel weights

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 Unreleased
 
+* explain how to create a local datapath for pixel weights <https://github.com/healpy/healpy/pull/720>
 * improvement on `is_seq` to avoid `synalm` breaking on JAX input arrays, added unit tests <https://github.com/healpy/healpy/pull/716>
 
 Release 1.15.0 22 June 2021, included in HEALPix 3.8.0

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -106,6 +106,7 @@ def anafast(
       If there is only one input map, it has no effect. Default: True.
     datapath : None or str, optional
       If given, the directory where to find the weights data.
+      See the docstring of `map2alm` for details on how to set it up
     gal_cut : float [degrees]
       pixels at latitude in [-gal_cut;+gal_cut] are not taken into account
     use_pixel_weights: bool, optional
@@ -191,11 +192,12 @@ def map2alm(
     Pixel weights provide the most accurate transform, so you should always use them if
     possible. However they are not included in healpy and will be automatically downloaded
     and cached in ~/.astropy the first time you compute a trasform at a specific nside.
+
     If datapath is specified, healpy will first check that local folder before downloading
     the weights.
     The easiest way to setup the folder is to clone the healpy-data repository:
     git clone --depth 1 https://github.com/healpy/healpy-data
-    and add the NSIDE 8192 weight from https://github.com/healpy/healpy-data/releases
+    bash download_weights_8192.sh
     and set datapath to the root of the repository.
 
     Parameters
@@ -217,7 +219,8 @@ def map2alm(
     use_weights: bool, scalar, optional
       If True, use the ring weighting. Default: False.
     datapath : None or str, optional
-      If given, the directory where to find the weights data.
+      If given, the directory where to find the pixel weights.
+      See in the docstring above details on how to set it up.
     gal_cut : float [degrees]
       pixels at latitude in [-gal_cut;+gal_cut] are not taken into account
     use_pixel_weights: bool, optional
@@ -923,7 +926,8 @@ def smoothing(
       If True, use pixel by pixel weighting, healpy will automatically download the weights, if needed
       See the map2alm docs for details about weighting
     datapath : None or str, optional
-      If given, the directory where to find the weights data.
+      If given, the directory where to find the pixel weights data.
+      See the docstring of `map2alm` for details on how to set it up
     verbose : bool, optional
       Deprecated, has not effect.
     nest : bool, optional

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -196,8 +196,11 @@ def map2alm(
     If datapath is specified, healpy will first check that local folder before downloading
     the weights.
     The easiest way to setup the folder is to clone the healpy-data repository:
+
     git clone --depth 1 https://github.com/healpy/healpy-data
+    cd healpy-data
     bash download_weights_8192.sh
+
     and set datapath to the root of the repository.
 
     Parameters


### PR DESCRIPTION
@ntessore following https://github.com/healpy/healpy/pull/595#issuecomment-935792362

`healpy` has already this functionality, I improved the docs, please review them,
can you also make a test to make sure it works as advertised?

We also have a unit test on this: https://github.com/healpy/healpy/blob/c632a318fecc3ae020f6b5367e024e8927c4df4c/healpy/test/test_pixelweights.py#L37-L52

