### PR TITLE
Build Linux aarch64 wheels natively, not under emulation

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -32,18 +32,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,10 +79,6 @@ test-command = [
 ]
 test-extras = ["test"]
 
-[tool.cibuildwheel.linux]
-# Build wheels for aarch64 under emulation.
-archs = ["auto", "aarch64"]
-
 [tool.cibuildwheel.macos]
 before-all = "brew install autoconf automake libtool libomp"
 


### PR DESCRIPTION
This will result in faster builds.