### PR TITLE
Build against Numpy>=2.0.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ homepage = "http://github.com/healpy"
 requires = ["setuptools>=45",
             "setuptools_scm[toml]>=6.2",
             "cython>=0.16",
-            "numpy>=1.25",
+            "numpy>=2.0.0rc1",
             "pykg-config"]
 
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
Numpy 2.0.0 is coming out soon. In order to support both Numpy 1.x and 2.x, we must build against Numpy 2.x.

The [official guidance from Numpy](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-abi-handling) is that we should be targeting numpy 2.0.0rc1 as a build dependency now.