### PR TITLE
Optional dependencies

### DIFF
--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -94,10 +94,29 @@ from ._pixelfunc import ringinfo, pix2ring
 from ._sphtools import rotate_alm
 from .rotator import Rotator, vec2dir, dir2vec
 from ._healpy_pixel_lib import UNSEEN
+try:
+    from .visufunc import (
+        mollview,
+        graticule,
+        delgraticules,
+        gnomview,
+        projplot,
+        projscatter,
+        projtext,
+        cartview,
+        orthview,
+        azeqview,
+    )
+    from .zoomtool import mollzoom, set_g_clim
+    from .newvisufunc import projview, newprojplot
+except:
+    pass
+
 from .fitsfunc import write_map, read_map, read_alm, write_alm, write_cl, read_cl
 from ._masktools import dist2holes_healpy as dist2holes
 from ._hotspots import hotspots_healpy as hotspots
 from ._line_integral_convolution import line_integral_convolution
+
 
 from .utils.deprecation import deprecated
 

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -94,25 +94,25 @@ from ._pixelfunc import ringinfo, pix2ring
 from ._sphtools import rotate_alm
 from .rotator import Rotator, vec2dir, dir2vec
 from ._healpy_pixel_lib import UNSEEN
-from .visufunc import (
-    mollview,
-    graticule,
-    delgraticules,
-    gnomview,
-    projplot,
-    projscatter,
-    projtext,
-    cartview,
-    orthview,
-    azeqview,
-)
-from .zoomtool import mollzoom, set_g_clim
+# from .visufunc import (
+#     mollview,
+#     graticule,
+#     delgraticules,
+#     gnomview,
+#     projplot,
+#     projscatter,
+#     projtext,
+#     cartview,
+#     orthview,
+#     azeqview,
+# )
+# from .zoomtool import mollzoom, set_g_clim
 from .fitsfunc import write_map, read_map, read_alm, write_alm, write_cl, read_cl
 from ._masktools import dist2holes_healpy as dist2holes
 from ._hotspots import hotspots_healpy as hotspots
 from ._line_integral_convolution import line_integral_convolution
 
-from .newvisufunc import projview, newprojplot
+#from .newvisufunc import projview, newprojplot
 
 
 from .utils.deprecation import deprecated

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -94,7 +94,12 @@ from ._pixelfunc import ringinfo, pix2ring
 from ._sphtools import rotate_alm
 from .rotator import Rotator, vec2dir, dir2vec
 from ._healpy_pixel_lib import UNSEEN
+
 try:
+    import matplotlib
+except ImportError:
+    pass
+else:
     from .visufunc import (
         mollview,
         graticule,
@@ -109,8 +114,6 @@ try:
     )
     from .zoomtool import mollzoom, set_g_clim
     from .newvisufunc import projview, newprojplot
-except:
-    pass
 
 from .fitsfunc import write_map, read_map, read_alm, write_alm, write_cl, read_cl
 from ._masktools import dist2holes_healpy as dist2holes

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -94,26 +94,10 @@ from ._pixelfunc import ringinfo, pix2ring
 from ._sphtools import rotate_alm
 from .rotator import Rotator, vec2dir, dir2vec
 from ._healpy_pixel_lib import UNSEEN
-# from .visufunc import (
-#     mollview,
-#     graticule,
-#     delgraticules,
-#     gnomview,
-#     projplot,
-#     projscatter,
-#     projtext,
-#     cartview,
-#     orthview,
-#     azeqview,
-# )
-# from .zoomtool import mollzoom, set_g_clim
 from .fitsfunc import write_map, read_map, read_alm, write_alm, write_cl, read_cl
 from ._masktools import dist2holes_healpy as dist2holes
 from ._hotspots import hotspots_healpy as hotspots
 from ._line_integral_convolution import line_integral_convolution
-
-#from .newvisufunc import projview, newprojplot
-
 
 from .utils.deprecation import deprecated
 

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -24,7 +24,6 @@ import numpy as np
 
 import astropy.io.fits as pf
 from .utils.deprecation import deprecated_renamed_argument
-from scipy.integrate import trapz
 from astropy.utils import data
 
 DATAURL = "https://healpy.github.io/healpy-data/"
@@ -1338,6 +1337,7 @@ def beam2bl(beam, theta, lmax):
     bl : array
         Beam window function b(l).
     """
+    from scipy.integrate import trapz
 
     nx = len(theta)
     nb = len(beam)

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -63,8 +63,6 @@ __all__ = [
 
 from . import projaxes as PA
 import numpy as np
-import matplotlib
-import matplotlib.pyplot as plt
 from . import pixelfunc
 
 pi = np.pi
@@ -187,6 +185,8 @@ def mollview(
     """
     # Create the figure
     import pylab
+    import matplotlib
+    import matplotlib.pyplot as plt
 
     if map is None:
         map = np.zeros(12) + np.inf
