### PR TITLE
fix overflow in map2alm_lsq

### DIFF
--- a/lib/healpy/sphtfunc.py
+++ b/lib/healpy/sphtfunc.py
@@ -352,7 +352,7 @@ def map2alm_lsq(maps, lmax, mmax, pol=True, tol=1e-10, maxiter=20):
         the number of iterations required
     """
     from scipy.sparse.linalg import LinearOperator, lsqr, lsmr
-    from scipy.linalg import norm
+    from numpy.linalg import norm
 
     maps = ma_to_array(maps)
     info = maptype(maps)


### PR DESCRIPTION
For large arrays `scipy.linalg.norm` overflows and gives 0 output:

```python
> norm(np.ones(int(2.5e9))*10)
0
```

`numpy`'s version of the function works fine.
