### PR TITLE
Fix #843: query_strip is not implemented for NESTED

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Unreleased
 
 * added support for automatically adjusting latitudes within [-90, 90] range in ang2pix https://github.com/healpy/healpy/pull/1026
+* Implemented NESTED support in query_strip https://github.com/healpy/healpy/pull/1025
 
 Release 1.18.1 26 Mar 2025
 


### PR DESCRIPTION
Minimal implementation and unit test for issue #843. This fixes the crash when calling query_strip with nest=True by internally converting to RING ordering, performing the query, and then converting the result back to NEST ordering if required.