### PR TITLE
Modernize some aspects of Numpy and CPython API usage

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ sphinx:
   configuration: doc/conf.py
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   apt_packages:
     - autoconf
     - automake
@@ -15,7 +15,7 @@ build:
     - libtool
     - pkgconf
   tools:
-    python: "3.11"
+    python: "3.12"
 
 python:
   install:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Unreleased
 * CI: Added test workflow (`.github/workflows/tests.yml`) running the full test suite on Python 3.10–3.13 with ccache, plus an astropy pre-release job https://github.com/healpy/healpy/pull/1109
 * Fix off-by-one in ``synalm`` Cℓ boundary check that caused out-of-bounds reads when ``l == len(cl)`` https://github.com/healpy/healpy/pull/1108
 * Fix scalar boolean array indexing in ``projector.py`` projection functions (``mollview``, ``gnomview``, ``azeqview``) that caused corrupted masked output and ``"must not happen"`` assertion errors with NumPy 2.2.x + Python 3.14 https://github.com/healpy/healpy/pull/1112
+* **BREAKING**: Bump minimum NumPy version to 2.0.0 and compile extensions against the NumPy 2.0 ABI. The last stable release supporting NumPy 1.x is 1.19.0. Replaced soft-deprecated ``PyModule_AddObject`` with ``PyModule_AddObjectRef`` and converted single-phase C extension init to two-phase (``Py_mod_exec``) init. https://github.com/healpy/healpy/pull/1106
 
 Release 1.20.0b1 29 May 2026
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ authors = [
 ]
 license = {text = "GPL-2.0-only"}
 requires-python = ">=3.10"
-dependencies = ["numpy>=1.19", "astropy"]
+dependencies = ["numpy>=2.0.0", "astropy"]
 
 [project.optional-dependencies]
 all = ["matplotlib", "scipy"]
@@ -41,8 +41,6 @@ doc = [
     "matplotlib",
     "nbsphinx",
     "numpydoc",
-    "numpy<2",
-    "scipy<1.12",
     "sphinxnotebookgist",
     "sphinx>=6,<9",
     "sphinx-book-theme",
@@ -62,7 +60,7 @@ issues = "https://github.com/healpy/healpy/issues"
 requires = ["setuptools>=77",
             "setuptools-scm>=8.0",
             "cython>=0.16",
-            "numpy>=2.0.0rc1",
+            "numpy>=2.0.0",
             "pykg-config"]
 
 build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -292,7 +292,10 @@ class custom_build_ext(build_ext):
 
 ext_kwargs = dict(
     extra_compile_args=["-std=c++11"],
-    define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_19_API_VERSION')],
+    define_macros=[
+        ('NPY_TARGET_VERSION', 'NPY_2_0_API_VERSION'),
+        ('NPY_NO_DEPRECATED_API', 'NPY_2_0_API_VERSION'),
+    ],
     language="c++",
 )
 

--- a/src/_healpy_pixel_lib.cc
+++ b/src/_healpy_pixel_lib.cc
@@ -387,13 +387,13 @@ static void
 }
 
 
