### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -35,7 +35,7 @@ environment installing ``healpy`` alongside said packages. For instance if one
 wishes to install ``healpy`` alongside Spyder and My_Package into newly created
 environment env_healpy, the command will be::
 
-    conda create --name env_healpy python=3.9 healpy spyder my_package
+    conda create --name env_healpy python=3.10 healpy spyder my_package
 
 Binary installation with Pip (recommended for most other Python users)
 ----------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ https://healpy.readthedocs.io/en/latest/tutorial.html, or execute it on `mybinde
 Requirements
 ------------
 
-* `Python <http://www.python.org>`_ 3.9, 3.10, or 3.11
+* `Python <http://www.python.org>`_ 3.10, 3.11, or 3.12
 
 * `Numpy <http://numpy.scipy.org/>`_ (tested with version >=1.19)
 

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,7 +2,7 @@ name: readthedocs
 channels:
     - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.11
   - pip
   - astropy
   - numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Operating System :: POSIX",
     "Programming Language :: C++",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -22,7 +21,7 @@ authors = [
     { name = "A. Zonca" },
 ]
 license = { text = "GPL-2.0-only" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["numpy>=1.19", "astropy"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
In accordance with https://numpy.org/neps/nep-0029-deprecation_policy.html.