### PR TITLE
Shrink wheels by building dependencies as shared libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,6 @@ class build_external_clib(build_clib):
                 "/bin/sh",
                 os.path.join(os.path.realpath(local_source), "configure"),
                 "--prefix=" + build_clib,
-                "--disable-shared",
                 "--with-pic",
                 "--disable-maintainer-mode",
             ]


### PR DESCRIPTION
Healpy's extension modules took up a surprising amount of space in the wheels:

```
$ du -h *.so
3.6M	_healpy_pixel_lib.cpython-312-x86_64-linux-gnu.so
 13M	_healpy_sph_transform_lib.cpython-312-x86_64-linux-gnu.so
3.9M	_hotspots.cpython-312-x86_64-linux-gnu.so
 13M	_line_integral_convolution.cpython-312-x86_64-linux-gnu.so
4.1M	_masktools.cpython-312-x86_64-linux-gnu.so
4.0M	_pixelfunc.cpython-312-x86_64-linux-gnu.so
4.4M	_query_disc.cpython-312-x86_64-linux-gnu.so
 15M	_sphtools.cpython-312-x86_64-linux-gnu.so
```

This was the because dependencies (cfitsio, libsharp, libhealpix-cxx) were built as static libraries and a copies of them were statically linked into each of the extension modules.

Instead, build all of the bundled dependencies as shared libaries so that the wheels only contain single copies of their object code.