### PR TITLE
Only build wheels for 64-bit archs (skip i686)

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
         env:
+          CIBW_ARCHS: auto64
           CIBW_BEFORE_ALL_LINUX: yum install -y curl-devel openssl-devel
           CIBW_BEFORE_ALL_MACOS: brew install automake
           CIBW_ENVIRONMENT_MACOS: CC=gcc-9 CXX=g++-9

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -41,11 +41,10 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
         env:
-          CIBW_ARCHS: auto64
           CIBW_BEFORE_ALL_LINUX: yum install -y curl-devel openssl-devel
           CIBW_BEFORE_ALL_MACOS: brew install automake
           CIBW_ENVIRONMENT_MACOS: CC=gcc-9 CXX=g++-9
-          CIBW_SKIP: pp*
+          CIBW_SKIP: pp* *_i686
           CIBW_TEST_COMMAND: pytest --doctest-plus --doctest-cython -v --pyargs healpy
           CIBW_TEST_REQUIRES: pytest pytest-cython pytest-doctestplus requests
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -44,7 +44,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: yum install -y curl-devel openssl-devel
           CIBW_BEFORE_ALL_MACOS: brew install automake
           CIBW_ENVIRONMENT_MACOS: CC=gcc-9 CXX=g++-9
-          CIBW_SKIP: pp* *_i686
+          CIBW_SKIP: "*-musllinux_* pp* *_i686"
           CIBW_TEST_COMMAND: pytest --doctest-plus --doctest-cython -v --pyargs healpy
           CIBW_TEST_REQUIRES: pytest pytest-cython pytest-doctestplus requests
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -40,13 +40,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
-        env:
-          CIBW_BEFORE_ALL_LINUX: yum install -y curl-devel openssl-devel
-          CIBW_BEFORE_ALL_MACOS: brew install automake
-          CIBW_ENVIRONMENT_MACOS: CC=gcc-9 CXX=g++-9
-          CIBW_SKIP: "*-musllinux_* pp* *_i686"
-          CIBW_TEST_COMMAND: pytest --doctest-plus --doctest-cython -v --pyargs healpy
-          CIBW_TEST_REQUIRES: pytest pytest-cython pytest-doctestplus requests
 
       - uses: actions/upload-artifact@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,15 @@ requires = ["setuptools",
             "oldest-supported-numpy"]
 
 build-backend = 'setuptools.build_meta'
+
+[tool.cibuildwheel]
+skip = "*-musllinux_* pp* *_i686"
+test-command = "pytest --doctest-plus --doctest-cython -v --pyargs healpy"
+test-requires = ["pytest", "pytest-cython", "pytest-doctestplus", "requests"]
+
+[tool.cibuildwheel.linux]
+before-all = "yum install -y curl-devel openssl-devel"
+
+[tool.cibuildwheel.macos]
+before-all = "brew install automake"
+environment = {"CC" = "gcc-9", "CXX" = "g++-9"}


### PR DESCRIPTION
The cibuildwheel CI job is timing out. Skip wheels for 32-bit archs (i686). These archs are very rare nowadays and it is not common for our upstream dependencies to provide wheels for them anyway. Numpy, for example, does not distribute i686 wheels.

This should significantly reduce the build time because the CI job will only have to build half as many wheels. The skipped i686 wheels were the slowest anyway, because it had to build wheels for many of the dependencies too (including Numpy).