### PR TITLE
Use new style of pyproject.toml license field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
     { name = "C. Rosset", email = "cyrille.rosset@apc.univ-paris-diderot.fr" },
     { name = "A. Zonca" },
 ]
-license = { text = "GPL-2.0-only" }
+license = "GPL-2.0-only"
 requires-python = ">=3.10"
 dependencies = ["numpy>=1.19", "astropy"]
 
@@ -47,7 +47,7 @@ homepage = "http://github.com/healpy"
 
 [build-system]
 
-requires = ["setuptools>=60",
+requires = ["setuptools>=77",
             "setuptools-scm>=8.0",
             "cython>=0.16",
             "numpy>=2.0.0rc1",


### PR DESCRIPTION
This fixes the following warning:

```
********************************************************************************
Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

By 2026-Feb-18, you need to update your project and remove deprecated calls
or your builds will no longer be supported.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```