### PR TITLE
Update gcc compiler for macOS cibuildwheel

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-10.15]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ before-all = "yum install -y curl-devel openssl-devel"
 
 [tool.cibuildwheel.macos]
 before-all = "brew install automake"
-environment = {"CC" = "gcc-9", "CXX" = "g++-9"}
+environment = {"CC" = "gcc-11", "CXX" = "g++-11"}


### PR DESCRIPTION
The gcc version on GitHub's macos-latest runners has been updated.

This fixes an error in which the macOS wheel build would fail with the error message, "C compiler cannot create executables".

See #794.