### PR TITLE
Don't use deprecated pkg_resources package to find pykg-config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ requires = ["setuptools>=45",
             "setuptools_scm[toml]>=6.2",
             "cython>=0.16",
             "wheel",
-            "numpy>=1.25"]
+            "numpy>=1.25",
+            "pykg-config"]
 
 build-backend = 'setuptools.build_meta'
 

--- a/run_pykg_config.py
+++ b/run_pykg_config.py
@@ -1,7 +1,0 @@
-# Helper to run pykg-config, whether it is installed or lives in a zipped egg.
-from setuptools import Distribution
-from pkg_resources import run_script
-
-requirement = "pykg-config >= 1.2.0"
-Distribution().fetch_build_eggs(requirement)
-run_script(requirement, "pykg-config.py")

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import errno
 import fnmatch
 import sys
 import shlex
+import shutil
 from Cython.Distutils import build_ext
 from distutils.sysconfig import get_config_var, get_config_vars
 from subprocess import check_output, CalledProcessError, check_call
@@ -69,9 +70,7 @@ class build_external_clib(build_clib):
                 if e.errno != errno.ENOENT:
                     raise
                 log.warn("pkg-config is not installed, falling back to pykg-config")
-                env["PKG_CONFIG"] = (
-                    sys.executable + " " + os.path.abspath("run_pykg_config.py")
-                )
+                env["PKG_CONFIG"] = shutil.which('pykg-config.py')
             else:
                 env["PKG_CONFIG"] = "pkg-config"
 


### PR DESCRIPTION
This stopped working in Python 3.12.