### PR TITLE
Unpin pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = ["numpy>=1.19", "astropy"]
 [project.optional-dependencies]
 all = ["matplotlib", "scipy"]
 test = [
-    "pytest<8",  # pytest-cython does not work with pytest 8.x. See https://github.com/lgpage/pytest-cython/issues/58
+    "pytest",
     "pytest-cython",
     "pytest-doctestplus",
     "requests",


### PR DESCRIPTION
pytest-cython is now compatible with pytest>=8.