### PR TITLE
dist2holes: add support for ignoring small holes (GPT-4.1 initial implementation)

### DIFF
--- a/src/_masktools.pyx
+++ b/src/_masktools.pyx
@@ -12,7 +12,7 @@ cdef extern from "mask_tools.h":
     cdef Healpix_Map[double] dist2holes(Healpix_Map[double] &mask,
                                         double max_distance)
 
-def dist2holes_healpy(m, maxdist=np.pi):
+def dist2holes_healpy(m, maxdist=np.pi, hole_min_size=None, hole_min_surf_arcmin2=None):
     """Computes the distance (in radians) from pixel center to center of
     closest invalid pixel up to a maximal distance.
 
@@ -25,6 +25,12 @@ def dist2holes_healpy(m, maxdist=np.pi):
       The maximal distance in radians. Pixel farther from this distance are not
       taken into account (default: pi).
 
+    hole_min_size : int, optional
+      Minimum hole size (in pixels) to ignore. Holes smaller than this will be filled before distance calculation.
+
+    hole_min_surf_arcmin2 : float, optional
+      Minimum hole surface (in arcmin^2) to ignore. Holes smaller than this will be filled before distance calculation.
+
     Returns
     -------
     distances : out map of distances (in radians) in RING scheme as numpy arrays
@@ -34,7 +40,7 @@ def dist2holes_healpy(m, maxdist=np.pi):
     >>> import healpy as hp
     >>> import numpy as np
     >>> nside = 16
-    >>> hp.dist2holes(np.random.randint(0, 2, 12*nside**2))
+    >>> hp.dist2holes(np.random.randint(0, 2, 12*nside**2), hole_min_size=10)
     array([0.        , 0.        , 0.        , ..., 0.05831086, 0.05831086,
        0.        ])
 
@@ -46,6 +52,30 @@ def dist2holes_healpy(m, maxdist=np.pi):
         mi = m[0].astype(np.float64, order='C', copy=True)
     else:
         raise ValueError("Wrong input map (must be a valid healpix map)")
+
+    # Optionally fill small holes before distance calculation
+    if hole_min_size is not None or hole_min_surf_arcmin2 is not None:
+        try:
+            from scipy.ndimage import label
+        except ImportError:
+            raise ImportError("scipy is required for hole filtering. Please install scipy.")
+        nside = int(np.sqrt(mi.size // 12))
+        # Identify holes (regions of 0s surrounded by 1s)
+        mask = (mi == 0)
+        structure = np.ones((3,), dtype=int)  # 1D connectivity for flat array
+        labeled, num_features = label(mask, structure=structure)
+        # Compute sizes
+        sizes = np.bincount(labeled.ravel())
+        # Area per pixel in arcmin^2
+        area_per_pix = 4 * np.pi / mi.size * (180*60/np.pi)**2
+        fill = np.zeros_like(mi, dtype=bool)
+        for i in range(1, num_features+1):
+            size = sizes[i]
+            area = size * area_per_pix
+            if (hole_min_size is not None and size < hole_min_size) or \
+               (hole_min_surf_arcmin2 is not None and area < hole_min_surf_arcmin2):
+                fill |= (labeled == i)
+        mi[fill] = 1.0
 
     # View the ndarray as a Healpix_Map
     M = ndarray2map(mi, RING)

--- a/test/test_dist2holes.py
+++ b/test/test_dist2holes.py
@@ -1,0 +1,42 @@
+import numpy as np
+import healpy as hp
+import pytest
+
+
+def test_dist2holes_hole_min_size():
+    nside = 8
+    npix = hp.nside2npix(nside)
+    mask = np.ones(npix, dtype=np.float64)
+    # Create two holes: one small (single pixel), one large (10 pixels)
+    mask[10] = 0
+    mask[20:30] = 0
+    # With hole_min_size=2, the single-pixel hole should be filled
+    d1 = hp.dist2holes(mask, hole_min_size=2)
+    # The pixel at 10 should now be treated as valid (filled)
+    assert d1[10] > 0  # Should not be zero (not a hole anymore)
+    # The large hole should remain
+    assert np.any(d1[20:30] == 0)
+
+
+def test_dist2holes_hole_min_surf_arcmin2():
+    nside = 8
+    npix = hp.nside2npix(nside)
+    mask = np.ones(npix, dtype=np.float64)
+    # Create a small hole (single pixel)
+    mask[42] = 0
+    # Compute area per pixel
+    area_per_pix = 4 * np.pi / npix * (180 * 60 / np.pi) ** 2
+    # Set threshold just above one pixel
+    d2 = hp.dist2holes(mask, hole_min_surf_arcmin2=area_per_pix * 1.1)
+    # The hole should be filled
+    assert d2[42] > 0
+
+
+def test_dist2holes_no_hole_filter():
+    nside = 8
+    npix = hp.nside2npix(nside)
+    mask = np.ones(npix, dtype=np.float64)
+    mask[100] = 0
+    d = hp.dist2holes(mask)
+    assert d[100] == 0
+    assert np.all(d >= 0)


### PR DESCRIPTION
This pull request adds support for ignoring small holes in the dist2holes function, addressing issue #1007.

Implementation plan:

1. Review Current Implementation:
   - The current dist2holes implementation does not expose parameters for ignoring small holes.
   - The Fortran90 code supports hole_min_size and hole_min_surf_arcmin2 to filter out small holes before distance computation.

2. Design API Extension:
   - Add new optional arguments to healpy.dist2holes (and the underlying C++/Cython code) for:
     - hole_min_size (int, in pixels)
     - hole_min_surf_arcmin2 (float, in arcmin2)
   - Update the docstring and documentation to describe these options.

3. Implement Hole Filtering:
   - Before computing distances, identify and fill holes in the mask smaller than the user-specified threshold.
   - This can be done by:
     - Labeling connected regions of zeros (holes) in the mask.
     - Measuring their size (in pixels and/or arcmin2).
     - Filling (setting to 1) those below the threshold.

4. Integrate with Existing Pipeline:
   - Ensure the mask with small holes filled is passed to the distance computation.
   - Maintain backward compatibility (default: do not ignore any holes).

5. Testing:
   - Add unit tests for the new feature, including edge cases (no holes, all holes, holes at threshold).
   - Validate that results match the Fortran90 behavior for equivalent parameters.

6. Documentation:
   - Update the user documentation and docstrings.
   - Add an example in the docs and/or a Jupyter notebook.

This is an initial implementation, created while experimenting with GPT-4.1 for code assistance. Feedback and suggestions are welcome.