### PR TITLE
Shrink wheels by not linking against libcurl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/healpy/healpixmirror.git
 [submodule "cfitsio"]
 	path = cfitsio
-	url = https://github.com/healpy/cfitsio.git
+	url = https://github.com/HEASARC/cfitsio.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ test-extras = ["test"]
 [tool.cibuildwheel.linux]
 # Build wheels for aarch64 under emulation.
 archs = ["auto", "aarch64"]
-before-all = "yum install -y curl-devel openssl-devel"
 
 [tool.cibuildwheel.macos]
 before-all = "brew install autoconf automake libtool libomp"

--- a/setup.py
+++ b/setup.py
@@ -185,6 +185,7 @@ class build_external_clib(build_clib):
                 "/bin/sh",
                 os.path.join(os.path.realpath(local_source), "configure"),
                 "--prefix=" + build_clib,
+                "--disable-curl",
                 "--with-pic",
                 "--disable-maintainer-mode",
             ]


### PR DESCRIPTION
Cfitsio links against libcurl to support remote file I/O. On Linux, curl adds 24 shared libraries totalling 11 MB in size that get bundled into the wheel.

Nowadays, remote I/O support for FITS reading in Python is not provided by cfitsio but by the Python code in astropy.io.fits.

It's unlikely that the cfitsio remote file I/O was working anyway because the default certificate paths baked into the libraries are unlikely to match their locations on the target system, and there is no way to control those paths from the Python-level API.