-static char *docstring = CP_(
+static char *docstring =
   "This module contains basic ufunc related to healpix pixelisation\n"
   "scheme, such as ang2pix, ring<->nest swapping, etc.\n"
   "\n"
   "Available ufunc: _ang2pix_ring, _ang2pix_nest, _pix2ang_ring,\n"
   "                 _pix2ang_nest, _ring2nest, _nest2ring,\n"
-  "                 _get_interpol_ring, _get_interpol_nest.");
+  "                 _get_interpol_ring, _get_interpol_nest.";
 
 /* to define the ufunc */
 static PyUFuncGenericFunction ang2pix_ring_functions[] = {
@@ -455,209 +455,208 @@ static PyUFuncGenericFunction max_pixrad_functions[] = {
 };
 
 
-static void * blank_data[] = { (void *)NULL };
+static void *const blank_data[] = { (void *)NULL };
 
-static char ang2pix_signatures[] = {
+static const char ang2pix_signatures[] = {
   NPY_INT64, NPY_DOUBLE, NPY_DOUBLE, NPY_INT64
 };
-static char pix2ang_signatures[] = {
+static const char pix2ang_signatures[] = {
   NPY_INT64, NPY_INT64, NPY_DOUBLE, NPY_DOUBLE
 };
-static char xyf2pix_signatures[] = {
+static const char xyf2pix_signatures[] = {
   NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64
 };
-static char pix2xyf_signatures[] = {
+static const char pix2xyf_signatures[] = {
   NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64
 };
-static char pix2vec_signatures[] = {
+static const char pix2vec_signatures[] = {
   NPY_INT64, NPY_INT64, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE
 };
-static char vec2pix_signatures[] = {
+static const char vec2pix_signatures[] = {
   NPY_INT64, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_INT64
 };
-static char ring2nest_signatures[] = {
+static const char ring2nest_signatures[] = {
   NPY_INT64, NPY_INT64, NPY_INT64
 };
-static char get_interpol_signatures[] = {
+static const char get_interpol_signatures[] = {
   NPY_INT64, NPY_DOUBLE, NPY_DOUBLE,
   NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
   NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE
 };
-static char get_neighbors_ring_signatures[] = {
+static const char get_neighbors_ring_signatures[] = {
   NPY_INT64, NPY_INT64, // input
   NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, // output
   NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64 // output
 };
-static char get_neighbors_nest_signatures[] = {
+static const char get_neighbors_nest_signatures[] = {
   NPY_INT64, NPY_INT64, // input
   NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, // output
   NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64 // output
 };
-static char max_pixrad_signatures[] = {
+static const char max_pixrad_signatures[] = {
   NPY_INT64, NPY_DOUBLE
 };
+
+static int m_exec(PyObject *module) {
+  if (PyModule_AddObjectRef(module, "_ang2pix_ring", PyUFunc_FromFuncAndData(
+      ang2pix_ring_functions, blank_data,
+      ang2pix_signatures, 1,
+      3, 1, PyUFunc_None, "_ang2pix_ring",
+      "nside,theta,phi [rad] -> ipix (RING)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_ang2pix_nest", PyUFunc_FromFuncAndData(
+      ang2pix_nest_functions, blank_data,
+      ang2pix_signatures, 1,
+      3, 1, PyUFunc_None, "_ang2pix_nest",
+      "nside,theta,phi [rad] -> ipix (NEST)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_pix2ang_ring", PyUFunc_FromFuncAndData(
+      pix2ang_ring_functions, blank_data,
+      pix2ang_signatures, 1,
+      2, 2, PyUFunc_None, "_pix2ang_ring",
+      "nside,ipix -> theta,phi [rad] (RING)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_pix2ang_nest", PyUFunc_FromFuncAndData(
+      pix2ang_nest_functions, blank_data,
+      pix2ang_signatures, 1,
+      2, 2, PyUFunc_None, "_pix2ang_nest",
+      "nside,ipix -> theta,phi [rad] (NEST)",0)) < 0)
+    return -1;
+
+  //=========
+
+  if (PyModule_AddObjectRef(module, "_xyf2pix_ring", PyUFunc_FromFuncAndData(
+      xyf2pix_ring_functions, blank_data,
+      xyf2pix_signatures, 1,
+      4, 1, PyUFunc_None, "_xyf2pix_ring",
+      "nside,x,y,face -> ipix (RING)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_xyf2pix_nest", PyUFunc_FromFuncAndData(
+      xyf2pix_nest_functions, blank_data,
+      xyf2pix_signatures, 1,
+      4, 1, PyUFunc_None, "_xyf2pix_nest",
+      "nside,x,y,face -> ipix (NEST)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_pix2xyf_ring", PyUFunc_FromFuncAndData(
+      pix2xyf_ring_functions, blank_data,
+      pix2xyf_signatures, 1,
+      2, 3, PyUFunc_None, "_pix2xyf_ring",
+      "nside,ipix -> x,y,face (RING)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_pix2xyf_nest", PyUFunc_FromFuncAndData(
+      pix2xyf_nest_functions, blank_data,
+      pix2xyf_signatures, 1,
+      2, 3, PyUFunc_None, "_pix2xyf_nest",
+      "nside,ipix -> x,y,face (NEST)",0)) < 0)
+    return -1;
+
+  //=========
+
+  if (PyModule_AddObjectRef(module, "_vec2pix_ring", PyUFunc_FromFuncAndData(
+      vec2pix_ring_functions, blank_data,
+      vec2pix_signatures, 1,
+      4, 1, PyUFunc_None, "_vec2pix_ring",
+      "nside,x,y,z -> ipix (RING)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_vec2pix_nest", PyUFunc_FromFuncAndData(
+      vec2pix_nest_functions, blank_data,
+      vec2pix_signatures, 1,
+      4, 1, PyUFunc_None, "_vec2pix_nest",
+      "nside,x,y,z -> ipix (NEST)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_pix2vec_ring", PyUFunc_FromFuncAndData(
+      pix2vec_ring_functions, blank_data,
+      pix2vec_signatures, 1,
+      2, 3, PyUFunc_None, "_pix2vec_ring",
+      "nside,ipix -> x,y,z (RING)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_pix2vec_nest", PyUFunc_FromFuncAndData(
+      pix2vec_nest_functions, blank_data,
+      pix2vec_signatures, 1,
+      2, 3, PyUFunc_None, "_pix2vec_nest",
+      "nside,ipix -> x,y,z (NEST)",0)) < 0)
+    return -1;
+
+  //=============
+
+  if (PyModule_AddObjectRef(module, "_ring2nest", PyUFunc_FromFuncAndData(
+      ring2nest_functions, blank_data,
+      ring2nest_signatures, 1,
+      2, 1, PyUFunc_None, "_ring2nest",
+      "ipix(ring) -> ipix(nest)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_nest2ring", PyUFunc_FromFuncAndData(
+      nest2ring_functions, blank_data,
+      ring2nest_signatures, 1,
+      2, 1, PyUFunc_None, "_nest2ring",
+      "ipix(nest) -> ipix(ring)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_get_interpol_ring", PyUFunc_FromFuncAndData(
+      get_interpol_ring_functions, blank_data,
+      get_interpol_signatures, 1,
+      3, 8, PyUFunc_None, "_get_interpol_ring",
+      "nside,theta,phi->4 nearest pixels+4weights",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_get_interpol_nest", PyUFunc_FromFuncAndData(
+      get_interpol_nest_functions, blank_data,
+      get_interpol_signatures, 1,
+      3, 8, PyUFunc_None, "_get_interpol_nest",
+      "nside,theta,phi->4 nearest pixels+4weights",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_get_neighbors_ring", PyUFunc_FromFuncAndData(
+      get_neighbors_ring_functions, blank_data,
+      get_neighbors_ring_signatures, 1,
+      2, 8, PyUFunc_None, "_get_neigbors_ring",
+      "nside, ipix [rad] -> 8 neighbors",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "_get_neighbors_nest", PyUFunc_FromFuncAndData(
+      get_neighbors_nest_functions, blank_data,
+      get_neighbors_nest_signatures, 1,
+      2, 8, PyUFunc_None, "_get_neigbors_nest",
+      "nside, ipix [rad] -> 8 neighbors",0)) < 0)
+    return -1;
+
+
+  if (PyModule_AddObjectRef(module, "_max_pixrad", PyUFunc_FromFuncAndData(
+      max_pixrad_functions, blank_data,
+      max_pixrad_signatures, 1,
+      1, 1, PyUFunc_None, "max_pixrad",
+      "nside -> max_distance to pixel corners from center)",0)) < 0)
+    return -1;
+
+  if (PyModule_AddObjectRef(module, "UNSEEN", PyFloat_FromDouble(Healpix_undef)) < 0)
+    return -1;
+
+  return 0;
+}
 
 static PyModuleDef moduledef = {
   PyModuleDef_HEAD_INIT,
   "_healpy_pixel_lib",
-  NULL, -1, NULL
+  docstring, 0, NULL, (PyModuleDef_Slot []) {
+        {Py_mod_exec, (void *) m_exec},
+        {/* terminal element, all NULL */}
+  }
 };
-
-#define FREE_MODULE_AND_FAIL do { Py_DECREF(m); return NULL; } while(0)
 
 PyMODINIT_FUNC
 PyInit__healpy_pixel_lib(void)
 {
-  PyObject *m;
-
   import_array();
   import_ufunc();
-
-	m = PyModule_Create(&moduledef);
-	if (!m) return NULL;
-
-  if (PyModule_AddObject(m, "_ang2pix_ring", PyUFunc_FromFuncAndData(
-      ang2pix_ring_functions, blank_data,
-      ang2pix_signatures, 1,
-      3, 1, PyUFunc_None, CP_("_ang2pix_ring"),
-      CP_("nside,theta,phi [rad] -> ipix (RING)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_ang2pix_nest", PyUFunc_FromFuncAndData(
-      ang2pix_nest_functions, blank_data,
-      ang2pix_signatures, 1,
-      3, 1, PyUFunc_None, CP_("_ang2pix_nest"),
-      CP_("nside,theta,phi [rad] -> ipix (NEST)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_pix2ang_ring", PyUFunc_FromFuncAndData(
-      pix2ang_ring_functions, blank_data,
-      pix2ang_signatures, 1,
-      2, 2, PyUFunc_None, CP_("_pix2ang_ring"),
-      CP_("nside,ipix -> theta,phi [rad] (RING)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_pix2ang_nest", PyUFunc_FromFuncAndData(
-      pix2ang_nest_functions, blank_data,
-      pix2ang_signatures, 1,
-      2, 2, PyUFunc_None, CP_("_pix2ang_nest"),
-      CP_("nside,ipix -> theta,phi [rad] (NEST)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  //=========
-
-  if (PyModule_AddObject(m, "_xyf2pix_ring", PyUFunc_FromFuncAndData(
-      xyf2pix_ring_functions, blank_data,
-      xyf2pix_signatures, 1,
-      4, 1, PyUFunc_None, CP_("_xyf2pix_ring"),
-      CP_("nside,x,y,face -> ipix (RING)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_xyf2pix_nest", PyUFunc_FromFuncAndData(
-      xyf2pix_nest_functions, blank_data,
-      xyf2pix_signatures, 1,
-      4, 1, PyUFunc_None, CP_("_xyf2pix_nest"),
-      CP_("nside,x,y,face -> ipix (NEST)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_pix2xyf_ring", PyUFunc_FromFuncAndData(
-      pix2xyf_ring_functions, blank_data,
-      pix2xyf_signatures, 1,
-      2, 3, PyUFunc_None, CP_("_pix2xyf_ring"),
-      CP_("nside,ipix -> x,y,face (RING)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_pix2xyf_nest", PyUFunc_FromFuncAndData(
-      pix2xyf_nest_functions, blank_data,
-      pix2xyf_signatures, 1,
-      2, 3, PyUFunc_None, CP_("_pix2xyf_nest"),
-      CP_("nside,ipix -> x,y,face (NEST)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  //=========
-
-  if (PyModule_AddObject(m, "_vec2pix_ring", PyUFunc_FromFuncAndData(
-      vec2pix_ring_functions, blank_data,
-      vec2pix_signatures, 1,
-      4, 1, PyUFunc_None, CP_("_vec2pix_ring"),
-      CP_("nside,x,y,z -> ipix (RING)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_vec2pix_nest", PyUFunc_FromFuncAndData(
-      vec2pix_nest_functions, blank_data,
-      vec2pix_signatures, 1,
-      4, 1, PyUFunc_None, CP_("_vec2pix_nest"),
-      CP_("nside,x,y,z -> ipix (NEST)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_pix2vec_ring", PyUFunc_FromFuncAndData(
-      pix2vec_ring_functions, blank_data,
-      pix2vec_signatures, 1,
-      2, 3, PyUFunc_None, CP_("_pix2vec_ring"),
-      CP_("nside,ipix -> x,y,z (RING)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_pix2vec_nest", PyUFunc_FromFuncAndData(
-      pix2vec_nest_functions, blank_data,
-      pix2vec_signatures, 1,
-      2, 3, PyUFunc_None, CP_("_pix2vec_nest"),
-      CP_("nside,ipix -> x,y,z (NEST)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  //=============
-
-  if (PyModule_AddObject(m, "_ring2nest", PyUFunc_FromFuncAndData(
-      ring2nest_functions, blank_data,
-      ring2nest_signatures, 1,
-      2, 1, PyUFunc_None, CP_("_ring2nest"),
-      CP_("ipix(ring) -> ipix(nest)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_nest2ring", PyUFunc_FromFuncAndData(
-      nest2ring_functions, blank_data,
-      ring2nest_signatures, 1,
-      2, 1, PyUFunc_None, CP_("_nest2ring"),
-      CP_("ipix(nest) -> ipix(ring)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_get_interpol_ring", PyUFunc_FromFuncAndData(
-      get_interpol_ring_functions, blank_data,
-      get_interpol_signatures, 1,
-      3, 8, PyUFunc_None, CP_("_get_interpol_ring"),
-      CP_("nside,theta,phi->4 nearest pixels+4weights"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_get_interpol_nest", PyUFunc_FromFuncAndData(
-      get_interpol_nest_functions, blank_data,
-      get_interpol_signatures, 1,
-      3, 8, PyUFunc_None, CP_("_get_interpol_nest"),
-      CP_("nside,theta,phi->4 nearest pixels+4weights"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_get_neighbors_ring", PyUFunc_FromFuncAndData(
-      get_neighbors_ring_functions, blank_data,
-      get_neighbors_ring_signatures, 1,
-      2, 8, PyUFunc_None, CP_("_get_neigbors_ring"),
-      CP_("nside, ipix [rad] -> 8 neighbors"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "_get_neighbors_nest", PyUFunc_FromFuncAndData(
-      get_neighbors_nest_functions, blank_data,
-      get_neighbors_nest_signatures, 1,
-      2, 8, PyUFunc_None, CP_("_get_neigbors_nest"),
-      CP_("nside, ipix [rad] -> 8 neighbors"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-
-  if (PyModule_AddObject(m, "_max_pixrad", PyUFunc_FromFuncAndData(
-      max_pixrad_functions, blank_data,
-      max_pixrad_signatures, 1,
-      1, 1, PyUFunc_None, CP_("max_pixrad"),
-      CP_("nside -> max_distance to pixel corners from center)"),0)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  if (PyModule_AddObject(m, "UNSEEN", PyFloat_FromDouble(Healpix_undef)) < 0)
-    FREE_MODULE_AND_FAIL;
-
-  return m;
+  return PyModuleDef_Init(&moduledef);
 }

--- a/src/_healpy_sph_transform_lib.cc
+++ b/src/_healpy_sph_transform_lib.cc
@@ -973,7 +973,7 @@ static PyObject *healpy_synalm(PyObject *self, PyObject *args,
   return NULL;
 }
 
-PyObject *healpy_getn(PyObject *self, PyObject *args)
+static PyObject *healpy_getn(PyObject *self, PyObject *args)
 {
   long s;
   healpyAssertType (PyArg_ParseTuple(args, "l", &s),
@@ -1006,13 +1006,12 @@ static PyMethodDef methods[] = {
 static PyModuleDef moduledef = {
   PyModuleDef_HEAD_INIT,
   "_healpy_sph_transform_lib",
-  NULL, -1, methods
+  NULL, 0, methods
 };
 
 PyMODINIT_FUNC
 PyInit__healpy_sph_transform_lib(void)
 {
   import_array();
-
-  return PyModule_Create(&moduledef);
+  return PyModuleDef_Init(&moduledef);
 }

--- a/src/_healpy_utils.h
+++ b/src/_healpy_utils.h
@@ -6,6 +6,4 @@ do { if (testval); else { PyErr_SetString(PyExc_TypeError, msg); return NULL; } 
 #define healpyAssertValue(testval,msg) \
 do { if (testval); else { PyErr_SetString(PyExc_ValueError, msg); return NULL; } } while(0)
 
-#define CP_(str)(char *)(str)
-
 #endif


### PR DESCRIPTION
- Replace soft-deprecated `PyModule_AddObject` with `PyModule_AddObjectRef`.
- Replace single-phase module initialization with two-phase module initialization, with simpler error handling.
- Remove now unnecessary workarounds for const-correctness.
- Update Numpy API target version.