### PR TITLE
Fix: Handle pixel weights download failures in map2alm

### DIFF
--- a/lib/healpy/sphtfunc.py
+++ b/lib/healpy/sphtfunc.py
@@ -262,12 +262,20 @@ def map2alm(
                     "is missing at {}".format(pixel_weights_filename)
                 )
         if pixel_weights_filename is None:
-            with data.conf.set_temp("dataurl", DATAURL), data.conf.set_temp(
-                "dataurl_mirror", DATAURL_MIRROR
-            ), data.conf.set_temp("remote_timeout", 30):
-                pixel_weights_filename = data.get_pkg_data_filename(
-                    filename, package="healpy"
+            try:
+                with data.conf.set_temp("dataurl", DATAURL), data.conf.set_temp(
+                    "dataurl_mirror", DATAURL_MIRROR
+                ), data.conf.set_temp("remote_timeout", 30):
+                    pixel_weights_filename = data.get_pkg_data_filename(
+                        filename, package="healpy"
+                    )
+            except Exception as e:
+                log.warning(
+                    "Could not download pixel weights for nside %d: %s. "
+                    "Proceeding without pixel weights.", nside, e
                 )
+                use_pixel_weights = False
+                pixel_weights_filename = None # Ensure it's None so it doesn't try to use a non-existent file
 
     if pol or info in (0, 1):
         alms = _sphtools.map2alm(

--- a/test/test_pixelweights.py
+++ b/test/test_pixelweights.py
@@ -26,6 +26,27 @@ def test_astropy_download_file():
     )
 
 
+import unittest.mock
+from urllib.error import URLError
+
+
+def test_map2alm_pixelweights_download_fail(caplog):
+    nside = 16
+    m = np.arange(hp.nside2npix(nside))
+
+    with unittest.mock.patch('astropy.utils.data.get_pkg_data_filename') as mock_get_pkg_data_filename:
+        mock_get_pkg_data_filename.side_effect = URLError('Simulated download error')
+        
+        alm = hp.map2alm(m, use_pixel_weights=True, lmax=3*nside-1)
+
+        mock_get_pkg_data_filename.assert_called_once()
+
+        assert "Could not download pixel weights" in caplog.text
+        assert "Proceeding without pixel weights" in caplog.text
+
+        assert isinstance(alm, np.ndarray)
+
+
 def test_pixelweights_local_datapath_missing():
 
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Addresses issue #1015 by adding a try-except block around the pixel weights download in map2alm. If the download fails, a warning is logged and the function proceeds without using pixel weights. Also includes a new test case to verify this behavior.
