### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ build:
    image: latest
 
 python:
-   version: 3.8
+   version: 3.9
    install:
       - method: pip
         path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Operating System :: POSIX",
     "Programming Language :: C++",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -22,7 +21,7 @@ authors = [
     { name = "A. Zonca" },
 ]
 license = { text = "GPL-2.0-only" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["matplotlib", "numpy>=1.13", "astropy", "scipy"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
See https://numpy.org/neps/nep-0029-deprecation_policy.html.