### PR TITLE
Extract artifacts in the dir where twine expects them

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -63,9 +63,9 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+          path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: artifact/


### PR DESCRIPTION
I use this approach for publishing wheels in https://github.com/nasa/radbelt.