### PR TITLE
Fix errors with Matplotlib 3.9

### DIFF
--- a/lib/healpy/projaxes.py
+++ b/lib/healpy/projaxes.py
@@ -948,14 +948,14 @@ def create_colormap(cmap, badcolor="gray", bgcolor="white"):
             cmap_path = os.path.join(datapath, f"{cmap}_cmap.dat")
             cmap0 = matplotlib.colors.ListedColormap(np.loadtxt(cmap_path) / 255.0, cmap)
         else:
-            cmap0 = matplotlib.cm.get_cmap(cmap)
+            cmap0 = plt.get_cmap(cmap)
     elif type(cmap) in [
         matplotlib.colors.LinearSegmentedColormap,
         matplotlib.colors.ListedColormap,
     ]:
         cmap0 = cmap
     else:
-        cmap0 = matplotlib.cm.get_cmap(matplotlib.rcParams["image.cmap"])
+        cmap0 = plt.get_cmap(matplotlib.rcParams["image.cmap"])
     if hasattr(cmap0, "_segmentdata"):
         newcm = matplotlib.colors.LinearSegmentedColormap(
             "newcm", cmap0._segmentdata, cmap0.N

--- a/src/_line_integral_convolution.pyx
+++ b/src/_line_integral_convolution.pyx
@@ -78,12 +78,12 @@ def line_integral_convolution(
     -------
     >>> import healpy as hp
     >>> import numpy as np
-    >>> import matplotlib.cm
     >>> import matplotlib.colors
+    >>> import matplotlib.pyplot as plt
     >>> I, Q, U = hp.read_map('iqu_map.fits', (0, 1, 2))
     >>> lic = hp.line_integral_convolution(Q, U)
     >>> hp.mollview(I)
-    >>> cmap_colors = matplotlib.cm.get_cmap('binary', 256)(np.linspace(0, 1, 256))
+    >>> cmap_colors = plt.get_cmap('binary', 256)(np.linspace(0, 1, 256))
     >>> cmap_colors[..., 3] = 0.5  # Make colormap partially transparent
     >>> cmap = matplotlib.colors.ListedColormap(cmap_colors)
     >>> hp.mollview(lic, cmap=cmap, cbar=False, reuse_axes=True)

--- a/test/test_visufunc.py
+++ b/test/test_visufunc.py
@@ -1,8 +1,8 @@
 import matplotlib
-import matplotlib.cm
 
 matplotlib.use("agg")
 import unittest
+import matplotlib.pyplot as plt
 import numpy as np
 import copy
 
@@ -93,7 +93,7 @@ class TestNoCrash(unittest.TestCase):
     def test_cmap_colors(self):
         # Get a built-in colormap
         name = 'viridis'
-        cmap = copy.copy(matplotlib.cm.get_cmap(name))
+        cmap = copy.copy(plt.get_cmap(name))
 
         # Set outlier colors
         color = (0.25,0.75,0.95,1.0)


### PR DESCRIPTION
The `matplotlib.cm.get_cmap` API was deprecated in 3.7, and removed in 3.9, but `matplotlib.pyplot.get_cmap` remains.