### PR TITLE
Do not fold the caller's arrays in place in lonlat2thetaphi

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Unreleased
 |
 
+* Fixed ``lonlat2thetaphi(..., latauto=True)`` (and therefore ``ang2pix(..., latauto=True)``) modifying the caller's ``lat``/``lon`` arrays in place and raising ``ValueError`` on read-only input https://github.com/healpy/healpy/pull/1122
+
 Release 1.20.0 22 Jul 2026
 
 * Fixed ``test_rotate_alm2``: the ``a_lm`` initialization now includes the ``m == ell`` diagonal, matching the Fortran reference (the test previously compared the reference to itself) https://github.com/healpy/healpy/pull/1118

--- a/lib/healpy/pixelfunc.py
+++ b/lib/healpy/pixelfunc.py
@@ -179,14 +179,16 @@ def lonlat2thetaphi(lon, lat, latauto=False, latbounce=True):
       The co-latitude and longitude in radians
     """
     if latauto:
-        lat = np.asarray(lat)
+        # np.asarray does not copy an ndarray input, so folding in place would
+        # modify the caller's arrays and fail outright on read-only input.
+        lat = np.array(lat, copy=True)
         if not latbounce:
-            lon = np.asarray(lon)
+            lon = np.array(lon, copy=True)
             lon[lat > 90] = lon[lat > 90] + 180
             lon[lat < -90] = lon[lat < -90] + 180
         lat[lat > 90] = 180 - lat[lat > 90]
         lat[lat < -90] = -(180 + lat[lat < -90])
-          
+
     return np.pi / 2.0 - np.radians(lat), np.radians(lon)
 
 

--- a/test/test_pixelfunc.py
+++ b/test/test_pixelfunc.py
@@ -272,6 +272,40 @@ class TestPixelFunc(unittest.TestCase):
         self.assertTrue(np.allclose(theta_scalar, np.pi / 2 + np.deg2rad(80)))
         self.assertTrue(np.allclose(phi_scalar, np.deg2rad(lon_scalar) + np.pi))
 
+    def test_latauto_leaves_input_arrays_unchanged(self):
+        """latauto must fold copies, not the caller's arrays."""
+        for latbounce in (True, False):
+            lat = np.array([-100.0, -90.0, 0.0, 90.0, 100.0])
+            lon = np.array([0.0, 60.0, 90.0, 0.0, 180.0])
+            lat_before = lat.copy()
+            lon_before = lon.copy()
+
+            lonlat2thetaphi(lon, lat, latauto=True, latbounce=latbounce)
+
+            np.testing.assert_array_equal(lat, lat_before)
+            np.testing.assert_array_equal(lon, lon_before)
+
+            ang2pix(16, lon, lat, lonlat=True, latauto=True, latbounce=latbounce)
+
+            np.testing.assert_array_equal(lat, lat_before)
+            np.testing.assert_array_equal(lon, lon_before)
+
+    def test_latauto_accepts_read_only_input(self):
+        """latauto must work on read-only arrays and bounce at the poles."""
+        lat = np.array([100.0, -100.0])
+        lon = np.array([10.0, 20.0])
+        lat.flags.writeable = False
+        lon.flags.writeable = False
+
+        theta, phi = lonlat2thetaphi(lon, lat, latauto=True)
+        # 100 deg bounces back to 80 deg, -100 deg to -80 deg
+        self.assertTrue(np.allclose(theta, np.pi / 2 - np.deg2rad([80.0, -80.0])))
+        self.assertTrue(np.allclose(phi, np.deg2rad([10.0, 20.0])))
+
+        theta, phi = lonlat2thetaphi(lon, lat, latauto=True, latbounce=False)
+        self.assertTrue(np.allclose(theta, np.pi / 2 - np.deg2rad([80.0, -80.0])))
+        self.assertTrue(np.allclose(phi, np.deg2rad([190.0, 200.0])))
+
     def test_query_strip_nest(self):
         # Test query_strip with nest=True, which was previously crashing
         nside = 2


### PR DESCRIPTION
`lonlat2thetaphi(..., latauto=True)` folds the latitudes in place on `np.asarray(lat)`, which does not copy an ndarray. The caller's arrays come back modified, and read-only input raises:

```python
>>> lat = np.array([-100., -90., 0., 90., 100.]); lon = np.array([0., 60., 90., 0., 180.])
>>> hp.ang2pix(16, lon, lat, lonlat=True, latauto=True, latbounce=False)
>>> lat, lon
(array([-80., -90.,   0.,  90.,  80.]), array([180.,  60.,  90.,   0., 360.]))

>>> ro = np.array([100.]); ro.flags.writeable = False
>>> hp.ang2pix(16, np.array([0.]), ro, lonlat=True, latauto=True)
ValueError: assignment destination is read-only
```

Same class as gh-262 (`ud_grade modifies input array`). Fix is to fold copies; the returned values are unchanged for every input.

Why the existing test cannot see it: `test_latauto_and_latbounce` passes Python lists, and `np.asarray` always copies a list. It also reuses one `lat`/`lon` pair across three successive calls, which only works because of that copy. Swap those lists for float arrays and the existing third assertion fails on unmodified main — `phi` comes back `[0, 60, 90, 0, 180]` deg instead of `[180, 60, 90, 0, 360]`.

Ran (same venv, Python 3.13, macOS arm64): `pytest test/` 341 passed / 1 skipped before, 343 passed / 1 skipped after, no failures either way; `pytest --doctest-plus --pyargs healpy` 46 passed. Mutants, both new tests fail on each — (A) revert to `np.asarray`; (B) `np.asarray(lat, dtype=np.float64)`, the plausible "make it an array" fix, which does not copy a float64 input; (C) copy `lat` only, leaving `lon` aliased.

Not tested here: the `--doctest-cython` leg, the wheel builds, and any platform other than macOS arm64 / Python 3.13.

Separate defect, deliberately left out of this PR: the fold is one pass per sign and `lat[lat > 90]` runs before `lat[lat < -90]`, so `+280` converges to `-80` but `-280` lands on `+100`, outside the `[-90, 90]` the docstring promises — `lonlat2thetaphi([10.], [-280.], latauto=True)` returns `theta = -0.1745 rad`. Happy to open a follow-up.

Implementation, tests and this description were drafted with Claude Opus 5.

