### PR TITLE
Improve docs on coordinate systems

### DIFF
--- a/lib/healpy/newvisufunc.py
+++ b/lib/healpy/newvisufunc.py
@@ -140,9 +140,10 @@ def projview(
       center. An additional rotation of angle *psi* around this direction is
       applied.
     coord : sequence of character, optional
-      Either one of 'G', 'E' or 'C' to describe the coordinate system of the
-      map, or a sequence of 2 of these to rotate the map from the first to the
-      second coordinate system. default: 'G'
+      Either one of 'G', 'E' or 'C' (where 'E' stands for the Ecliptic, 'G' for 
+      the Galactic, and 'C' for the Celestial or equatorial) to describe the coordinate
+      system of the map, or a sequence of 2 of these to rotate the map from the first 
+      to the second coordinate system. default: 'G'
     unit : str, optional
       A text describing the unit of the data. Default: ''
     xsize : int, optional
@@ -187,8 +188,9 @@ def projview(
     rot_graticule : bool
       rotate also the graticule when rotating the map
     graticule_coord : str
-      Either one of 'G', 'E' or 'C' to describe the coordinate system of the
-      graticule
+      Either one of 'G', 'E' or 'C' (where 'E' stands for the Ecliptic, 'G' for
+      the Galactic system, and 'C' for the Celestial or equatorial system) to
+      describe the coordinate system of the graticule
     override_rot_graticule_properties : dict
       Override the following rotated graticule properties: "g_linestyle",
       "g_linewidth", "g_color", "g_alpha", "t_step", "p_step".

--- a/lib/healpy/projaxes.py
+++ b/lib/healpy/projaxes.py
@@ -248,9 +248,10 @@ class SphericalProjAxes(matplotlib.axes.Axes):
         lonlat : bool, optional
           If True, theta and phi are interpreted as longitude and latitude
           in degree, otherwise, as colatitude and longitude in radian
-        coord : {'E', 'G', 'C', None}
-          The coordinate system of the points, only used if the coordinate
-          coordinate system of the Axes has been defined and in this
+        coord : {'E', 'G', 'C', None}, optional
+          The coordinate system of the points, typically 'E' for Ecliptic,
+          'G' for Galactic or 'C' for Celestial (equatorial). Only used if the
+          coordinate coordinate system of the Axes has been defined and in this
           case, a rotation is performed
         rot : None or sequence
           rotation to be applied =(lon, lat, psi) : lon, lat will be position of the
@@ -338,8 +339,9 @@ class SphericalProjAxes(matplotlib.axes.Axes):
           If True, theta and phi are interpreted as longitude and latitude
           in degree, otherwise, as colatitude and longitude in radian
         coord : {'E', 'G', 'C', None}, optional
-          The coordinate system of the points, only used if the coordinate
-          coordinate system of the axes has been defined and in this
+          The coordinate system of the points, typically 'E' for Ecliptic,
+          'G' for Galactic or 'C' for Celestial (equatorial). Only used if the
+          coordinate coordinate system of the Axes has been defined and in this
           case, a rotation is performed
         rot : None or sequence, optional
           rotation to be applied =(lon, lat, psi) : lon, lat will be position of the
@@ -396,8 +398,9 @@ class SphericalProjAxes(matplotlib.axes.Axes):
           If True, theta and phi are interpreted as longitude and latitude
           in degree, otherwise, as colatitude and longitude in radian
         coord : {'E', 'G', 'C', None}, optional
-          The coordinate system of the points, only used if the coordinate
-          coordinate system of the axes has been defined and in this
+          The coordinate system of the points, typically 'E' for Ecliptic,
+          'G' for Galactic or 'C' for Celestial (equatorial). Only used if the
+          coordinate coordinate system of the Axes has been defined and in this
           case, a rotation is performed
         rot : None or sequence, optional
           rotation to be applied =(lon, lat, psi) : lon, lat will be position of the

--- a/lib/healpy/rotator.py
+++ b/lib/healpy/rotator.py
@@ -83,8 +83,9 @@ class Rotator(object):
     rot : None or sequence
       Describe the rotation by its euler angle. See :func:`euler_matrix_new`.
     coord : None or sequence of str
-      Describe the coordinate system transform. If *rot* is also given, the
-      coordinate transform is applied first, and then the rotation.
+      Describe the coordinate system transform, typically 'E' for Ecliptic,
+      'G' for Galactic or 'C' for Celestial (equatorial). If *rot* is also 
+      given, the coordinate transform is applied first, and then the rotation.
     inv : bool
       If True, the inverse rotation is defined. (Default: False)
     deg : bool

--- a/lib/healpy/visufunc.py
+++ b/lib/healpy/visufunc.py
@@ -117,9 +117,9 @@ def mollview(
       longitude *lon* and latitude *lat* will be at the center. An additional rotation
       of angle *psi* around this direction is applied.
     coord : sequence of character, optional
-      Either one of 'G', 'E' or 'C' to describe the coordinate
-      system of the map, or a sequence of 2 of these to rotate
-      the map from the first to the second coordinate system.
+      Either one of 'G', 'E' or 'C' (where 'E' stands for the Ecliptic, 'G' for the Galactic,
+      and 'C' for the Celestial or equatorial) to describe the coordinate system of the map,
+      or a sequence of 2 of these to rotate the map from the first to the second coordinate system.
     unit : str, optional
       A text describing the unit of the data. Default: ''
     xsize : int, optional
@@ -385,9 +385,9 @@ def gnomview(
       longitude *lon* and latitude *lat* will be at the center. An additional rotation
       of angle *psi* around this direction is applied.
     coord : sequence of character, optional
-      Either one of 'G', 'E' or 'C' to describe the coordinate
-      system of the map, or a sequence of 2 of these to rotate
-      the map from the first to the second coordinate system.
+      Either one of 'G', 'E' or 'C' (where 'E' stands for the Ecliptic, 'G' for the Galactic,
+      and 'C' for the Celestial or equatorial) to describe the coordinate system of the map,
+      or a sequence of 2 of these to rotate the map from the first to the second coordinate system.
     unit : str, optional
       A text describing the unit of the data. Default: ''
     xsize : int, optional
@@ -680,9 +680,9 @@ def cartview(
       longitude *lon* and latitude *lat* will be at the center. An additional rotation
       of angle *psi* around this direction is applied.
     coord : sequence of character, optional
-      Either one of 'G', 'E' or 'C' to describe the coordinate
-      system of the map, or a sequence of 2 of these to rotate
-      the map from the first to the second coordinate system.
+      Either one of 'G', 'E' or 'C' (where 'E' stands for the Ecliptic, 'G' for the Galactic,
+      and 'C' for the Celestial or equatorial) to describe the coordinate system of the map,
+      or a sequence of 2 of these to rotate the map from the first to the second coordinate system.
     unit : str, optional
       A text describing the unit of the data. Default: ''
     xsize : int, optional
@@ -953,9 +953,9 @@ def orthview(
       longitude *lon* and latitude *lat* will be at the center. An additional rotation
       of angle *psi* around this direction is applied.
     coord : sequence of character, optional
-      Either one of 'G', 'E' or 'C' to describe the coordinate
-      system of the map, or a sequence of 2 of these to rotate
-      the map from the first to the second coordinate system.
+      Either one of 'G', 'E' or 'C' (where 'E' stands for the Ecliptic, 'G' for the Galactic,
+      and 'C' for the Celestial or equatorial) to describe the coordinate system of the map,
+      or a sequence of 2 of these to rotate the map from the first to the second coordinate system.
     half_sky : bool, optional
       Plot only one side of the sphere. Default: False
     unit : str, optional
@@ -1225,9 +1225,9 @@ def azeqview(
       longitude *lon* and latitude *lat* will be at the center. An additional rotation
       of angle *psi* around this direction is applied.
     coord : sequence of character, optional
-      Either one of 'G', 'E' or 'C' to describe the coordinate
-      system of the map, or a sequence of 2 of these to rotate
-      the map from the first to the second coordinate system.
+      Either one of 'G', 'E' or 'C' (where 'E' stands for the Ecliptic, 'G' for the Galactic,
+      and 'C' for the Celestial or equatorial) to describe the coordinate system of the map,
+      or a sequence of 2 of these to rotate the map from the first to the second coordinate system.
     unit : str, optional
       A text describing the unit of the data. Default: ''
     xsize : int, optional
@@ -1466,9 +1466,10 @@ def graticule(dpar=None, dmer=None, coord=None, local=None, **kwds):
     ----------
     dpar, dmer : float, scalars
       Interval in degrees between meridians and between parallels
-    coord : {'E', 'G', 'C'}
+    coord : {'E', 'G', 'C', None}
       The coordinate system of the graticule (make rotation if needed,
-      using coordinate system of the map if it is defined).
+      using coordinate system of the map if it is defined), typically
+      'E' for Ecliptic, 'G' for Galactic or 'C' for Celestial (equatorial).
     local : bool
       If True, draw a local graticule (no rotation is performed, useful for
       a gnomonic view, for example)

--- a/lib/healpy/zoomtool.py
+++ b/lib/healpy/zoomtool.py
@@ -70,9 +70,10 @@ def mollzoom(
       longitude *lon* and latitude *lat* will be at the center. An additional rotation
       of angle *psi* around this direction is applied.
     coord : sequence of character, optional
-      Either one of 'G', 'E' or 'C' to describe the coordinate
-      system of the map, or a sequence of 2 of these to rotate
-      the map from the first to the second coordinate system.
+      Either one of 'G', 'E' or 'C' (where 'E' stands for the Ecliptic, 'G' for
+      the Galactic, and 'C' for the Celestial or equatorial) to describe the coordinate
+      system of the map, or a sequence of 2 of these to rotate the map from the first
+      to the second coordinate system.
     unit : str, optional
       A text describing the unit of the data. Default: ''
     xsize : int, optional


### PR DESCRIPTION
This pull request updates the documentation for coordinate system parameters, providing a clearer explanation of the available options ('E', 'G', and 'C') and their meanings (Ecliptic, Galactic, and Celestial/Equatorial). It also improves readability by integrating these definitions into the parameter description naturally. These changes aim to make the documentation more user-friendly and informative. Also solve issue #841.