### PR TITLE
Move cibuildwheel conf to pyproject.toml, fix OpenMP for macOS

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -45,17 +45,13 @@ jobs:
         with:
           platforms: arm64
 
+      - name: Set up macOS compilers
+        if: runner.os == 'macOS'
+        run: |
+          echo "CIBW_ENVIRONMENT=CC=$(brew --prefix llvm@15)/bin/clang CXX=$(brew --prefix llvm@15)/bin/clang++ CPPFLAGS=-I$(brew --prefix libomp)/include LDFLAGS=-L$(brew --prefix libomp)/lib" >> "$GITHUB_ENV"
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16
-        env:
-          CIBW_ENVIRONMENT: MPLBACKEND=agg
-          CIBW_BEFORE_ALL_MACOS: brew install autoconf automake libtool
-          # Build wheels for aarch64 under emulation.
-          CIBW_ARCHS_LINUX: "auto aarch64"
-          # Skip PyPy builds; Astropy wheels are not built for PyPy.
-          # Skip i686 builds.
-          # Skip MUSL libc builds.
-          CIBW_SKIP: 'pp* *_i686 *-musllinux_*'
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,16 +42,20 @@ requires = ["setuptools>=45",
 build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel]
-skip = "*-musllinux_* pp* *_i686"
+# Skip PyPy builds; Astropy wheels are not built for PyPy.
+# Skip i686 builds.
+# Skip MUSL libc builds.
+skip = "pp* *_i686 *-musllinux_*"
 test-command = "pytest --doctest-plus --doctest-cython -v --pyargs healpy"
 test-extras = ["test"]
 
 [tool.cibuildwheel.linux]
+# Build wheels for aarch64 under emulation.
+archs = ["auto", "aarch64"]
 before-all = "yum install -y curl-devel openssl-devel"
 
 [tool.cibuildwheel.macos]
-before-all = "brew install automake"
-environment = {"CC" = "gcc-12", "CXX" = "g++-12"}
+before-all = "brew install autoconf automake libtool libomp"
 
 [tool.setuptools_scm]
 write_to = "healpy/version.py"


### PR DESCRIPTION
https://github.com/healpy/healpy/pull/896 accidentally switched
the macOS builds form gcc to Xcode's clang; this disabled OpenMP on
macOS because the Xcode's clang does not support the `-fopenmp` flag.

Since gcc was causing crashes on macOS 14 (see
https://github.com/matplotlib/matplotlib/issues/27724), switch from
gcc to homebrew's clang, which does support OpenMP and does not
cause crashes.