### PR TITLE
Move projview's subplots_adjust inside check on return_only_data

### DIFF
--- a/healpy/newvisufunc.py
+++ b/healpy/newvisufunc.py
@@ -506,9 +506,6 @@ def projview(
     if graticule and graticule_labels:
         left += 0.02
 
-    if not return_only_data:
-        plt.subplots_adjust(left=left, right=right, top=top, bottom=bottom)
-
     ysize = xsize // 2
     theta = np.linspace(np.pi, 0, ysize)
     phi = np.linspace(-np.pi, np.pi, xsize)
@@ -517,6 +514,7 @@ def projview(
     if flip == "astro":
         longitude = longitude[::-1]
     if not return_only_data:
+        plt.subplots_adjust(left=left, right=right, top=top, bottom=bottom)
         # set property on ax so it can be used in newprojplot
         ax.healpy_flip = flip
 

--- a/healpy/newvisufunc.py
+++ b/healpy/newvisufunc.py
@@ -505,7 +505,9 @@ def projview(
     # end if not
     if graticule and graticule_labels:
         left += 0.02
-    plt.subplots_adjust(left=left, right=right, top=top, bottom=bottom)
+
+    if not return_only_data:
+        plt.subplots_adjust(left=left, right=right, top=top, bottom=bottom)
 
     ysize = xsize // 2
     theta = np.linspace(np.pi, 0, ysize)


### PR DESCRIPTION
Right now the projview function still does one figure-related operation even if return_only_data is set to True. This change stops that from happening by moving that call inside a check.