### PR TITLE
change "NESTED" to "NEST" in docstrings

### DIFF
--- a/lib/healpy/pixelfunc.py
+++ b/lib/healpy/pixelfunc.py
@@ -856,7 +856,7 @@ def reorder(map_in, inp=None, out=None, r2n=None, n2r=None):
     ----------
     map_in : array-like
       the input map to reorder, accepts masked arrays
-    inp, out : ``'RING'`` or ``'NESTED'``
+    inp, out : ``'RING'`` or ``'NEST'``
       define the input and output ordering
     r2n : bool
       if True, reorder from RING to NESTED
@@ -1932,7 +1932,7 @@ def ud_grade(
       if ``True``, in degrading, reject pixels which contains
       a bad sub_pixel. Otherwise, estimate average with good pixels
     order_in, order_out : str
-      pixel ordering of input and output ('RING' or 'NESTED')
+      pixel ordering of input and output ('RING' or 'NEST')
     power : float
       if non-zero, divide the result by (nside_in/nside_out)**power
       Examples:


### PR DESCRIPTION
This PR is a simple fix in the documentation.

The documentation of `hp.pixelfunc.reorder` states that the way to describe nested ordering input is `"NESTED"`.

https://github.com/healpy/healpy/blob/baa234cc7db9fd9eea765095fa02b18f8b54260b/lib/healpy/pixelfunc.py#L852-L864

However the code only accepts `"RING"` and `"NEST"`:

https://github.com/healpy/healpy/blob/baa234cc7db9fd9eea765095fa02b18f8b54260b/lib/healpy/pixelfunc.py#L929-L930

so using `"NESTED"` as suggested by the documentation leads to an error.

Note that `healpy.pixelfunc.ud_grade` also states to use `"NESTED"`, which will not raise an error because it only tests equality to `"RING"`, so any string that is not `"RING"` is considered nested ordering. To my knowledge these are the only functions that say to use `"NESTED"` in the documentation.

Proposed fix: change both occurences of `"NESTED"` in the docstring to `"NEST"`.