### PR TITLE
Avoid copying coordinates in lonlat2thetaphi

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Unreleased
 |
 
+* Fixed ``lonlat2thetaphi(..., latauto=True)`` modifying caller-owned coordinate arrays and rejecting read-only arrays. Latitude folding now reuses the newly allocated result buffers instead of making full-size input copies.
+
 Release 1.20.0 22 Jul 2026
 
 * Fixed ``test_rotate_alm2``: the ``a_lm`` initialization now includes the ``m == ell`` diagonal, matching the Fortran reference (the test previously compared the reference to itself) https://github.com/healpy/healpy/pull/1118

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Unreleased
 |
 
-* Fixed ``lonlat2thetaphi(..., latauto=True)`` modifying caller-owned coordinate arrays and rejecting read-only arrays. Latitude folding now reuses the newly allocated result buffers instead of making full-size input copies.
+* Fixed ``lonlat2thetaphi(..., latauto=True)`` modifying caller-owned coordinate arrays and rejecting read-only arrays. Latitude folding now reuses the newly allocated result buffers instead of making full-size input copies. https://github.com/healpy/healpy/pull/1123
 
 Release 1.20.0 22 Jul 2026
 

--- a/lib/healpy/pixelfunc.py
+++ b/lib/healpy/pixelfunc.py
@@ -167,26 +167,49 @@ def lonlat2thetaphi(lon, lat, latauto=False, latbounce=True):
       Longitude in degrees
     lat : int or array-like
       Latitude in degrees
-    latauto: bool, optional
-      If True, automatically adjust latitudes to be within [-90, 90] range
-    latbounce: bool, optional
+    latauto : bool, optional
+      If True, automatically adjust latitudes to be within [-90, 90] range.
+    latbounce : bool, optional
       If True, longitude is not affected, as if scanning and bouncing back at the pole.
-      If False, longitude is adjusted by 180 degrees, as if scanning through the pole. Needs latauto=True.
+      If False, longitude is adjusted by 180 degrees, as if scanning through
+      the pole. Requires ``latauto=True``.
 
     Returns
     -------
     theta, phi : float, scalar or array-like
       The co-latitude and longitude in radians
+
+    Notes
+    -----
+    Input arrays are never modified. When ``latauto`` is enabled, latitude
+    folding is performed in the newly allocated output arrays.
     """
     if latauto:
-        lat = np.asarray(lat)
+        latitude = np.asarray(lat)
+        theta = np.asarray(np.radians(latitude))
+
+        fold_mask = np.asarray(latitude > 90)
+        theta[fold_mask] = np.pi - theta[fold_mask]
+
+        fold_mask = np.asarray(theta < -np.pi / 2)
+        theta[fold_mask] = -(np.pi + theta[fold_mask])
+
         if not latbounce:
-            lon = np.asarray(lon)
-            lon[lat > 90] = lon[lat > 90] + 180
-            lon[lat < -90] = lon[lat < -90] + 180
-        lat[lat > 90] = 180 - lat[lat > 90]
-        lat[lat < -90] = -(180 + lat[lat < -90])
-          
+            fold_mask = np.asarray((latitude > 90) | (latitude < -90))
+
+        # Preserve scalar returns; arrays can reuse the theta allocation.
+        if theta.ndim == 0:
+            theta = np.pi / 2.0 - theta[()]
+        else:
+            np.subtract(np.pi / 2.0, theta, out=theta)
+
+        phi = np.asarray(np.radians(lon))
+        if not latbounce:
+            phi[fold_mask] += np.pi
+        if phi.ndim == 0:
+            phi = phi[()]
+        return theta, phi
+
     return np.pi / 2.0 - np.radians(lat), np.radians(lon)
 
 

--- a/lib/healpy/pixelfunc.py
+++ b/lib/healpy/pixelfunc.py
@@ -185,17 +185,21 @@ def lonlat2thetaphi(lon, lat, latauto=False, latbounce=True):
     folding is performed in the newly allocated output arrays.
     """
     if latauto:
-        latitude = np.asarray(lat)
-        theta = np.asarray(np.radians(latitude))
+        # np.asarray may alias caller-owned memory, so keep lat read-only. theta is
+        # newly allocated by np.radians and can be safely folded in place.
+        lat = np.asarray(lat)
+        theta = np.asarray(np.radians(lat))
 
-        fold_mask = np.asarray(latitude > 90)
+        fold_mask = np.asarray(lat > 90)
         theta[fold_mask] = np.pi - theta[fold_mask]
 
         fold_mask = np.asarray(theta < -np.pi / 2)
         theta[fold_mask] = -(np.pi + theta[fold_mask])
 
         if not latbounce:
