### PR TITLE
Improve pixel lib integer type portability across platforms

### DIFF
--- a/src/_healpy_pixel_lib.cc
+++ b/src/_healpy_pixel_lib.cc
@@ -113,7 +113,7 @@ template<Healpix_Ordering_Scheme scheme>static void
       if (nside!=oldnside)
         { oldnside=nside; hb.SetNside(nside, scheme); }
       try {
-        *(int64 *)op = hb.xyf2pix((int)*(long *)ip2,(int)*(long *)ip3,(int)*(long *)ip4);
+        *(int64 *)op = hb.xyf2pix((int)*(int64 *)ip2,(int)*(int64 *)ip3,(int)*(int64 *)ip4);
       } catch(PlanckError &e) {
         *(int64 *)op = -1;
       }
@@ -141,13 +141,13 @@ template<Healpix_Ordering_Scheme scheme> static void
       try {
         int x, y, f;
         hb.pix2xyf(*(int64 *)ip2, x, y, f);
-        *(long *)op1 = x;
-        *(long *)op2 = y;
-        *(long *)op3 = f;
+        *(int64 *)op1 = x;
+        *(int64 *)op2 = y;
+        *(int64 *)op3 = f;
       } catch (PlanckError & e) {
-        *(long *)op1 = -1;
-        *(long *)op2 = -1;
-        *(long *)op3 = -1;
+        *(int64 *)op1 = -1;
+        *(int64 *)op2 = -1;
+        *(int64 *)op3 = -1;
       }
     }
 }
@@ -464,10 +464,10 @@ static char pix2ang_signatures[] = {
   NPY_INT64, NPY_INT64, NPY_DOUBLE, NPY_DOUBLE
 };
 static char xyf2pix_signatures[] = {
-  NPY_INT64, NPY_LONG, NPY_LONG, NPY_LONG, NPY_INT64
+  NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64
 };
 static char pix2xyf_signatures[] = {
-  NPY_INT64, NPY_INT64, NPY_LONG, NPY_LONG, NPY_LONG
+  NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64
 };
 static char pix2vec_signatures[] = {
   NPY_INT64, NPY_INT64, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE

--- a/test/test_pixelfunc.py
+++ b/test/test_pixelfunc.py
@@ -4,7 +4,7 @@ from healpy._pixelfunc import pix2ring, isnsideok
 import numpy as np
 import unittest
 from healpy._query_disc import query_strip
-from healpy.pixelfunc import ring2nest
+from healpy.pixelfunc import ring2nest, pix2xyf, xyf2pix
 
 
 class TestPixelFunc(unittest.TestCase):
@@ -287,3 +287,18 @@ class TestPixelFunc(unittest.TestCase):
         actual_result = query_strip(nside, theta1, theta2, nest=True)
 
         np.testing.assert_array_equal(actual_result, expected_result)
+
+    def test_xyf2pix_pix2xyf_int64_roundtrip(self):
+        """Regression for cross-platform int64 ufunc behavior and xyf2pix round-trip."""
+        nside = 16
+        ipix = np.array([0, 427, 1440, 1520, 3068], dtype=np.int64)
+
+        for nest in (True, False):
+            x, y, face = pix2xyf(nside, ipix, nest=nest)
+            self.assertEqual(x.dtype, np.int64)
+            self.assertEqual(y.dtype, np.int64)
+            self.assertEqual(face.dtype, np.int64)
+
+            roundtrip = xyf2pix(nside, x, y, face, nest=nest)
+            self.assertEqual(roundtrip.dtype, np.int64)
+            np.testing.assert_array_equal(roundtrip, ipix)


### PR DESCRIPTION
Some parts of the code implicitly assume that long is 8 bytes. This is true on most Unix-like systems, but not on Windows. This change replaces those usages with explicit 64-bit types (int64_t) so the behaviour is consistent across platforms.

The issue was discovered while working on enabling Windows builds in the conda-forge healpy feedstock [PR.](https://github.com/conda-forge/healpy-feedstock/pull/84)

