### PR TITLE
Fix kebab case warning

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: artifact/
+          packages-dir: artifact/


### PR DESCRIPTION
Fix this warning from gh-action-pypi-publish:

    Warning: Input 'packages_dir' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `packages-dir` instead.