-            fold_mask = np.asarray((latitude > 90) | (latitude < -90))
+            # theta is already folded, so use the untouched input latitudes to find
+            # pole crossings that require a 180-degree longitude shift.
+            fold_mask = np.asarray((lat > 90) | (lat < -90))
 
         # Preserve scalar returns; arrays can reuse the theta allocation.
         if theta.ndim == 0:
@@ -203,6 +207,7 @@ def lonlat2thetaphi(lon, lat, latauto=False, latbounce=True):
         else:
             np.subtract(np.pi / 2.0, theta, out=theta)
 
+        # Convert before shifting longitude so narrow integer inputs cannot overflow.
         phi = np.asarray(np.radians(lon))
         if not latbounce:
             phi[fold_mask] += np.pi

--- a/test/test_pixelfunc.py
+++ b/test/test_pixelfunc.py
@@ -272,6 +272,129 @@ class TestPixelFunc(unittest.TestCase):
         self.assertTrue(np.allclose(theta_scalar, np.pi / 2 + np.deg2rad(80)))
         self.assertTrue(np.allclose(phi_scalar, np.deg2rad(lon_scalar) + np.pi))
 
+    def test_latauto_leaves_input_arrays_unchanged(self):
+        """latauto must fold outputs, not the caller's arrays."""
+        for latbounce in (True, False):
+            with self.subTest(latbounce=latbounce):
+                lat = np.array([-100.0, -90.0, 0.0, 90.0, 100.0])
+                lon = np.array([0.0, 60.0, 90.0, 0.0, 180.0])
+                lat_before = lat.copy()
+                lon_before = lon.copy()
+
+                theta, phi = lonlat2thetaphi(
+                    lon, lat, latauto=True, latbounce=latbounce
+                )
+
+                np.testing.assert_array_equal(lat, lat_before)
+                np.testing.assert_array_equal(lon, lon_before)
+                self.assertFalse(np.shares_memory(theta, lat))
+                self.assertFalse(np.shares_memory(phi, lon))
+
+                ang2pix(
+                    16,
+                    lon,
+                    lat,
+                    lonlat=True,
+                    latauto=True,
+                    latbounce=latbounce,
+                )
+
+                np.testing.assert_array_equal(lat, lat_before)
+                np.testing.assert_array_equal(lon, lon_before)
+
+    def test_latauto_accepts_read_only_input(self):
+        """latauto must work on read-only arrays and bounce at the poles."""
+        lat = np.array([100.0, -100.0])
+        lon = np.array([10.0, 20.0])
+        lat.flags.writeable = False
+        lon.flags.writeable = False
+
+        theta, phi = lonlat2thetaphi(lon, lat, latauto=True)
+        np.testing.assert_allclose(theta, np.pi / 2 - np.deg2rad([80.0, -80.0]))
+        np.testing.assert_allclose(phi, np.deg2rad([10.0, 20.0]))
+
+        theta, phi = lonlat2thetaphi(lon, lat, latauto=True, latbounce=False)
+        np.testing.assert_allclose(theta, np.pi / 2 - np.deg2rad([80.0, -80.0]))
+        np.testing.assert_allclose(phi, np.deg2rad([190.0, 200.0]))
+
+    def test_latauto_accepts_read_only_strided_input(self):
+        """Folding supports read-only, non-contiguous coordinate views."""
+        lat_storage = np.array(
+            [-100.0, 999.0, -90.0, 999.0, 0.0, 999.0, 90.0, 999.0, 100.0]
+        )
+        lon_storage = np.array(
+            [0.0, 999.0, 60.0, 999.0, 90.0, 999.0, 0.0, 999.0, 180.0]
+        )
+        lat_storage.flags.writeable = False
+        lon_storage.flags.writeable = False
+        lat = lat_storage[::2]
+        lon = lon_storage[::2]
+        self.assertFalse(lat.flags.writeable)
+        self.assertFalse(lon.flags.writeable)
+
+        theta, phi = lonlat2thetaphi(lon, lat, latauto=True, latbounce=False)
+
+        np.testing.assert_allclose(theta, np.deg2rad([170.0, 180.0, 90.0, 0.0, 10.0]))
+        np.testing.assert_allclose(phi, np.deg2rad([180.0, 60.0, 90.0, 0.0, 360.0]))
+        np.testing.assert_array_equal(
+            lat_storage,
+            [-100.0, 999.0, -90.0, 999.0, 0.0, 999.0, 90.0, 999.0, 100.0],
+        )
+        np.testing.assert_array_equal(
+            lon_storage,
+            [0.0, 999.0, 60.0, 999.0, 90.0, 999.0, 0.0, 999.0, 180.0],
+        )
+
+    def test_latauto_preserves_array_output_dtype(self):
+        """Output buffers use the dtype selected by NumPy's radians ufunc."""
+        for dtype in (np.int16, np.float32, np.float64):
+            with self.subTest(dtype=dtype):
+                lat = np.array([-100, 100], dtype=dtype)
+                lon = np.array([10, 20], dtype=dtype)
+
+                theta, phi = lonlat2thetaphi(lon, lat, latauto=True, latbounce=False)
+
+                self.assertEqual(theta.dtype, np.radians(lat).dtype)
+                self.assertEqual(phi.dtype, np.radians(lon).dtype)
+                np.testing.assert_allclose(
+                    theta,
+                    np.deg2rad([170.0, 10.0]),
+                    rtol=1e-6,
+                    atol=1e-6,
+                )
+                np.testing.assert_allclose(
+                    phi,
+                    np.deg2rad([190.0, 200.0]),
+                    rtol=1e-6,
+                    atol=1e-6,
+                )
+
+    def test_latauto_scalar_returns_scalars(self):
+        """Using zero-dimensional work buffers must not change scalar returns."""
+        for dtype in (int, np.float32, np.float64):
+            with self.subTest(dtype=dtype):
+                theta, phi = lonlat2thetaphi(
+                    dtype(10),
+                    dtype(-100),
+                    latauto=True,
+                    latbounce=False,
+                )
+
+                self.assertTrue(np.isscalar(theta))
+                self.assertTrue(np.isscalar(phi))
+                self.assertAlmostEqual(theta, np.deg2rad(170.0), places=6)
+                self.assertAlmostEqual(phi, np.deg2rad(190.0), places=6)
+
+    def test_latauto_avoids_integer_overflow_when_adjusting_longitude(self):
+        """Longitude adjustment takes place in the floating output buffer."""
+        lat = np.array([100], dtype=np.int16)
+        lon = np.array([32700], dtype=np.int16)
+
+        _, phi = lonlat2thetaphi(lon, lat, latauto=True, latbounce=False)
+
+        np.testing.assert_allclose(phi, np.deg2rad([32880.0]), rtol=1e-6)
+        np.testing.assert_array_equal(lon, [32700])
+
     def test_query_strip_nest(self):
         # Test query_strip with nest=True, which was previously crashing
         nside = 2


