### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2
         env:
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64
 
       - uses: actions/upload-artifact@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Unreleased
 
 * added support for automatically adjusting latitudes within [-90, 90] range in ang2pix https://github.com/healpy/healpy/pull/1026
 * Implemented NESTED support in query_strip https://github.com/healpy/healpy/pull/1025
+* Declare support for Python 3.14 in packaging and wheels
 
 Release 1.18.1 26 Mar 2025
 

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ https://healpy.readthedocs.io/en/latest/tutorial.html, or execute it on `mybinde
 Requirements
 ------------
 
-* `Python <http://www.python.org>`_ 3.10, 3.11, 3.12, or 3.13
+* `Python <http://www.python.org>`_ 3.10, 3.11, 3.12, 3.13, or 3.14
 
 * `Numpy <http://numpy.scipy.org/>`_ (tested with version >=1.19)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Visualization",
 ]
@@ -76,7 +77,7 @@ healpy = ["data/*.fits",
 "*" = ["*.cc", "*.cpp", "*.h", "*.pxd", "*.pyx"]
 
 [tool.cibuildwheel]
-build = "cp310-* cp311-* cp312-* cp313-*"
+build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 test-command = [
     "pytest --doctest-plus --doctest-cython --pyargs healpy",
     "pytest {project}/test"


### PR DESCRIPTION
## Summary
- add the Python 3.14 trove classifier and update the README
- build cp314 wheels in cibuildwheel locally and in CI
- mention the new support in the changelog

## Testing
- not run (metadata-only change)
