### PR TITLE
Update build-system.requires settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ homepage = "http://github.com/healpy"
 
 [build-system]
 
-requires = ["setuptools>=45",
-            "setuptools_scm[toml]>=6.2",
+requires = ["setuptools>=60",
+            "setuptools-scm>=8.0",
             "cython>=0.16",
             "numpy>=1.25",
             "pykg-config"]


### PR DESCRIPTION
setuptools_scm has updated the recommended package verisons for build-system.requires.