### PR DESCRIPTION
## Summary

- prevent `lonlat2thetaphi(..., latauto=True)` and the corresponding `ang2pix` path from modifying caller-owned coordinate arrays
- support read-only and non-contiguous inputs without making full-size latitude or longitude copies
- normalize `lat` once with `np.asarray` and keep it read-only for degree-based pole-crossing tests
- use the newly allocated `theta` and `phi` outputs as writable in-place folding buffers
- adjust longitude only after conversion to floating point, avoiding overflow for narrow integer inputs
- add comments around the non-obvious aliasing, pole-crossing, and output-buffer behavior
- document the non-mutation guarantee and add a changelog entry

This is a lower-memory alternative to #1122 and carries over its input-mutation and read-only regression coverage, with additional tests for strided views, output aliasing, dtype preservation, scalar returns, `ang2pix`, and narrow-integer overflow.

The implementation deliberately keeps pole-crossing tests in degrees using the untouched `lat` input. `theta` is allocated by `np.radians(lat)` and is then folded in place; when `latbounce=False`, the original degree values are still available to determine which longitudes need the 180-degree shift. This avoids the previous redundant `latitude` variable while preserving the existing numerical semantics.

For two million float64 longitude/latitude values with `latbounce=False`, a local `tracemalloc` comparison measured peak result/temporary allocation at 61.0 MiB for the copy-based implementation and 34.0 MiB for this output-buffer implementation. The result arrays themselves account for about 30.5 MiB.

The separate repeated-pole-crossing behavior noted in #1122 remains out of scope; this PR preserves the existing one-pass folding semantics.

## Testing

- `uv run --no-sync pytest test/test_pixelfunc.py -q` — 28 passed, 8 subtests passed
- `uv run --no-sync pytest --doctest-plus --doctest-cython --pyargs healpy` — 46 passed
- `uv run --no-sync pytest test/` — 347 passed, 1 skipped
- additional equivalence checks for the final cleanup covered `int16`, `int32`, `float32`, and `float64`, both `latbounce` modes, scalar inputs, and read-only inputs
