### PR TITLE
Bump macOS version used for wheel builds

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-11]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ before-all = "yum install -y curl-devel openssl-devel"
 
 [tool.cibuildwheel.macos]
 before-all = "brew install automake"
-environment = {"CC" = "gcc-11", "CXX" = "g++-11"}
+environment = {"CC" = "gcc-12", "CXX" = "g++-12"}


### PR DESCRIPTION
GitHub has retired macOS 10.15 support.