### PR TITLE
Rename trapz function from scipy.integrate module to trapezoid

### DIFF
--- a/lib/healpy/sphtfunc.py
+++ b/lib/healpy/sphtfunc.py
@@ -1336,7 +1336,7 @@ def beam2bl(beam, theta, lmax):
     bl : array
         Beam window function b(l).
     """
-    from scipy.integrate import trapz
+    from scipy.integrate import trapezoid as trapz
 
     nx = len(theta)
     nb = len(beam)


### PR DESCRIPTION
The fix should be backward compatible up to `scipy` 1.6.0 where the function first appears.

Fix #952 