### PR TITLE
Update bundled cfitsio to 4.3.1, use official GH mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/healpy/healpixmirror.git
 [submodule "cfitsio"]
 	path = cfitsio
-	url = https://github.com/healpy/cfitsio.git
+	url = https://github.com/HEASARC/cfitsio.git


### PR DESCRIPTION
- Update bundled cfitsio to 4.3.1.
- Use official GitHub mirror maintained by HEASARC instead of our own mirror.