@@ -455,6 +455,8 @@ def gnomview(
     mollview, cartview, orthview, azeqview
     """
     import pylab
+    import matplotlib
+    import matplotlib.pyplot as plt
 
     if map is None:
         map = np.zeros(12) + np.inf
@@ -751,6 +753,8 @@ def cartview(
     mollview, gnomview, orthview, azeqview
     """
     import pylab
+    import matplotlib
+    import matplotlib.pyplot as plt 
 
     if map is None:
         map = np.zeros(12) + np.inf
@@ -1025,6 +1029,8 @@ def orthview(
     """
     # Create the figure
     import pylab
+    import matplotlib.pyplot as plt
+    import matplotlib
 
     if map is None:
         map = np.zeros(12) + np.inf
@@ -1303,6 +1309,8 @@ def azeqview(
     """
     # Create the figure
     import pylab
+    import matplotlib.pyplot as plt
+    import matplotlib
 
     if map is None:
         map = np.zeros(12) + np.inf

--- a/healpy/visufunc.py
+++ b/healpy/visufunc.py
@@ -64,6 +64,8 @@ __all__ = [
 from . import projaxes as PA
 import numpy as np
 from . import pixelfunc
+import matplotlib
+import matplotlib.pyplot as plt
 
 pi = np.pi
 dtor = pi / 180.0
@@ -185,8 +187,6 @@ def mollview(
     """
     # Create the figure
     import pylab
-    import matplotlib
-    import matplotlib.pyplot as plt
 
     if map is None:
         map = np.zeros(12) + np.inf
@@ -455,8 +455,6 @@ def gnomview(
     mollview, cartview, orthview, azeqview
     """
     import pylab
-    import matplotlib
-    import matplotlib.pyplot as plt
 
     if map is None:
         map = np.zeros(12) + np.inf
@@ -753,8 +751,6 @@ def cartview(
     mollview, gnomview, orthview, azeqview
     """
     import pylab
-    import matplotlib
-    import matplotlib.pyplot as plt 
 
     if map is None:
         map = np.zeros(12) + np.inf
@@ -1029,8 +1025,6 @@ def orthview(
     """
     # Create the figure
     import pylab
-    import matplotlib.pyplot as plt
-    import matplotlib
 
     if map is None:
         map = np.zeros(12) + np.inf
@@ -1309,8 +1303,6 @@ def azeqview(
     """
     # Create the figure
     import pylab
-    import matplotlib.pyplot as plt
-    import matplotlib
 
     if map is None:
         map = np.zeros(12) + np.inf

--- a/healpy/zoomtool.py
+++ b/healpy/zoomtool.py
@@ -20,6 +20,7 @@
 
 import logging
 log = logging.getLogger("healpy")
+import matplotlib
 from . import projaxes as PA
 from . import rotator as R
 import numpy as np
@@ -98,7 +99,6 @@ def mollzoom(
       The format of the scale label. Default: '%g'
     """
     import pylab
-    import matplotlib
 
     # Ensure that the nside is valid
     nside = pixelfunc.get_nside(map)
@@ -517,7 +517,6 @@ class ZoomTool(object):
 
     def draw_gnom(self, lon=None, lat=None):
         import pylab
-        import matplotlib
 
         wasinteractive = pylab.isinteractive()
         pylab.ioff()

--- a/healpy/zoomtool.py
+++ b/healpy/zoomtool.py
@@ -23,7 +23,6 @@ log = logging.getLogger("healpy")
 from . import projaxes as PA
 from . import rotator as R
 import numpy as np
-import matplotlib
 from ._healpy_pixel_lib import UNSEEN
 from . import pixelfunc
 
@@ -99,6 +98,7 @@ def mollzoom(
       The format of the scale label. Default: '%g'
     """
     import pylab
+    import matplotlib
 
     # Ensure that the nside is valid
     nside = pixelfunc.get_nside(map)
@@ -517,6 +517,7 @@ class ZoomTool(object):
 
     def draw_gnom(self, lon=None, lat=None):
         import pylab
+        import matplotlib
 
         wasinteractive = pylab.isinteractive()
         pylab.ioff()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = ["numpy>=1.19", "astropy"]
 
 [project.optional-dependencies]
 all = ["matplotlib", "scipy"]
-test = ["pytest", "pytest-cython", "pytest-doctestplus", "requests"]
+test = ["matplotlib", "scipy", "pytest", "pytest-cython", "pytest-doctestplus", "requests"]
 
 [project.urls]
 homepage = "http://github.com/healpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,10 @@ authors = [
 ]
 license = { text = "GPL-2.0-only" }
 requires-python = ">=3.9"
-dependencies = ["matplotlib", "numpy>=1.19", "astropy", "scipy"]
+dependencies = ["numpy>=1.19", "astropy"]
 
 [project.optional-dependencies]
+all = ["matplotlib", "scipy"]
 test = ["pytest", "pytest-cython", "pytest-doctestplus", "requests"]
 
 [project.urls]


### PR DESCRIPTION
# Changes
Made `scipy` and `matplotlib` optional dependencies, where they can be included by doing `pip install "healpy[all]"`.  Addresses https://github.com/healpy/healpy/issues/907

# Implications
The `scipy` dependency was simple, and moving it to the function level was trivial. However for `matplotlib`, custom `healpy` classes inherit directly from `matplotlib` classes, thus simply moving the imports to the function level wasn't possible. In order to have a _semi-stable_  library, I had to remove the `visfunc`, `zoomtool`, and `newvisfunc` imports from `healpy/__init__.py`. Which means that users will have to call those methods by descending into those modules directly (e.g. `healpy.visfunc.mollview(...)`).

- Upsides: 
  - Importing `healpy` will be much faster.
  - Installing sans `scipy` and `matplotlib` will be much slimmer.
- Downsides: 
  - Will break existing applications where plotting methods are used.
  - API documentation and examples will certainly be affected. 