### PR TITLE
Fix `reuse_axes=True` for `cartview` and `gnomview`

### DIFF
--- a/healpy/test/test_visufunc.py
+++ b/healpy/test/test_visufunc.py
@@ -108,3 +108,15 @@ class TestNoCrash(unittest.TestCase):
         assert cmap._rgba_bad == color
         assert cmap._rgba_over == color
         assert cmap._rgba_under == color
+
+    def test_reuse_axes(self):
+        cartview(self.m)
+        cartview(self.m, reuse_axes=True)
+        mollview(self.m)
+        mollview(self.m, reuse_axes=True)
+        gnomview(self.m)
+        gnomview(self.m, reuse_axes=True)
+        orthview(self.m)
+        orthview(self.m, reuse_axes=True)
+        azeqview(self.m)
+        azeqview(self.m, reuse_axes=True)

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -492,12 +492,13 @@ def gnomview(
             1.0 / ncols - margins[2] - margins[0],
             1.0 / nrows - margins[3] - margins[1],
         )
-    extent = (
-        extent[0] + margins[0],
-        extent[1] + margins[1],
-        extent[2] - margins[2] - margins[0],
-        extent[3] - margins[3] - margins[1],
-    )
+    if not reuse_axes:
+        extent = (
+            extent[0] + margins[0],
+            extent[1] + margins[1],
+            extent[2] - margins[2] - margins[0],
+            extent[3] - margins[3] - margins[1],
+        )
     # f=pylab.figure(fig,figsize=(5.5,6))
 
     # Starting to draw : turn interactive off
@@ -787,12 +788,13 @@ def cartview(
             1.0 / ncols - margins[2] - margins[0],
             1.0 / nrows - margins[3] - margins[1],
         )
-    extent = (
-        extent[0] + margins[0],
-        extent[1] + margins[1],
-        extent[2] - margins[2] - margins[0],
-        extent[3] - margins[3] - margins[1],
-    )
+    if not reuse_axes:
+        extent = (
+            extent[0] + margins[0],
+            extent[1] + margins[1],
+            extent[2] - margins[2] - margins[0],
+            extent[3] - margins[3] - margins[1],
+        )
 
     # f=pylab.figure(fig,figsize=(5.5,6))
     # Starting to draw : turn interactive off


### PR DESCRIPTION
It's come to my attention that when I wrote #617, I apparently forgot to actually test `reuse_axes=True` for `cartview` and `gnomview`, since it never actually worked in these cases and threw an exception instead. This PR fixes those mistakes and also adds tests to prevent future regressions for this.