### PR TITLE
Move packages, package data, and scripts to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,20 @@ requires = ["setuptools>=45",
 
 build-backend = 'setuptools.build_meta'
 
+[tool.setuptools]
+script-files = ["bin/healpy_get_wmap_maps.sh"]
+
+[tool.setuptools.packages.find]
+include = ["healpy*"]
+
+[tool.setuptools.package-data]
+healpy = ["data/*.fits",
+          "data/*_cmap.dat",
+          "data/totcls.dat",
+          "test/data/*.fits",
+          "test/data/*.fits.gz",
+          "test/data/*.sh"]
+
 [tool.cibuildwheel]
 # Skip PyPy builds; Astropy wheels are not built for PyPy.
 # Skip i686 builds.

--- a/setup.py
+++ b/setup.py
@@ -318,7 +318,6 @@ ext_kwargs = dict(
 )
 
 setup(
-    packages=["healpy", "healpy.test"],
     libraries=[
         (
             "cfitsio",
@@ -342,17 +341,6 @@ setup(
                 "local_source": "healpixsubmodule/src/cxx",
             },
         ),
-    ],
-    py_modules=[
-        "healpy.pixelfunc",
-        "healpy.sphtfunc",
-        "healpy.visufunc",
-        "healpy.fitsfunc",
-        "healpy.projector",
-        "healpy.rotator",
-        "healpy.projaxes",
-        "healpy.utils.deprecation",
-        "healpy.version",
     ],
     cmdclass={"build_ext": custom_build_ext, "build_clib": build_external_clib},
     ext_modules=[
@@ -410,15 +398,4 @@ setup(
             **ext_kwargs
         ),
     ],
-    package_data={
-        "healpy": [
-            "data/*.fits",
-            "data/*_cmap.dat",
-            "data/totcls.dat",
-            "test/data/*.fits",
-            "test/data/*.fits.gz",
-            "test/data/*.sh",
-        ]
-    },
-    scripts=["bin/healpy_get_wmap_maps.sh"],
 )


### PR DESCRIPTION
Move as much of the build configuration as possible from setup.py to pyproject.toml.