### PR TITLE
Use moving minor tag for cibuildwheel

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -45,7 +45,7 @@ jobs:
           platforms: arm64
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.13.1
+        uses: pypa/cibuildwheel@v2.14
         env:
           # Build wheels for aarch64 under emulation.
           CIBW_ARCHS_LINUX: "auto aarch64"


### PR DESCRIPTION
This will eliminate manual dependabot update PRs for patch releases of cibuildwheel.

See https://github.com/pypa/cibuildwheel/pull/1517