### PR TITLE
Remove unittest module runner

### DIFF
--- a/healpy/test/test_fitsfunc.py
+++ b/healpy/test/test_fitsfunc.py
@@ -338,7 +338,3 @@ def test_writemap_typestr_endianness(tmp_path):
         with pf.open(filename) as f:
             assert f[1].data.field(0).dtype.name == "float32"
             np.testing.assert_array_almost_equal(f[1].data.field(0), m)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/healpy/test/test_pixelfunc.py
+++ b/healpy/test/test_pixelfunc.py
@@ -189,7 +189,3 @@ class TestPixelFunc(unittest.TestCase):
         self.assertTrue(not isnsideok(nside=-16, nest=True))
         self.assertTrue(not isnsideok(nside=-16, nest=False))
         self.assertTrue(not isnsideok(nside=13, nest=True))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/healpy/test/test_sphtfunc.py
+++ b/healpy/test/test_sphtfunc.py
@@ -671,7 +671,3 @@ def test_resize_alm(lmax, mmax, lmax_out, mmax_out):
     alm_out2 = hp.resize_alm([alm, 2 * alm], lmax, mmax, lmax_out, mmax_out)
     np.testing.assert_allclose(alm_out, alm_out2[0])
     np.testing.assert_allclose(2 * alm_out, alm_out2[1])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/healpy/test/test_spinfunc.py
+++ b/healpy/test/test_spinfunc.py
@@ -1088,7 +1088,3 @@ class TestSpinFunc(unittest.TestCase):
             tglm, tclm = hp.map2alm_spin([rmap, imap], spin, self.lmax)
             np.testing.assert_allclose(almg, tglm, rtol=1.0e-2, atol=1.0e-2)
             np.testing.assert_allclose(almc, tclm, rtol=1.0e-2, atol=1.0e-2)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
Nowadays, we always run these tests with pytest.