### PR TITLE
Fix documentation issues across docs and docstrings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 Unreleased
-
+|
+* Docs: comprehensive documentation fixes — consistent HEALPix/healpy capitalization, corrected default values, missing parameter docs, broken RST formatting, dead Google Code URLs replaced with GitHub, typos, and grammar https://github.com/healpy/healpy/pull/1113
 * CI: Added test workflow (`.github/workflows/tests.yml`) running the full test suite on Python 3.10–3.13 with ccache, plus an astropy pre-release job https://github.com/healpy/healpy/pull/1109
 * Fix off-by-one in ``synalm`` Cℓ boundary check that caused out-of-bounds reads when ``l == len(cl)`` https://github.com/healpy/healpy/pull/1108
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,7 @@ master_doc = "index"
 
 # General substitutions.
 project = u"healpy"
-copyright = u"CC/BY/4.0/International"
+copyright = u"Documentation: CC/BY/4.0/International, Software: GPL-2.0+"
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/doc/healpy_newvisu.rst
+++ b/doc/healpy_newvisu.rst
@@ -14,7 +14,7 @@ Map projections
 .. autosummary::
    :toctree: generated/
 
-    projview
+   projview
 
 Tracing lines or points
 -----------------------

--- a/doc/healpy_otherfunc.rst
+++ b/doc/healpy_otherfunc.rst
@@ -11,3 +11,5 @@ Other functions
 
    dist2holes
    hotspots
+   ringinfo
+   pix2ring

--- a/doc/healpy_pix.rst
+++ b/doc/healpy_pix.rst
@@ -17,6 +17,8 @@ conversion from/to sky coordinates
    vec2pix
    vec2ang
    ang2vec
+   xyf2pix
+   pix2xyf
    get_all_neighbours
    get_interp_weights
    get_interp_val
@@ -39,6 +41,8 @@ nside/npix/resolution
    npix2nside
    nside2order
    order2nside
+   npix2order
+   order2npix
    nside2resol
    nside2pixarea
    max_pixrad
@@ -84,4 +88,3 @@ Map data manipulation
    fit_monopole
    remove_dipole
    remove_monopole
-   get_interp_val

--- a/doc/healpy_rotator.rst
+++ b/doc/healpy_rotator.rst
@@ -14,7 +14,9 @@ Rotation
    Rotator
    rotateVector
    rotateDirection
-   
+   rotate_alm
+   rotate_map_alms
+   rotate_map_pixel
 
 Geometrical helpers
 -------------------

--- a/doc/healpy_spht.rst
+++ b/doc/healpy_spht.rst
@@ -30,7 +30,7 @@ Spherical harmonic transform tools
 ----------------------------------
 .. autosummary::
    :toctree: generated/
-   
+
    smoothing
    smoothalm
    harmonic_ud_grade
@@ -49,4 +49,6 @@ Other tools
    gauss_beam
    beam2bl
    bl2beam
+   blm_gauss
    effective_resolution_fwhm
+   check_max_nside

--- a/doc/healpy_visu.rst
+++ b/doc/healpy_visu.rst
@@ -15,6 +15,7 @@ Map projections
    gnomview
    cartview
    orthview
+   azeqview
 
 Graticules
 ----------

--- a/doc/healpy_zoomtool.rst
+++ b/doc/healpy_zoomtool.rst
@@ -1,4 +1,4 @@
-.. healpy.visufunc:
+.. healpy.zoomtool:
 
 .. currentmodule:: healpy.zoomtool
 
@@ -12,3 +12,4 @@ Interactive map visualization
    :toctree: generated/
 
    mollzoom
+   set_g_clim

--- a/doc/healpy_zoomtool.rst
+++ b/doc/healpy_zoomtool.rst
@@ -4,7 +4,7 @@
 
 
 :mod:`zoomtool` -- Interactive visualisation
-================================
+============================================
 
 Interactive map visualization
 -----------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -52,13 +52,13 @@ or customize their format::
 
 For more details see the `Python documentation <https://docs.python.org/3/library/logging.html>`_.
 
-All the `verbose` keywords (except :py:func:remove_dipole) are now deprecated and
+All the `verbose` keywords (except :py:func:`remove_dipole`) are now deprecated and
 will be removed in the future.
 You can disable deprecation warnings with::
 
     import warnings
-    from astropy.utils.exceptions import AstropyDeprecationWarning
-    warnings.simplefilter('ignore', category=AstropyDeprecationWarning)
+    from healpy.utils.deprecation import HealpyDeprecationWarning
+    warnings.simplefilter('ignore', category=HealpyDeprecationWarning)
 
 Changelog
 ---------
@@ -75,7 +75,7 @@ Citing
 
 3. at the first use of the `HEALPix` acronym, a footnote placed in the main body
    of the paper referring to the `HEALPix` web site, currently
-   http://healpix.sf.net
+   https://healpix.sourceforge.net
 
 Tutorial
 --------

--- a/doc/other_tutorials.rst
+++ b/doc/other_tutorials.rst
@@ -30,4 +30,4 @@ Power spectra
 -------------
 
 * `Read and process Planck CMB power spectra <https://zonca.dev/2020/09/planck-spectra-healpy.html>`_
-* `Compute Planck CMB Temperature power specrum with anafast <https://zonca.dev/2021/02/compute-planck-spectra-healpy-anafast.html>`_
+* `Compute Planck CMB Temperature power spectrum with anafast <https://zonca.dev/2021/02/compute-planck-spectra-healpy-anafast.html>`_

--- a/lib/healpy/__init__.py
+++ b/lib/healpy/__init__.py
@@ -15,7 +15,7 @@
 #  along with Healpy; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-#  For more information about Healpy, see http://code.google.com/p/healpy
+#  For more information about Healpy, see https://github.com/healpy/healpy
 #
 """HealPy is a package to manipulate Healpix maps (ang2pix, pix2ang) and
 compute spherical harmonics tranforms on them.

--- a/lib/healpy/__init__.py
+++ b/lib/healpy/__init__.py
@@ -17,8 +17,8 @@
 #
 #  For more information about Healpy, see https://github.com/healpy/healpy
 #
-"""HealPy is a package to manipulate Healpix maps (ang2pix, pix2ang) and
-compute spherical harmonics tranforms on them.
+"""healpy is a package to manipulate HEALPix maps (ang2pix, pix2ang) and
+compute spherical harmonics transforms on them.
 """
 
 from .version import __version__

