### PR TITLE
Update supported Python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ https://healpy.readthedocs.io/en/latest/tutorial.html, or execute it on `mybinde
 Requirements
 ------------
 
-* `Python <http://www.python.org>`_ 3.6, 3.7, 3.8, or 3.9
+* `Python <http://www.python.org>`_ 3.7, 3.8, 3.9, or 3.10
 
 * `Numpy <http://numpy.scipy.org/>`_ (tested with version >=1.5.0)
 

--- a/setup.py
+++ b/setup.py
@@ -334,10 +334,10 @@ setup(
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
         "Operating System :: POSIX",
         "Programming Language :: C++",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering :: Astronomy",
         "Topic :: Scientific/Engineering :: Visualization",
     ],
@@ -457,5 +457,5 @@ setup(
     test_suite="healpy",
     license="GPLv2",
     scripts=["bin/healpy_get_wmap_maps.sh"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
Python 3.6 is past end of life. Drop Python 3.6, add Python 3.10.