### PR TITLE
Switch to gh-action-pypi-publish release

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
 
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
According to the [README](https://github.com/pypa/gh-action-pypi-publish):

> The master branch version has been sunset. Please, change the GitHub Action version you use from master to release/v1 or use an exact tag, or a full Git commit SHA.