### PR TITLE
Remove deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Operating System :: POSIX",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
See https://peps.python.org/pep-0639/#deprecate-license-classifiers.