### PR TITLE
Remove conftest code for Numpy < 1.13

### DIFF
--- a/healpy/test/conftest.py
+++ b/healpy/test/conftest.py
@@ -4,9 +4,4 @@ import numpy as np
 def pytest_configure():
     """Set the Numpy print style to a fixed version to make doctest outputs
     reproducible."""
-    try:
-        np.set_printoptions(legacy="1.13")
-    except TypeError:
-        # On older versions of Numpy, the unrecognized 'legacy' option will
-        # raise a TypeError.
-        pass
+    np.set_printoptions(legacy="1.13")


### PR DESCRIPTION
This is no longer necessary, because we require Numpy >= 1.19.