### PR TITLE
Restrict workflow triggers

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -2,6 +2,8 @@ name: build
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   release:
     types:


### PR DESCRIPTION
Limit the build workflow so pushes only run on main; PR runs stay unchanged. This mirrors the configuration we applied elsewhere so other branches don't get duplicate builds.