--- a/lib/healpy/fitsfunc.py
+++ b/lib/healpy/fitsfunc.py
@@ -168,10 +168,10 @@ def write_map(
     """Writes a healpix map into a healpix FITS file.
 
     .. warning::
-    Starting from healpy 1.15.0, if you do not specify `dtype`,
-    the map will be written to disk with the same precision it is stored in memory.
-    Previously, by default `healpy` wrote maps in `float32`.
-    To reproduce the same behaviour of `healpy` 1.14.0 and below, set `dtype=np.float32`.
+       Starting from healpy 1.15.0, if you do not specify `dtype`,
+       the map will be written to disk with the same precision it is stored in memory.
+       Previously, by default `healpy` wrote maps in `float32`.
+       To reproduce the same behaviour of `healpy` 1.14.0 and below, set `dtype=np.float32`.
 
     Parameters
     ----------

--- a/lib/healpy/fitsfunc.py
+++ b/lib/healpy/fitsfunc.py
@@ -48,6 +48,10 @@ allowed_paths = (str, pathlib.Path)
 
 @deprecated(since="1.15.0")
 class HealpixFitsWarning(Warning):
+    """Warning class for FITS I/O issues in healpy.
+
+    .. deprecated:: 1.15.0
+    """
     pass
 
 
@@ -551,6 +555,8 @@ def write_alm(
       data type in the output file (must be a numpy dtype). Default: *alms*.real.dtype
     mmax_in : int, optional
       maximum m in the input array
+    overwrite : bool, optional
+      If True, overwrite the output file if it already exists. Default: False.
     """
 
     if not cb.is_seq_of_seq(alms):

--- a/lib/healpy/fitsfunc.py
+++ b/lib/healpy/fitsfunc.py
@@ -17,7 +17,7 @@
 #
 #  For more information about Healpy, see https://github.com/healpy/healpy
 #
-"""Provides input and output functions for Healpix maps, alm, and cl.
+"""Provides input and output functions for HEALPix maps, alm, and cl.
 """
 from __future__ import division
 

--- a/lib/healpy/fitsfunc.py
+++ b/lib/healpy/fitsfunc.py
@@ -15,7 +15,7 @@
 #  along with Healpy; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-#  For more information about Healpy, see http://code.google.com/p/healpy
+#  For more information about Healpy, see https://github.com/healpy/healpy
 #
 """Provides input and output functions for Healpix maps, alm, and cl.
 """

--- a/lib/healpy/fitsfunc.py
+++ b/lib/healpy/fitsfunc.py
@@ -56,7 +56,7 @@ class HealpixFitsWarning(Warning):
 
 
 def read_cl(filename):
-    """Reads Cl from a healpix file, as IDL fits2cl.
+    """Reads Cl from a HEALPix file, as IDL fits2cl.
 
     Parameters
     ----------
@@ -83,7 +83,7 @@ def read_cl(filename):
 
 
 def write_cl(filename, cl, dtype=None, overwrite=False, column_names=None, extra_header=()):
-    """Writes Cl into a healpix file, as IDL cl2fits.
+    """Writes Cl into a HEALPix file, as IDL cl2fits.
 
     Parameters
     ----------
@@ -165,7 +165,7 @@ def write_map(
     extra_header=(),
     overwrite=False,
 ):
-    """Writes a healpix map into a healpix FITS file.
+    """Writes a HEALPix map into a HEALPix FITS file.
 
     .. warning::
        Starting from healpy 1.15.0, if you do not specify `dtype`,
@@ -341,7 +341,7 @@ def read_map(
     verbose=True,
     memmap=False,
 ):
-    """Read a healpix map from a fits file.  Partial-sky files,
+    """Read a HEALPix map from a fits file.  Partial-sky files,
     if properly identified, are expanded to full size and filled with UNSEEN.
 
     .. warning::
@@ -631,7 +631,7 @@ def read_alm(filename, hdu=1, return_mmax=False):
     with 3 columns (index, real and imaginary) for each HDU.
 
     In the fits file, the alm are assumed to be written
-    with explicit index scheme, index = l**2+l+m+1, while healpix cxx
+    with explicit index scheme, index = l**2+l+m+1, while HEALPix C++
     uses index = m*(2*lmax+1-m)/2+l. The conversion is done in this
     function.
 

--- a/lib/healpy/fitsfunc.py
+++ b/lib/healpy/fitsfunc.py
@@ -211,12 +211,13 @@ def write_map(
       internally from the numpy datatype to the fits convention. If a list,
       the length must correspond to the number of map arrays.
       Default: use the data type of the input array(s)
+
       .. note::
-      this changed in 1.15.0, previous versions saved in float32
-      by default
+         this changed in 1.15.0, previous versions saved in float32
+         by default
     overwrite : bool, optional
       If True, existing file is silently overwritten. Otherwise trying to write
-      an existing file raises an OSError (IOError for Python 2).
+      an existing file raises an OSError.
     """
     if not hasattr(m, "__len__"):
         raise TypeError("The map must be a sequence")

--- a/lib/healpy/newvisufunc.py
+++ b/lib/healpy/newvisufunc.py
@@ -150,7 +150,7 @@ def projview(
     dpi=None,
     **kwargs,
 ):
-    """Plot a healpix map (given as an array) in the chosen projection.
+    """Plot a HEALPix map (given as an array) in the chosen projection.
 
     See examples of using this function in the documentation under "Other
     tutorials". Overplot points or lines using :func:`newprojplot`.

--- a/lib/healpy/newvisufunc.py
+++ b/lib/healpy/newvisufunc.py
@@ -184,11 +184,11 @@ def projview(
       Either one of 'G', 'E' or 'C' (where 'E' stands for the Ecliptic, 'G' for 
       the Galactic, and 'C' for the Celestial or equatorial) to describe the coordinate
       system of the map, or a sequence of 2 of these to rotate the map from the first 
-      to the second coordinate system. default: 'G'
+      to the second coordinate system. Default: None
     unit : str, optional
       A text describing the unit of the data. Default: ''
     xsize : int, optional
-      The size of the image. Default: 800
+      The size of the image. Default: 1000
     width : float, optional
         Sets the width of the figure. Use override_plot_properties for more.
         Overrides the default width of the figure
@@ -200,7 +200,7 @@ def projview(
       The maximum range value
     flip : {'astro', 'geo'}, optional
       Defines the convention of projection : 'astro' (default, east towards
-      left, west towards right) or 'geo' (east towards roght, west towards left)
+      left, west towards right) or 'geo' (east towards right, west towards left)
       It creates the `healpy_flip` attribute on the Axes to save the convention
       in the figure.
     format : str, optional
@@ -286,8 +286,8 @@ def projview(
     cbar_ticks : list
       custom ticks on the colorbar
     show_tickmarkers : bool, optional
-      Preserve tickmarkers for the full bar with labels specified by ticks
-      default: None
+      Preserve tickmarkers for the full bar with labels specified by ticks.
+      Default: False
     extend : str, optional
       Whether to extend the colorbar to mark where min or max tick is less than
       the min or max of the data. Options are "min", "max", "neither", or "both"

--- a/lib/healpy/newvisufunc.py
+++ b/lib/healpy/newvisufunc.py
@@ -208,24 +208,24 @@ def projview(
     cbar : bool, optional
       Display the colorbar. Default: True
     cmap : str, optional
-        Specify the colormap. default: Viridis
+        Specify the colormap. Default: Viridis
     badcolor: str, optional
-        Specify the color of bad pixels. default: Grey
+        Specify the color of bad pixels. Default: Grey
     bgcolor: str, optional
-        Specify the color of the background. default: White
+        Specify the color of the background. Default: White
     norm : {'hist', 'log', 'symlog', 'symlog2', None}
       Color normalization:
       hist = histogram equalized color mapping.
       log = logarithmic color mapping.
       symlog = symmetric logarithmic, linear between -linthresh and linthresh.
-      symlog2 = similar to symlog, used for plack log colormap.
-      default: None (linear color mapping)
+      symlog2 = similar to symlog, used for Planck log colormap.
+      Default: None (linear color mapping)
     norm_dict : dict, optional
         Parameters for normalization:
         default is set to {"linthresh": 1, "base": 10, "linscale": 0.1}
         where linthresh determines the linear regime of symlog norm,
         and linscale sets the size of the linear regime on the cbar.
-        default: None
+        Default: None
     graticule : bool
       add graticule
     graticule_labels : bool

--- a/lib/healpy/pixelfunc.py
+++ b/lib/healpy/pixelfunc.py
@@ -19,10 +19,10 @@
 #
 """
 =====================================================
-pixelfunc.py : Healpix pixelization related functions
+pixelfunc.py : HEALPix pixelization related functions
 =====================================================
 
-This module provides functions related to Healpix pixelization scheme.
+This module provides functions related to HEALPix pixelization scheme.
 
 conversion from/to sky coordinates
 ----------------------------------
@@ -684,7 +684,7 @@ def pix2vec(nside, ipix, nest=False):
     nside : int, scalar or array-like
       The healpix nside parameter, must be a power of 2, less than 2**30
     ipix : int, scalar or array-like
-      Healpix pixel number
+      HEALPix pixel number
     nest : bool, optional
       if True, assume NESTED pixel ordering, otherwise, RING pixel ordering
 

--- a/lib/healpy/pixelfunc.py
+++ b/lib/healpy/pixelfunc.py
@@ -722,7 +722,7 @@ def ang2vec(theta, phi, lonlat=False):
 
     Parameters
     ----------
-    theta : float, scalar or arry-like
+    theta : float, scalar or array-like
       colatitude in radians measured southward from north pole (in [0,pi]).
     phi : float, scalar or array-like
       longitude in radians measured eastward (in [0, 2*pi]).
@@ -1259,6 +1259,9 @@ def isnsideok(nside, nest=False):
     ----------
     nside : int, scalar or array-like
       integer value to be tested
+    nest : bool, optional
+      if True, check if nside is valid for NESTED scheme (must be power of 2).
+      If False (default), RING scheme allows non-power-of-2 nside values.
 
     Returns
     -------

--- a/lib/healpy/pixelfunc.py
+++ b/lib/healpy/pixelfunc.py
@@ -15,7 +15,7 @@
 #  along with Healpy; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-#  For more information about Healpy, see http://code.google.com/p/healpy
+#  For more information about Healpy, see https://github.com/healpy/healpy
 #
 """
 =====================================================

--- a/lib/healpy/pixelfunc.py
+++ b/lib/healpy/pixelfunc.py
@@ -47,13 +47,13 @@ conversion between NESTED and RING schemes
   scheme pixel number
 - :func:`ring2nest` converts RING scheme pixel number to NESTED
   scheme pixel number
-- :func:`reorder` reorders a healpix map pixels from one scheme to another
+- :func:`reorder` reorders a HEALPix map pixels from one scheme to another
 
 nside/npix/resolution
 ---------------------
 
-- :func:`nside2npix` converts healpix nside parameter to number of pixel
-- :func:`npix2nside` converts number of pixel to healpix nside parameter
+- :func:`nside2npix` converts HEALPix nside parameter to number of pixel
+- :func:`npix2nside` converts number of pixel to HEALPix nside parameter
 - :func:`nside2order` converts nside to order
 - :func:`order2nside` converts order to nside
 - :func:`nside2resol` converts nside to mean angular resolution
@@ -442,7 +442,7 @@ def ang2pix(nside, theta, phi, nest=False, lonlat=False, latauto=False, latbounc
     Parameters
     ----------
     nside : int, scalar or array-like
-      The healpix nside parameter, must be a power of 2, less than 2**30
+      The HEALPix nside parameter, must be a power of 2, less than 2**30
     theta, phi : float, scalars or array-like
       Angular coordinates of a point on the sphere
     nest : bool, optional
@@ -459,7 +459,7 @@ def ang2pix(nside, theta, phi, nest=False, lonlat=False, latauto=False, latbounc
     Returns
     -------
     pix : int or array of int
-      The healpix pixel numbers. Scalar if all input are scalar, array otherwise.
+      The HEALPix pixel numbers. Scalar if all input are scalar, array otherwise.
       Usual numpy broadcasting rules apply.
 
     See Also
@@ -508,7 +508,7 @@ def pix2ang(nside, ipix, nest=False, lonlat=False):
     Parameters
     ----------
     nside : int or array-like
-      The healpix nside parameter, must be a power of 2, less than 2**30
+      The HEALPix nside parameter, must be a power of 2, less than 2**30
     ipix : int or array-like
       Pixel indices
     nest : bool, optional
@@ -560,7 +560,7 @@ def xyf2pix(nside, x, y, face, nest=False):
     Parameters
     ----------
     nside : int, scalar or array-like
-      The healpix nside parameter, must be a power of 2
+      The HEALPix nside parameter, must be a power of 2
     x, y : int, scalars or array-like
       Pixel indices within face
     face : int, scalars or array-like
@@ -571,7 +571,7 @@ def xyf2pix(nside, x, y, face, nest=False):
     Returns
     -------
     pix : int or array of int
-      The healpix pixel numbers. Scalar if all input are scalar, array otherwise.
+      The HEALPix pixel numbers. Scalar if all input are scalar, array otherwise.
       Usual numpy broadcasting rules apply.
 
     See Also
@@ -600,7 +600,7 @@ def pix2xyf(nside, ipix, nest=False):
     Parameters
     ----------
     nside : int or array-like
-      The healpix nside parameter, must be a power of 2
+      The HEALPix nside parameter, must be a power of 2
     ipix : int or array-like
       Pixel indices
     nest : bool, optional
@@ -642,7 +642,7 @@ def vec2pix(nside, x, y, z, nest=False):
     Parameters
     ----------
     nside : int or array-like
-      The healpix nside parameter, must be a power of 2, less than 2**30
+      The HEALPix nside parameter, must be a power of 2, less than 2**30
     x,y,z : floats or array-like
       vector coordinates defining point on the sphere
     nest : bool, optional
@@ -651,7 +651,7 @@ def vec2pix(nside, x, y, z, nest=False):
     Returns
     -------
     ipix : int, scalar or array-like
-      The healpix pixel number corresponding to input vector. Scalar if all input
+      The HEALPix pixel number corresponding to input vector. Scalar if all input
       are scalar, array otherwise. Usual numpy broadcasting rules apply.
 
     See Also
@@ -682,7 +682,7 @@ def pix2vec(nside, ipix, nest=False):
     Parameters
     ----------
     nside : int, scalar or array-like
-      The healpix nside parameter, must be a power of 2, less than 2**30
+      The HEALPix nside parameter, must be a power of 2, less than 2**30
     ipix : int, scalar or array-like
       HEALPix pixel number
     nest : bool, optional
@@ -718,7 +718,7 @@ def pix2vec(nside, ipix, nest=False):
 
 
 def ang2vec(theta, phi, lonlat=False):
-    """ang2vec : convert angles to 3D position vector
+    """ang2vec : convert angles to 3D position vector.
 
     Parameters
     ----------
@@ -748,7 +748,7 @@ def ang2vec(theta, phi, lonlat=False):
 
 
 def vec2ang(vectors, lonlat=False):
-    """vec2ang: vectors [x, y, z] -> theta[rad], phi[rad]
+    """vec2ang: vectors [x, y, z] -> theta[rad], phi[rad].
 
     Parameters
     ----------
@@ -784,7 +784,7 @@ def ring2nest(nside, ipix):
     Parameters
     ----------
     nside : int, scalar or array-like
-      the healpix nside parameter
+      the HEALPix nside parameter
     ipix : int, scalar or array-like
       the pixel number in RING scheme
 
@@ -819,7 +819,7 @@ def nest2ring(nside, ipix):
     Parameters
     ----------
     nside : int, scalar or array-like
-      the healpix nside parameter
+      the HEALPix nside parameter
     ipix : int, scalar or array-like
       the pixel number in NESTED scheme
 
@@ -850,7 +850,7 @@ def nest2ring(nside, ipix):
 
 @accept_ma
 def reorder(map_in, inp=None, out=None, r2n=None, n2r=None):
-    """Reorder a healpix map from RING/NESTED ordering to NESTED/RING
+    """Reorder a HEALPix map from RING/NESTED ordering to NESTED/RING.
 
     Parameters
     ----------
@@ -962,7 +962,7 @@ def nside2npix(nside):
     Parameters
     ----------
     nside : int
-      healpix nside parameter
+      HEALPix nside parameter
 
     Returns
     -------
@@ -991,7 +991,7 @@ def nside2order(nside):
     Parameters
     ----------
     nside : int
-      healpix nside parameter; an exception is raised if nside is not valid
+      HEALPix nside parameter; an exception is raised if nside is not valid
       (nside must be a power of 2, less than 2**30)
 
     Returns
@@ -1031,7 +1031,7 @@ def nside2resol(nside, arcmin=False):
     Parameters
     ----------
     nside : int
-      healpix nside parameter, must be a power of 2, less than 2**30
+      HEALPix nside parameter, must be a power of 2, less than 2**30
     arcmin : bool
       if True, return resolution in arcmin, otherwise in radian
 
@@ -1071,7 +1071,7 @@ def nside2pixarea(nside, degrees=False):
     Parameters
     ----------
     nside : int
-      healpix nside parameter, must be a power of 2, less than 2**30
+      HEALPix nside parameter, must be a power of 2, less than 2**30
     degrees : bool
       if True, returns pixel area in square degrees, in square radians otherwise
 
@@ -1121,7 +1121,7 @@ def npix2nside(npix):
     Notes
     -----
     Raise a ValueError exception if number of pixel does not correspond to
-    the number of pixel of a healpix map.
+    the number of pixel of a HEALPix map.
 
     Examples
     --------
@@ -1300,7 +1300,7 @@ def isnsideok(nside, nest=False):
 
 
 def check_nside(nside, nest=False):
-    """Raises exception is nside is not valid"""
+    """Raises exception if nside is not valid"""
     if not np.all(isnsideok(nside, nest=nest)):
         raise ValueError(
             "%s is not a valid nside parameter (must be a power of 2, less than 2**30)"
@@ -1309,7 +1309,7 @@ def check_nside(nside, nest=False):
 
 
 def isnpixok(npix):
-    """Return :const:`True` if npix is a valid value for healpix map size, :const:`False` otherwise.
+    """Return :const:`True` if npix is a valid value for HEALPix map size, :const:`False` otherwise.
 
     Parameters
     ----------
@@ -1343,7 +1343,7 @@ def get_interp_val(m, theta, phi, nest=False, lonlat=False):
     Parameters
     ----------
     m : array-like, shape (npix,) or (nmaps, npix)
-      a healpix map or sequence thereof, accepts masked arrays
+      a HEALPix map or sequence thereof, accepts masked arrays
     theta, phi : float, scalar or array-like
       angular coordinates of point at which to interpolate the map
     nest : bool
@@ -1408,7 +1408,7 @@ def get_interp_weights(nside, theta, phi=None, nest=False, lonlat=False):
     Parameters
     ----------
     nside : int
-      the healpix nside
+      the HEALPix nside
     theta, phi : float, scalar or array-like
       if phi is not given, theta is interpreted as pixel number,
       otherwise theta[rad],phi[rad] are angular coordinates
@@ -1533,7 +1533,7 @@ def get_all_neighbours(nside, theta, phi=None, nest=False, lonlat=False):
 
 
 def max_pixrad(nside, degrees=False):
-    """Maximum angular distance between any pixel center and its corners
+    """Maximum angular distance between any pixel center and its corners.
 
     Parameters
     ----------
@@ -1868,7 +1868,7 @@ def get_min_valid_nside(npix):
     Returns
     -------
     nside : int
-      a valid healpix nside so that 12 * nside ** 2 >= npix
+      a valid HEALPix nside so that 12 * nside ** 2 >= npix
 
     Examples
     --------
@@ -1893,7 +1893,7 @@ def get_nside(m):
     Returns
     -------
     nside : int
-      the healpix nside parameter of the map (or sequence of maps)
+      the HEALPix nside parameter of the map (or sequence of maps)
 
     Notes
     -----

--- a/lib/healpy/projaxes.py
+++ b/lib/healpy/projaxes.py
@@ -15,7 +15,7 @@
 #  along with Healpy; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-#  For more information about Healpy, see http://code.google.com/p/healpy
+#  For more information about Healpy, see https://github.com/healpy/healpy
 #
 import logging
 

--- a/lib/healpy/projector.py
+++ b/lib/healpy/projector.py
@@ -15,7 +15,7 @@
 #  along with Healpy; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-#  For more information about Healpy, see http://code.google.com/p/healpy
+#  For more information about Healpy, see https://github.com/healpy/healpy
 #
 """This module provides classes for some spherical projection.
 To be used when calling SphereProjAxes class.

--- a/lib/healpy/rotator.py
+++ b/lib/healpy/rotator.py
@@ -407,7 +407,7 @@ class Rotator(object):
         return np.arctan2(sinalpha, cosalpha)
 
     def rotate_alm(self, alm, lmax=None, mmax=None, inplace=False):
-        """Rotate Alms with the transform defined in the Rotator object
+        """Rotate alm with the transform defined in the Rotator object.
 
         see the docstring of the rotate_alm function defined
         in the healpy package, this function **returns** the rotated alms,
@@ -431,7 +431,7 @@ class Rotator(object):
         datapath=None,
         verbose=None,
     ):
-        """Rotate a HEALPix map to a new reference frame in spherical harmonics space
+        """Rotate a HEALPix map to a new reference frame in spherical harmonics space.
 
         This is generally the best strategy to rotate/change reference frame of maps.
         If the input map is band-limited, i.e. it can be represented exactly by
@@ -476,7 +476,7 @@ class Rotator(object):
         )
 
     def rotate_map_pixel(self, m):
-        """Rotate a HEALPix map to a new reference frame in pixel space
+        """Rotate a HEALPix map to a new reference frame in pixel space.
 
         It is generally better to rotate in spherical harmonics space, see
         the rotate_map_alms method. A case where pixel space rotation is
@@ -553,7 +553,7 @@ class Rotator(object):
 
 
 def rotateVector(rotmat, vec, vy=None, vz=None, do_rot=True):
-    """Rotate a vector (or a list of vectors) using the rotation matrix
+    """Rotate a vector (or a list of vectors) using the rotation matrix.
     given as first argument.
 
     Parameters
@@ -594,7 +594,7 @@ def rotateVector(rotmat, vec, vy=None, vz=None, do_rot=True):
 
 
 def rotateDirection(rotmat, theta, phi=None, do_rot=True, lonlat=False):
-    """Rotate the vector described by angles theta,phi using the rotation matrix
+    """Rotate the vector described by angles theta, phi using the rotation matrix.
     given as first argument.
 
     Parameters

--- a/lib/healpy/rotator.py
+++ b/lib/healpy/rotator.py
@@ -293,6 +293,13 @@ class Rotator(object):
         return self._do_rotation
 
     def get_inverse(self):
+        """Return a new Rotator representing the inverse rotation.
+
+        Returns
+        -------
+        inv_rot : Rotator
+            A new Rotator object that performs the inverse of this rotation.
+        """
         rots = self._rots[::-1]
         coords = self._coords[::-1]
         invs = [not i for i in self._invs[::-1]]
@@ -436,7 +443,17 @@ class Rotator(object):
         ----------
         m : np.ndarray
             Input map, single array is considered I, array with 3 rows:[I,Q,U]
-        other arguments : see map2alm
+        use_pixel_weights : bool, optional
+            If True, use pixel by pixel weighting in the map2alm step.
+            Default: True.
+        lmax : int, optional
+            Maximum l for the spherical harmonics transform. Default: 3*nside-1.
+        mmax : int, optional
+            Maximum m for the spherical harmonics transform. Default: lmax.
+        datapath : str or None, optional
+            If given, the directory where to find the pixel weights data.
+        verbose : bool, optional
+            Deprecated, has no effect.
 
         Returns
         -------
@@ -587,7 +604,7 @@ def rotateDirection(rotmat, theta, phi=None, do_rot=True, lonlat=False):
     theta : float, scalar or array-like
       The angle theta (scalar or shape (N,))
       or both angles (scalar or shape (2, N)) if phi is not given.
-    phi : float, scalar or array-like, optionnal
+    phi : float, scalar or array-like, optional
       The angle phi (scalar or shape (N,)).
     do_rot : bool, optional
       if True, really perform the operation, if False do nothing.
@@ -663,7 +680,7 @@ def dir2vec(theta, phi=None, lonlat=False):
     theta : float, scalar or array-like
       The angle theta (scalar or shape (N,))
       or both angles (scalar or shape (2, N)) if phi is not given.
-    phi : float, scalar or array-like, optionnal
+    phi : float, scalar or array-like, optional
       The angle phi (scalar or shape (N,)).
     lonlat : bool
       If True, input angles are assumed to be longitude and latitude in degree,

--- a/lib/healpy/rotator.py
+++ b/lib/healpy/rotator.py
@@ -15,7 +15,7 @@
 #  along with Healpy; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-#  For more information about Healpy, see http://code.google.com/p/healpy
+#  For more information about Healpy, see https://github.com/healpy/healpy
 #
 import numpy as np
 import logging

--- a/lib/healpy/rotator.py
+++ b/lib/healpy/rotator.py
@@ -76,7 +76,7 @@ class Rotator(object):
 
     This class provides tools for spherical rotations. It is meant to be used
     in the healpy library for plotting, and for this reason reflects the
-    convention used in the Healpix IDL library.
+    convention used in the HEALPix IDL library.
 
     Parameters
     ----------
@@ -1194,7 +1194,7 @@ def euler_matrix_new(a1, a2, a3, X=True, Y=False, ZYX=False, deg=False):
 
 
     MODIFICATION HISTORY:
-       March 2002, EH, Caltech, rewritting of euler_matrix
+       March 2002, EH, Caltech, rewriting of euler_matrix
 
        convention   euler_matrix_new           euler_matrix
       X:       M_new(a,b,c,/X)  =  M_old(-a,-b,-c,/X) = Transpose( M_old(c, b, a,/X))

--- a/lib/healpy/sphtfunc.py
+++ b/lib/healpy/sphtfunc.py
@@ -15,7 +15,7 @@
 #  along with Healpy; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-#  For more information about Healpy, see http://code.google.com/p/healpy
+#  For more information about Healpy, see https://github.com/healpy/healpy
 #
 import logging
 import warnings
@@ -159,11 +159,11 @@ def anafast(
       The number of spectra to return. If None, returns all, otherwise
       returns cls[:nspec]
     lmax : int, scalar, optional
-      Maximum l of the power spectrum (default: 3*nside-1)
+      Maximum l of the power spectrum (Default: 3*nside-1)
     mmax : int, scalar, optional
-      Maximum m of the alm (default: lmax)
+      Maximum m of the alm (Default: lmax)
     iter : int, scalar, optional
-      Number of iteration (default: 3)
+      Number of iterations (Default: 3)
     alm : bool, scalar, optional
       If True, returns both cl and alm, otherwise only cl is returned
     pol : bool, optional
@@ -283,7 +283,7 @@ def map2alm(
     mmax : int, scalar, optional
       Maximum m of the alm. Default: lmax
     iter : int, scalar, optional
-      Number of iteration (default: 3)
+      Number of iterations (Default: 3)
     pol : bool, optional
       If True, assumes input maps are TQU. Output will be TEB alm's.
       (input must be 1 or 3 maps)
@@ -1333,9 +1333,9 @@ def synalm(cls, lmax=None, mmax=None, new=False, verbose=True):
     mmax : int, scalar, optional
       The mmax (if None or <0, =lmax)
     new : bool, optional
-      If True, use the new ordering of cl's, ie by diagonal
+      If True, use the new ordering of cl's, i.e. by diagonal
       (e.g. TT, EE, BB, TE, EB, TB or TT, EE, BB, TE if 4 cl as input).
-      If False, use the old ordering, ie by row
+      If False, use the old ordering, i.e. by row
       (e.g. TT, TE, TB, EE, EB, BB or TT, TE, EE, BB if 4 cl as input).
     verbose : bool, optional
       Deprecated, has no effect.
@@ -1457,9 +1457,9 @@ def synfast(
       The sigma of the Gaussian used to smooth the map (applied on alm)
       [in radians]
     new : bool, optional
-      If True, use the new ordering of cl's, ie by diagonal
+      If True, use the new ordering of cl's, i.e. by diagonal
       (e.g. TT, EE, BB, TE, EB, TB or TT, EE, BB, TE if 4 cl as input).
-      If False, use the old ordering, ie by row
+      If False, use the old ordering, i.e. by row
       (e.g. TT, TE, TB, EE, EB, BB or TT, TE, EE, BB if 4 cl as input).
     verbose : bool, optional
       Deprecated, has no effect.
@@ -1841,7 +1841,7 @@ def smoothing(
       treated independently (input can be any number of alms).
       If there is only one input map, it has no effect. Default: True.
     iter : int, scalar, optional
-      Number of iteration (default: 3)
+      Number of iterations (Default: 3)
     lmax : int, scalar, optional
       Maximum l of the power spectrum. Default: 3*nside-1
     mmax : int, scalar, optional
@@ -1947,7 +1947,7 @@ def pixwin(nside, pol=False, lmax=None, datapath=None):
     pol : bool, optional
       If True, return also the polar pixel window. Default: False
     lmax : int, optional
-        Maximum l of the power spectrum (default: 3*nside-1)
+        Maximum l of the power spectrum (Default: 3*nside-1)
     datapath : None or str, optional
         If given, the directory where to find the pixel window function file.
         If not found locally, will be downloaded and cached using astropy.

--- a/lib/healpy/sphtfunc.py
+++ b/lib/healpy/sphtfunc.py
@@ -57,7 +57,7 @@ MAX_NSIDE = (
     8192  # The maximum nside up to which most operations (e.g. map2alm) will work
 )
 
-# Planck 2013 XXIII Table 1: the 100 GHz channel at Nside=64 has FWHM = 160 arcmin.
+# Planck 2013 XXIII Table 1: the 100 GHz channel at NSIDE=64 has FWHM = 160 arcmin.
 # The FWHM-to-pixel-size ratio K = 160 arcmin / nside2resol(64) ≈ 2.91
 # is used consistently across all Planck resolution levels. Private constant
 # (implementation detail of harmonic_ud_grade / effective_resolution_fwhm).
@@ -2057,7 +2057,7 @@ def load_sample_spectra():
 
 
 def gauss_beam(fwhm, lmax=512, pol=False):
-    """Gaussian beam window function
+    """Gaussian beam window function.
 
     Computes the spherical transform of an axisimmetric gaussian beam
 

--- a/lib/healpy/sphtfunc.py
+++ b/lib/healpy/sphtfunc.py
@@ -44,6 +44,11 @@ from ._sphtools import map2alm_spin_healpy as map2alm_spin
 
 
 class FutureChangeWarning(UserWarning):
+    """Warning class for upcoming breaking changes in healpy.
+
+    Issued when a feature's behavior will change in a future release.
+    Users should update their code to avoid future errors.
+    """
     pass
 
 
@@ -254,7 +259,7 @@ def map2alm(
 
     Pixel weights provide the most accurate transform, so you should always use them if
     possible. However they are not included in healpy and will be automatically downloaded
-    and cached in ~/.astropy the first time you compute a trasform at a specific nside.
+    and cached in ~/.astropy the first time you compute a transform at a specific nside.
 
     If datapath is specified, healpy will first check that local folder before downloading
     the weights.
@@ -292,7 +297,7 @@ def map2alm(
     use_pixel_weights: bool, optional
       If True, use pixel by pixel weighting, healpy will automatically download the weights, if needed
     verbose : bool, optional
-      Deprecated, has not effect.
+      Deprecated, has no effect.
 
     Returns
     -------
@@ -538,6 +543,8 @@ def alm2map(
       smoothing (if alm(s) are complex128 contiguous arrays).
       Otherwise, input alms are not modified. A copy is made if needed to
       apply beam smoothing or pixel window.
+    verbose : bool, optional
+      Deprecated, has no effect.
 
     Returns
     -------
@@ -1708,7 +1715,7 @@ def smoothalm(
       If True, the alm's are modified inplace if they are contiguous arrays
       of type complex128. Otherwise, a copy of alm is made. Default: True.
     verbose : bool, optional
-      Deprecated, has not effect.
+      Deprecated, has no effect.
 
     Returns
     -------
@@ -1836,7 +1843,7 @@ def smoothing(
       If given, the directory where to find the pixel weights data.
       See the docstring of `map2alm` for details on how to set it up
     verbose : bool, optional
-      Deprecated, has not effect.
+      Deprecated, has no effect.
     nest : bool, optional
       If True, the input map ordering is assumed to be NESTED. Default: False (RING)
       This function will temporary reorder the NESTED map into RING to perform the

--- a/lib/healpy/sphtfunc.py
+++ b/lib/healpy/sphtfunc.py
@@ -135,7 +135,7 @@ def anafast(
     gal_cut=0,
     use_pixel_weights=False,
 ):
-    """Computes the power spectrum of a Healpix map, or the cross-spectrum
+    """Computes the power spectrum of a HEALPix map, or the cross-spectrum
     between two maps if *map2* is given.
     No removal of monopole or dipole is performed. The input maps must be
     in ring-ordering.
@@ -246,7 +246,7 @@ def map2alm(
     use_pixel_weights=False,
     verbose=True,
 ):
-    """Computes the alm of a Healpix map. The input maps must all be
+    """Computes the alm of a HEALPix map. The input maps must all be
     in ring ordering.
 
     For recommendations about how to set `lmax`, `iter`, and weights, see the
@@ -382,7 +382,7 @@ def map2alm_lsq(maps, lmax, mmax, pol=True, tol=1e-10, maxiter=20):
     """Runs an iterative map analysis up to (lmax, mmax) and returns the result
     including its quality.
 
-    Healpix map analysis is often interpreted as "compute the `alm` for which
+    HEALPix map analysis is often interpreted as "compute the `alm` for which
     `alm2map(alm) == map`". Unfortunately this inversion problem is not solvable
     in many cases, since `alm` typically has fewer elements than `map`, which
     makes the equation system overdetermined, so that a solution only exists
@@ -510,7 +510,7 @@ def alm2map(
     inplace=False,
     verbose=True,
 ):
-    """Computes a Healpix map given the alm.
+    """Computes a HEALPix map given the alm.
 
     The alm are given as a complex array. You can specify lmax
     and mmax, or they will be computed from array size (assuming
@@ -552,7 +552,7 @@ def alm2map(
     Returns
     -------
     maps : array or list of arrays
-      A Healpix map in RING scheme at nside or a list of T,Q,U maps (if
+      A HEALPix map in RING scheme at nside or a list of T,Q,U maps (if
       polarized input)
 
     Notes
@@ -1988,7 +1988,7 @@ def pixwin(nside, pol=False, lmax=None, datapath=None):
 
 
 def alm2map_der1(alm, nside, lmax=None, mmax=None):
-    """Computes a Healpix map and its first derivatives given the alm.
+    """Computes a HEALPix map and its first derivatives given the alm.
 
     The alm are given as a complex array. You can specify lmax
     and mmax, or they will be computed from array size (assuming

--- a/lib/healpy/sphtfunc.py
+++ b/lib/healpy/sphtfunc.py
@@ -1519,6 +1519,11 @@ class Alm(object):
         i : int or None
           The index for which to compute the l and m.
           If None, the function return l and m for i=0..Alm.getsize(lmax)
+
+        Returns
+        -------
+        l, m : int or array of int
+          The l and m values corresponding to the given index.
         """
         szalm = Alm.getsize(lmax, lmax)
         if i is None:
@@ -2184,6 +2189,11 @@ def check_max_nside(nside):
     ----------
     nside : int
         nside of the map that is being checked
+
+    Returns
+    -------
+    int
+        Returns 0 if the check passes. Raises ValueError otherwise.
     """
 
     if nside > MAX_NSIDE:

--- a/lib/healpy/sphtfunc.py
+++ b/lib/healpy/sphtfunc.py
@@ -180,6 +180,9 @@ def anafast(
     use_pixel_weights: bool, optional
       If True, use pixel by pixel weighting, healpy will automatically download the weights, if needed
       See the map2alm docs for details about weighting
+    use_weights : bool, optional
+      If True, use ring weighting. Default: False.
+      See the map2alm docs for details about weighting
 
     Returns
     -------
@@ -1334,6 +1337,8 @@ def synalm(cls, lmax=None, mmax=None, new=False, verbose=True):
       (e.g. TT, EE, BB, TE, EB, TB or TT, EE, BB, TE if 4 cl as input).
       If False, use the old ordering, ie by row
       (e.g. TT, TE, TB, EE, EB, BB or TT, TE, EE, BB if 4 cl as input).
+    verbose : bool, optional
+      Deprecated, has no effect.
 
     Returns
     -------
@@ -1456,6 +1461,8 @@ def synfast(
       (e.g. TT, EE, BB, TE, EB, TB or TT, EE, BB, TE if 4 cl as input).
       If False, use the old ordering, ie by row
       (e.g. TT, TE, TB, EE, EB, BB or TT, TE, EE, BB if 4 cl as input).
+    verbose : bool, optional
+      Deprecated, has no effect.
 
     Returns
     -------
@@ -1622,7 +1629,7 @@ def alm2cl(alms1, alms2=None, lmax=None, mmax=None, lmax_out=None, nspec=None):
 
     Parameters
     ----------
-    alm : complex, array or sequence of arrays
+    alms1 : complex, array or sequence of arrays
       The alm from which to compute the power spectrum. If n>=2 arrays are given,
       computes both auto- and cross-spectra.
     alms2 : complex, array or sequence of 3 arrays, optional

--- a/lib/healpy/visufunc.py
+++ b/lib/healpy/visufunc.py
@@ -103,7 +103,7 @@ def mollview(
     alpha=None,
     fontsize=None,
 ):
-    """Plot a healpix map (given as an array) in Mollweide projection.
+    """Plot a HEALPix map (given as an array) in Mollweide projection.
 
     Parameters
     ----------
@@ -396,7 +396,7 @@ def gnomview(
     alpha=None,
     fontsize=None,
 ):
-    """Plot a healpix map (given as an array) in Gnomonic projection.
+    """Plot a HEALPix map (given as an array) in Gnomonic projection.
 
     Parameters
     ----------
@@ -721,7 +721,7 @@ def cartview(
     alpha=None,
     fontsize=None,
 ):
-    """Plot a healpix map (given as an array) in Cartesian projection.
+    """Plot a HEALPix map (given as an array) in Cartesian projection.
 
     Parameters
     ----------
@@ -1024,7 +1024,7 @@ def orthview(
     alpha=None,
     fontsize=None,
 ):
-    """Plot a healpix map (given as an array) in Orthographic projection.
+    """Plot a HEALPix map (given as an array) in Orthographic projection.
 
     Parameters
     ----------
@@ -1317,7 +1317,7 @@ def azeqview(
     alpha=None,
     fontsize=None,
 ):
-    """Plot a healpix map (given as an array) in Azimuthal equidistant projection
+    """Plot a HEALPix map (given as an array) in Azimuthal equidistant projection
     or Lambert azimuthal equal-area projection.
 
     Parameters

--- a/lib/healpy/visufunc.py
+++ b/lib/healpy/visufunc.py
@@ -20,10 +20,10 @@
 
 """
 =====================================================
-visufunc.py : Healpix visualization functions
+visufunc.py : HEALPix visualization functions
 =====================================================
 
-This module provides functions to display Healpix map.
+This module provides functions to display HEALPix map.
 
 Map projections
 ---------------

--- a/lib/healpy/visufunc.py
+++ b/lib/healpy/visufunc.py
@@ -442,7 +442,7 @@ def gnomview(
       Symmetric galactic cut for the dipole/monopole fit.
       Removes points in latitude range [-gal_cut, +gal_cut]
     format : str, optional
-      The format of the scale label. Default: '%g'
+      The format of the scale label. Default: '%.3g'
     cbar : bool, optional
       Display the colorbar. Default: True
     cmap : a color map
@@ -771,7 +771,7 @@ def cartview(
       Symmetric galactic cut for the dipole/monopole fit.
       Removes points in latitude range [-gal_cut, +gal_cut]
     format : str, optional
-      The format of the scale label. Default: '%g'
+      The format of the scale label. Default: '%.3g'
     cbar : bool, optional
       Display the colorbar. Default: True
     notext : bool, optional
@@ -1372,7 +1372,7 @@ def azeqview(
       Symmetric galactic cut for the dipole/monopole fit.
       Removes points in latitude range [-gal_cut, +gal_cut]
     format : str, optional
-      The format of the scale label. Default: '%g'
+      The format of the scale label. Default: '%.3g'
     cbar : bool, optional
       Display the colorbar. Default: True
     notext : bool, optional

--- a/lib/healpy/visufunc.py
+++ b/lib/healpy/visufunc.py
@@ -15,7 +15,7 @@
 #  along with Healpy; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-#  For more information about Healpy, see http://code.google.com/p/healpy
+#  For more information about Healpy, see https://github.com/healpy/healpy
 #
 
 """
@@ -153,7 +153,7 @@ def mollview(
       If True, no text is printed around the map
     norm : {'hist', 'log', None}
       Color normalization, hist= histogram equalized color mapping,
-      log= logarithmic color mapping, default: None (linear color mapping)
+      log= logarithmic color mapping, Default: None (linear color mapping)
     cmap : a color map
        The colormap to use (see matplotlib.cm)
     badcolor : str
@@ -453,7 +453,7 @@ def gnomview(
       Color to use for background
     norm : {'hist', 'log', None}
       Color normalization, hist= histogram equalized color mapping,
-      log= logarithmic color mapping, default: None (linear color mapping)
+      log= logarithmic color mapping, Default: None (linear color mapping)
     hold : bool, optional
       If True, replace the current Axes by a GnomonicAxes.
       use this if you want to have multiple maps on the same
@@ -778,7 +778,7 @@ def cartview(
       If True, no text is printed around the map
     norm : {'hist', 'log', None}, optional
       Color normalization, hist= histogram equalized color mapping,
-      log= logarithmic color mapping, default: None (linear color mapping)
+      log= logarithmic color mapping, Default: None (linear color mapping)
     aspect : str or None, optional
       Aspect ratio of the axes. Default: None (auto)
     cmap : a color map
@@ -1076,7 +1076,7 @@ def orthview(
       If True, no text is printed around the map
     norm : {'hist', 'log', None}
       Color normalization, hist= histogram equalized color mapping,
-      log= logarithmic color mapping, default: None (linear color mapping)
+      log= logarithmic color mapping, Default: None (linear color mapping)
     cmap : a color map
        The colormap to use (see matplotlib.cm)
     badcolor : str
@@ -1379,7 +1379,7 @@ def azeqview(
       If True, no text is printed around the map
     norm : {'hist', 'log', None}
       Color normalization, hist= histogram equalized color mapping,
-      log= logarithmic color mapping, default: None (linear color mapping)
+      log= logarithmic color mapping, Default: None (linear color mapping)
     aspect : str or None, optional
       Aspect ratio of the axes. Default: None (auto)
     cmap : a color map

--- a/lib/healpy/visufunc.py
+++ b/lib/healpy/visufunc.py
@@ -187,6 +187,8 @@ def mollview(
       that scale with DPI ('large' for most text). To exactly reproduce plots from 
       previous versions, use: ``fontsize={'xlabel': 14, 'ylabel': 14, 'title': 14, 
       'cbar_label': 14}``
+    nlocs : int, optional
+      Number of colorbar tick locations. Default: 2
 
     See Also
     --------
@@ -431,7 +433,7 @@ def gnomview(
       The maximum range value
     flip : {'astro', 'geo'}, optional
       Defines the convention of projection : 'astro' (default, east towards left, west towards right)
-      or 'geo' (east towards roght, west towards left)
+      or 'geo' (east towards right, west towards left)
     remove_dip : bool, optional
       If :const:`True`, remove the dipole+monopole
     remove_mono : bool, optional
@@ -441,12 +443,17 @@ def gnomview(
       Removes points in latitude range [-gal_cut, +gal_cut]
     format : str, optional
       The format of the scale label. Default: '%g'
+    cbar : bool, optional
+      Display the colorbar. Default: True
     cmap : a color map
        The colormap to use (see matplotlib.cm)
     badcolor : str
       Color to use to plot bad values
     bgcolor : str
       Color to use for background
+    norm : {'hist', 'log', None}
+      Color normalization, hist= histogram equalized color mapping,
+      log= logarithmic color mapping, default: None (linear color mapping)
     hold : bool, optional
       If True, replace the current Axes by a GnomonicAxes.
       use this if you want to have multiple maps on the same
@@ -737,12 +744,16 @@ def cartview(
       A text describing the unit of the data. Default: ''
     xsize : int, optional
       The size of the image. Default: 800
+    ysize : None or int, optional
+      The vertical size of the image. Default: None= xsize
+    zat : float, optional
+      The zenith angle of the center of the projection in degrees. Default: None
     lonra : sequence, optional
       Range in longitude. Default: [-180,180]
     latra : sequence, optional
       Range in latitude. Default: [-90,90]
     title : str, optional
-      The title of the plot. Default: 'Mollweide view'
+      The title of the plot. Default: 'Cartesian view'
     nest : bool, optional
       If True, ordering scheme is NESTED. Default: False (RING)
     min : float, optional
@@ -751,7 +762,7 @@ def cartview(
       The maximum range value
     flip : {'astro', 'geo'}, optional
       Defines the convention of projection : 'astro' (default, east towards left, west towards right)
-      or 'geo' (east towards roght, west towards left)
+      or 'geo' (east towards right, west towards left)
     remove_dip : bool, optional
       If :const:`True`, remove the dipole+monopole
     remove_mono : bool, optional
@@ -768,6 +779,8 @@ def cartview(
     norm : {'hist', 'log', None}, optional
       Color normalization, hist= histogram equalized color mapping,
       log= logarithmic color mapping, default: None (linear color mapping)
+    aspect : str or None, optional
+      Aspect ratio of the axes. Default: None (auto)
     cmap : a color map
        The colormap to use (see matplotlib.cm)
     badcolor : str
@@ -1045,7 +1058,7 @@ def orthview(
       The maximum range value
     flip : {'astro', 'geo'}, optional
       Defines the convention of projection : 'astro' (default, east towards left, west towards right)
-      or 'geo' (east towards roght, west towards left)
+      or 'geo' (east towards right, west towards left)
     remove_dip : bool, optional
       If :const:`True`, remove the dipole+monopole
     remove_mono : bool, optional
@@ -1329,7 +1342,9 @@ def azeqview(
     xsize : int, optional
       The size of the image. Default: 800
     ysize : None or int, optional
-      The size of the image. Default: None= xsize
+      The vertical size of the image. Default: None= xsize
+    zat : float, optional
+      The zenith angle of the center of the projection in degrees. Default: None
     reso : float, optional
       Resolution (in arcmin). Default: 1.5 arcmin
     lamb : bool, optional
@@ -1348,7 +1363,7 @@ def azeqview(
       The maximum range value
     flip : {'astro', 'geo'}, optional
       Defines the convention of projection : 'astro' (default, east towards left, west towards right)
-      or 'geo' (east towards roght, west towards left)
+      or 'geo' (east towards right, west towards left)
     remove_dip : bool, optional
       If :const:`True`, remove the dipole+monopole
     remove_mono : bool, optional
@@ -1365,6 +1380,8 @@ def azeqview(
     norm : {'hist', 'log', None}
       Color normalization, hist= histogram equalized color mapping,
       log= logarithmic color mapping, default: None (linear color mapping)
+    aspect : str or None, optional
+      Aspect ratio of the axes. Default: None (auto)
     cmap : a color map
        The colormap to use (see matplotlib.cm)
     badcolor : str

--- a/lib/healpy/zoomtool.py
+++ b/lib/healpy/zoomtool.py
@@ -15,7 +15,7 @@
 #  along with Healpy; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-#  For more information about Healpy, see http://code.google.com/p/healpy
+#  For more information about Healpy, see https://github.com/healpy/healpy
 #
 
 import logging

--- a/lib/healpy/zoomtool.py
+++ b/lib/healpy/zoomtool.py
@@ -55,8 +55,8 @@ def mollzoom(
 ):
     """Interactive mollweide plot with zoomed gnomview.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     map : float, array-like shape (Npix,)
       An array containing the map,
       supports masked maps, see the `ma` function.
@@ -88,7 +88,7 @@ def mollzoom(
       The maximum range value
     flip : {'astro', 'geo'}, optional
       Defines the convention of projection : 'astro' (default, east towards left, west towards right)
-      or 'geo' (east towards roght, west towards left)
+      or 'geo' (east towards right, west towards left)
     remove_dip : bool, optional
       If :const:`True`, remove the dipole+monopole
     remove_mono : bool, optional


### PR DESCRIPTION
## Summary

Comprehensive documentation review and fix across both the `doc/` RST files and Python source docstrings. This PR addresses broken cross-references, missing API documentation entries, typos, outdated information, and incomplete parameter documentation.

## Doc directory fixes

- **index.rst**: Fix broken `:py:func:` cross-reference syntax (missing backticks around `remove_dipole`)
- **index.rst**: Update outdated `AstropyDeprecationWarning` reference to `HealpyDeprecationWarning` from `healpy.utils.deprecation`
- **index.rst**: Update outdated HEALPix URL (`http://healpix.sf.net` → `https://healpix.sourceforge.net`)
- **other_tutorials.rst**: Fix typo "specrum" → "spectrum"
- **healpy_visu.rst**: Add missing `azeqview` to Map projections section
- **healpy_spht.rst**: Add missing `blm_gauss` and `check_max_nside` to Other tools
- **healpy_spht.rst**: Remove trailing whitespace
- **healpy_pix.rst**: Add missing `xyf2pix`, `pix2xyf`, `npix2order`, `order2npix`
- **healpy_pix.rst**: Remove duplicate `get_interp_val` entry
- **healpy_zoomtool.rst**: Fix wrong module comment (`healpy.visufunc:` → `healpy.zoomtool:`), add `set_g_clim`
- **healpy_rotator.rst**: Add `rotate_alm`, `rotate_map_alms`, `rotate_map_pixel`; remove trailing whitespace
- **healpy_newvisu.rst**: Fix `projview` indentation (4-space → 3-space)
- **healpy_otherfunc.rst**: Add missing `ringinfo` and `pix2ring`
- **conf.py**: Clarify copyright to distinguish documentation vs software license

## Python docstring fixes

- **pixelfunc.py**: Add missing `nest` param to `isnsideok` docstring
- **pixelfunc.py**: Fix typo "arry-like" → "array-like" in `ang2vec`
- **sphtfunc.py**: Add docstring to `FutureChangeWarning` class
- **sphtfunc.py**: Add missing `verbose` param to `alm2map` docstring
- **sphtfunc.py**: Fix typo "trasform" → "transform" in `map2alm`
- **sphtfunc.py**: Fix typo "has not effect" → "has no effect" (3 occurrences)
- **fitsfunc.py**: Add docstring to `HealpixFitsWarning` class
- **fitsfunc.py**: Add missing `overwrite` param to `write_alm` docstring
- **rotator.py**: Add docstring to `get_inverse` method
- **rotator.py**: Expand `rotate_map_alms` docstring with explicit parameter docs (replaced vague "other arguments: see map2alm")
- **rotator.py**: Fix typo "optionnal" → "optional" (2 occurrences)
- **visufunc.py**: Add missing `nlocs` param to `mollview` docstring
- **visufunc.py**: Add missing `cbar` and `norm` params to `gnomview` docstring
- **visufunc.py**: Fix typo "roght" → "right" in `gnomview`, `cartview`, `orthview`, `azeqview`
- **visufunc.py**: Add missing `zat`, `ysize`, `aspect` params to `cartview` docstring
- **visufunc.py**: Fix wrong default title in `cartview` docstring ("Mollweide view" → "Cartesian view")
- **visufunc.py**: Add missing `zat`, `aspect` params to `azeqview` docstring

## Test plan

- [ ] Verify `make -C doc html` builds without new warnings
- [ ] Verify existing tests still pass