### PR TITLE
Release 1.20.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Unreleased
 |
 
+Release 1.20.0 22 Jul 2026
+
 * Fixed ``test_rotate_alm2``: the ``a_lm`` initialization now includes the ``m == ell`` diagonal, matching the Fortran reference (the test previously compared the reference to itself) https://github.com/healpy/healpy/pull/1118
 * **Performance**: Optimized ``almxfl`` for better cache locality by swapping the loop order (m outer, l inner), giving a ~2-3x speedup for large datasets https://github.com/healpy/healpy/issues/964
 * Docs: comprehensive documentation fixes — consistent HEALPix/healpy capitalization, corrected default values, missing parameter docs, broken RST formatting, dead Google Code URLs replaced with GitHub, typos, and grammar https://github.com/healpy/healpy/pull/1113


### PR DESCRIPTION
Promote the beta to the official **1.20.0** stable release.

## What's new in 1.20.0

* Fixed `test_rotate_alm2`: the `a_lm` initialization now includes the `m == ell` diagonal, matching the Fortran reference (the test previously compared the reference to itself) https://github.com/healpy/healpy/pull/1118
* **Performance**: Optimized `almxfl` for better cache locality by swapping the loop order (m outer, l inner), giving a ~2-3x speedup for large datasets https://github.com/healpy/healpy/issues/964
* Docs: comprehensive documentation fixes — consistent HEALPix/healpy capitalization, corrected default values, missing parameter docs, broken RST formatting, dead Google Code URLs replaced with GitHub, typos, and grammar https://github.com/healpy/healpy/pull/1113
* CI: Added test workflow (`.github/workflows/tests.yml`) running the full test suite on Python 3.10–3.13 with ccache, plus an astropy pre-release job https://github.com/healpy/healpy/pull/1109
* Fix off-by-one in `synalm` Cℓ boundary check that caused out-of-bounds reads when `l == len(cl)` https://github.com/healpy/healpy/pull/1108
* Fix scalar boolean array indexing in `projector.py` projection functions (`mollview`, `gnomview`, `azeqview`) that caused corrupted masked output and `"must not happen"` assertion errors with NumPy 2.2.x + Python 3.14 https://github.com/healpy/healpy/pull/1112
* **BREAKING**: Bump minimum NumPy version to 2.0.0 and compile extensions against the NumPy 2.0 ABI. The last stable release supporting NumPy 1.x is 1.19.0. https://github.com/healpy/healpy/pull/1106

Closes #1103.