### PR TITLE
Build against numpy 1.25, not oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
 ]
 license = { text = "GPL-2.0-only" }
 requires-python = ">=3.9"
-dependencies = ["matplotlib", "numpy>=1.13", "astropy", "scipy"]
+dependencies = ["matplotlib", "numpy>=1.19", "astropy", "scipy"]
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cython", "pytest-doctestplus", "requests"]
@@ -36,7 +36,7 @@ requires = ["setuptools>=45",
             "setuptools_scm[toml]>=6.2",
             "cython>=0.16",
             "wheel",
-            "oldest-supported-numpy"]
+            "numpy>=1.25"]
 
 build-backend = 'setuptools.build_meta'
 

--- a/setup.py
+++ b/setup.py
@@ -312,6 +312,12 @@ class custom_build_ext(build_ext):
         build_ext.run(self)
 
 
+ext_kwargs = dict(
+    extra_compile_args=["-std=c++11"],
+    define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_19_API_VERSION')],
+    language="c++",
+)
+
 setup(
     packages=["healpy", "healpy.test"],
     libraries=[
@@ -354,49 +360,42 @@ setup(
         Extension(
             "healpy._healpy_pixel_lib",
             sources=["healpy/src/_healpy_pixel_lib.cc"],
-            language="c++",
-            extra_compile_args=["-std=c++11"],
+            **ext_kwargs
         ),
         Extension(
             "healpy._healpy_sph_transform_lib",
             sources=["healpy/src/_healpy_sph_transform_lib.cc"],
-            language="c++",
-            extra_compile_args=["-std=c++11"],
+            **ext_kwargs
         ),
         Extension(
             "healpy._query_disc",
             ["healpy/src/_query_disc.pyx"],
-            language="c++",
-            extra_compile_args=["-std=c++11"],
             cython_directives=dict(embedsignature=True),
+            **ext_kwargs
         ),
         Extension(
             "healpy._sphtools",
             ["healpy/src/_sphtools.pyx"],
-            language="c++",
-            extra_compile_args=["-std=c++11"],
             cython_directives=dict(embedsignature=True),
+            **ext_kwargs
         ),
         Extension(
             "healpy._pixelfunc",
             ["healpy/src/_pixelfunc.pyx"],
-            language="c++",
-            extra_compile_args=["-std=c++11"],
             cython_directives=dict(embedsignature=True),
+            **ext_kwargs
         ),
         Extension(
             "healpy._masktools",
             ["healpy/src/_masktools.pyx"],
-            language="c++",
-            extra_compile_args=["-std=c++11"],
             cython_directives=dict(embedsignature=True),
+            **ext_kwargs
         ),
         Extension(
             "healpy._hotspots",
             ["healpy/src/_hotspots.pyx", "healpy/src/_healpy_hotspots_lib.cc"],
-            language="c++",
-            extra_compile_args=["-std=c++11"],
             cython_directives=dict(embedsignature=True),
+            **ext_kwargs
         ),
         Extension(
             "healpy._line_integral_convolution",
@@ -404,13 +403,12 @@ setup(
                 "healpy/src/_line_integral_convolution.pyx",
                 "healpixsubmodule/src/cxx/Healpix_cxx/alice3.cc",
             ],
-            language="c++",
-            extra_compile_args=[
-                "-std=c++11",
-                "-Ihealpixsubmodule/src/cxx/cxxsupport",
-                "-Ihealpixsubmodule/src/cxx/Healpix_cxx",
+            include_dirs=[
+                "healpixsubmodule/src/cxx/cxxsupport",
+                "healpixsubmodule/src/cxx/Healpix_cxx",
             ],
             cython_directives=dict(embedsignature=True),
+            **ext_kwargs
         ),
     ],
     package_data={


### PR DESCRIPTION
From Numpy 1.25 onward, Numpy has API backwards compatibility. It is no longer necessary to build against oldest-supported-numpy.