### PR TITLE
Run macOS x86_64 builds on macOS 12

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11, macos-14]
+        os: [ubuntu-latest, macos-12, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,10 +94,10 @@ CPPFLAGS = "-I$(brew --prefix libomp)/include"
 LDFLAGS = "-L$(brew --prefix libomp)/lib"
 
 [[tool.cibuildwheel.overrides]]
-# macOS arm64 wheels are built on GitHub on macOS 11; set deployment target accordingly
+# macOS arm64 wheels are built on GitHub on macOS 12; set deployment target accordingly
 select = "*macosx_x86_64"
 inherit.environment = "append"
-environment.MACOSX_DEPLOYMENT_TARGET = "11.0"
+environment.MACOSX_DEPLOYMENT_TARGET = "12.0"
 
 [[tool.cibuildwheel.overrides]]
 # macOS arm64 wheels are built on GitHub on macOS 14; set deployment target accordingly


### PR DESCRIPTION
GitHub has retired their macOS 11 runners.