### PR TITLE
Remove wheel from build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ homepage = "http://github.com/healpy"
 requires = ["setuptools>=45",
             "setuptools_scm[toml]>=6.2",
             "cython>=0.16",
-            "wheel",
             "numpy>=1.25",
             "pykg-config"]
 


### PR DESCRIPTION
Setuptools no longer recommends this. See
https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use